### PR TITLE
fix: gate debug logging behind ABBENAY_DEBUG and fix chat daemon collision

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -66,8 +66,31 @@ always identity operations. Simplify them.
 2. Read all Copilot comments and CI logs.
 3. Fix all issues in a single commit (or minimal commits).
 4. Reply to each comment with the fix commit hash.
-5. Update the PR description to include the new commit(s).
-6. If CI failure is unrelated to your changes (e.g., flaky prebuild-install),
+5. **Resolve each review thread** after replying. Replying alone does not
+   resolve the thread. Use the GitHub GraphQL API:
+
+   ```bash
+   # List unresolved threads
+   gh api graphql -f query='{
+     repository(owner: "OWNER", name: "REPO") {
+       pullRequest(number: N) {
+         reviewThreads(first: 20) {
+           nodes { id isResolved comments(first:1) { nodes { body } } }
+         }
+       }
+     }
+   }'
+
+   # Resolve a thread
+   gh api graphql -f query='mutation {
+     resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+       thread { isResolved }
+     }
+   }'
+   ```
+
+6. Update the PR description to include the new commit(s).
+7. If CI failure is unrelated to your changes (e.g., flaky prebuild-install),
    fix it anyway — the PR owns the green build.
 
 ## Lessons from past reviews

--- a/packages/daemon/src/core/debug.ts
+++ b/packages/daemon/src/core/debug.ts
@@ -7,7 +7,8 @@
  */
 
 export function debug(...args: unknown[]): void {
-  if (process.env.ABBENAY_DEBUG) {
+  const flag = process.env.ABBENAY_DEBUG;
+  if (flag === '1' || flag?.toLowerCase() === 'true') {
     console.error(...args);
   }
 }

--- a/packages/daemon/src/core/debug.ts
+++ b/packages/daemon/src/core/debug.ts
@@ -1,0 +1,13 @@
+/**
+ * Lightweight debug logger gated on the ABBENAY_DEBUG environment variable.
+ * Output goes to stderr so it never pollutes piped stdout.
+ *
+ * Enable with:  ABBENAY_DEBUG=1 abbenay chat ...
+ * Or via CLI:   abbenay --verbose chat ...
+ */
+
+export function debug(...args: unknown[]): void {
+  if (process.env.ABBENAY_DEBUG) {
+    console.error(...args);
+  }
+}

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -16,6 +16,7 @@ import { streamText, jsonSchema, tool } from 'ai';
 import type { AssistantModelMessage, JSONSchema7, LanguageModel, ModelMessage, ToolSet } from 'ai';
 
 import { mockStreamChat, getMockModels } from './mock.js';
+import { debug } from './debug.js';
 
 // ── Provider config type for factory functions ─────────────────────────
 
@@ -632,7 +633,7 @@ export async function* streamChat(
     return;
   }
 
-  console.log(`[Adapter] streamChat: engine="${engineId}", model="${engineModelId}", messages=${messages.length}, tools=${tools?.length || 0}`);
+  debug(`[Adapter] streamChat: engine="${engineId}", model="${engineModelId}", messages=${messages.length}, tools=${tools?.length || 0}`);
 
   try {
     // Create the Vercel AI SDK model instance (async — loads provider package on demand)

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SecretStore } from './secrets.js';
+import { debug } from './debug.js';
 import {
   loadConfig,
   loadWorkspaceConfig,
@@ -511,7 +512,7 @@ export class CoreState {
     toolExecutor?: ToolExecutor,
   ): AsyncGenerator<ChatChunk> {
     const toolMode = toolOptions?.toolMode || 'auto';
-    console.log(`[State] Chat request: compositeModelId="${compositeModelId}", messages=${messages.length}, toolMode="${toolMode}", tools=${toolOptions?.tools?.length || 0}`);
+    debug(`[State] Chat request: compositeModelId="${compositeModelId}", messages=${messages.length}, toolMode="${toolMode}", tools=${toolOptions?.tools?.length || 0}`);
 
     // ── Validate passthrough mode ──
     if (toolMode === 'passthrough' && (!toolOptions?.tools || toolOptions.tools.length === 0)) {
@@ -532,7 +533,7 @@ export class CoreState {
 
     const providerId = compositeModelId.substring(0, slashIdx);
     const modelName = compositeModelId.substring(slashIdx + 1);
-    console.log(`[State] Chat: providerId="${providerId}", modelName="${modelName}"`);
+    debug(`[State] Chat: providerId="${providerId}", modelName="${modelName}"`);
 
     // ── Look up virtual provider ──
     const config = this.loadProviderConfig();
@@ -584,7 +585,7 @@ export class CoreState {
     // ── Merge params (4-tier: request > config > policy > engine default) ──
     const mergedParams = mergeParams(modelCfg, requestParams, flatPolicy);
 
-    console.log(`[State] Chat: engine="${providerCfg.engine}", engineModelId="${engineModelId}", toolMode="${effectiveToolMode}", baseUrl="${providerCfg.base_url || '(none)'}"`);
+    debug(`[State] Chat: engine="${providerCfg.engine}", engineModelId="${engineModelId}", toolMode="${effectiveToolMode}", baseUrl="${providerCfg.base_url || '(none)'}"`);
 
     // ── Resolve tools based on mode ──
     let tools: ToolDefinition[] | undefined;
@@ -611,7 +612,7 @@ export class CoreState {
         resolvedExecutor = this.toolRegistry.buildExecutor(
           toolExecutor ? (tool, args) => toolExecutor!(tool.originalName, args) : undefined,
         );
-        console.log(`[State] Auto-loaded ${tools.length} tools from registry`);
+        debug(`[State] Auto-loaded ${tools.length} tools from registry`);
       }
     }
 
@@ -629,7 +630,7 @@ export class CoreState {
 
           if (matchesAnyPattern(requirePatterns, nsName)) {
             const requestId = crypto.randomUUID();
-            console.log(`[State] Tool "${toolName}" (${nsName}) requires approval — requestId=${requestId}`);
+            debug(`[State] Tool "${toolName}" (${nsName}) requires approval — requestId=${requestId}`);
             return toolOptions.onToolApprovalNeeded!(requestId, toolName, args);
           }
 

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -11,7 +11,7 @@
 import * as readline from 'node:readline';
 import { startDaemon } from './daemon.js';
 import { isDaemonRunningSync } from './transport.js';
-import type { DaemonState } from './state.js';
+import { DaemonState } from './state.js';
 import type { ChatToolOptions } from '../core/state.js';
 
 interface ChatOptions {
@@ -33,11 +33,9 @@ const RED    = '\x1b[31m';
 export async function runInteractiveChat(options: ChatOptions): Promise<void> {
   let state: DaemonState;
 
-  // Start daemon in-process if not already running
   if (isDaemonRunningSync()) {
-    console.error(`${DIM}Daemon already running — connecting...${RESET}`);
-    // For now, start a lightweight in-process state (no gRPC overhead)
-    state = await startDaemon({ keepAlive: false });
+    console.error(`${DIM}Daemon already running — using in-process state...${RESET}`);
+    state = new DaemonState();
   } else {
     console.error(`${DIM}Starting daemon...${RESET}`);
     state = await startDaemon({ keepAlive: false });
@@ -134,7 +132,6 @@ async function runInteractiveMode(
   }
 
   rl.close();
-  process.exit(0);
 }
 
 async function runJsonMode(
@@ -150,7 +147,7 @@ async function runJsonMode(
   }
   const input = chunks.join('\n').trim();
   if (!input) {
-    process.exit(0);
+    return;
   }
 
   messages.push({ role: 'user', content: input });

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -36,6 +36,7 @@ export async function runInteractiveChat(options: ChatOptions): Promise<void> {
   if (isDaemonRunningSync()) {
     console.error(`${DIM}Daemon already running — using in-process state...${RESET}`);
     state = new DaemonState();
+    await state.initMcpConnections();
   } else {
     console.error(`${DIM}Starting daemon...${RESET}`);
     state = await startDaemon({ keepAlive: false });

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -34,7 +34,13 @@ const program = new Command();
 program
   .name('abbenay')
   .description('Abbenay - Unified AI Daemon')
-  .version(VERSION);
+  .version(VERSION)
+  .option('--verbose', 'Enable debug logging (same as ABBENAY_DEBUG=1)')
+  .hook('preAction', () => {
+    if (program.opts().verbose) {
+      process.env.ABBENAY_DEBUG = '1';
+    }
+  });
 
 program
   .command('daemon')


### PR DESCRIPTION
## Summary

- **Debug logging gated**: `[State]` and `[Adapter]` `console.log` calls in `state.ts` and `engines.ts` were writing to stdout, polluting piped output (especially `chat --json`). Introduced a `debug()` helper in `core/debug.ts` that writes to stderr only when `ABBENAY_DEBUG=1` is set. Added a `--verbose` global CLI flag as a convenience wrapper.
- **Chat daemon collision fixed**: `chat.ts` crashed with "Abbenay daemon is already running" when a daemon (e.g. web server) was already active. Now creates a lightweight in-process `DaemonState` instead of calling `startDaemon()`. Removed `process.exit(0)` calls from chat handlers.
- **PR review skill updated**: Added GraphQL commands for resolving review threads after replying.

## Test plan

- [x] `abbenay chat -m <model> --json` produces clean JSON on stdout (no `[State]`/`[Adapter]` lines)
- [x] `abbenay --verbose chat -m <model> --json` shows debug lines on stderr
- [x] `abbenay chat` works when daemon/web server is already running
- [ ] CI passes (lint, build, test)