### PR TITLE
fix(mcp): use Streamable HTTP transport instead of SSE for remote servers

### DIFF
--- a/packages/daemon/src/core/config.ts
+++ b/packages/daemon/src/core/config.ts
@@ -97,8 +97,8 @@ export interface McpServerConfig {
   args?: string[];
   /** URL for HTTP/SSE transport */
   url?: string;
-  /** Transport type */
-  transport: 'stdio' | 'http';
+  /** Transport type: stdio, http (Streamable HTTP), or sse (legacy SSE) */
+  transport: 'stdio' | 'http' | 'sse';
   /** Whether this server is enabled */
   enabled: boolean;
   /** HTTP headers (for authenticated endpoints) */

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -36,11 +36,12 @@ export async function runInteractiveChat(options: ChatOptions): Promise<void> {
   if (isDaemonRunningSync()) {
     console.error(`${DIM}Daemon already running — using in-process state...${RESET}`);
     state = new DaemonState();
-    await state.initMcpConnections();
   } else {
     console.error(`${DIM}Starting daemon...${RESET}`);
     state = await startDaemon({ keepAlive: false });
   }
+
+  await state.initMcpConnections();
 
   const rl = readline.createInterface({
     input: process.stdin,

--- a/packages/daemon/src/daemon/mcp-client-pool.ts
+++ b/packages/daemon/src/daemon/mcp-client-pool.ts
@@ -232,7 +232,7 @@ export class McpClientPool {
   /**
    * Build the appropriate transport for a config entry.
    */
-  private buildTransport(config: McpServerConfig): StdioMCPTransport | { type: 'sse'; url: string; headers?: Record<string, string> } {
+  private buildTransport(config: McpServerConfig): StdioMCPTransport | { type: 'sse' | 'http'; url: string; headers?: Record<string, string> } {
     if (config.transport === 'stdio') {
       if (!config.command) {
         throw new Error('stdio transport requires a command');
@@ -244,12 +244,11 @@ export class McpClientPool {
       });
     }
 
-    // HTTP/SSE transport
     if (!config.url) {
       throw new Error('http transport requires a url');
     }
     return {
-      type: 'sse' as const,
+      type: 'http' as const,
       url: config.url,
       headers: config.headers,
     };

--- a/packages/daemon/src/daemon/mcp-client-pool.ts
+++ b/packages/daemon/src/daemon/mcp-client-pool.ts
@@ -245,10 +245,10 @@ export class McpClientPool {
     }
 
     if (!config.url) {
-      throw new Error('http transport requires a url');
+      throw new Error(`${config.transport} transport requires a url`);
     }
     return {
-      type: 'http' as const,
+      type: config.transport === 'sse' ? 'sse' as const : 'http' as const,
       url: config.url,
       headers: config.headers,
     };


### PR DESCRIPTION
## Summary

- **MCP transport fix**: `McpClientPool.buildTransport()` was hardcoded to return `type: 'sse'` for all HTTP-based MCP servers. Remote servers like GitHub's hosted MCP endpoint (`api.githubcopilot.com/mcp/`) require the newer Streamable HTTP transport and reject SSE connections with `405 Method Not Allowed`. Changed to `type: 'http'` so `@ai-sdk/mcp` uses its `HttpMCPTransport` class.
- **MCP race condition fix**: `chat` could send the first message before MCP tools were discovered because `startDaemon()` fires `initMcpConnections()` non-blocking. Moved `await state.initMcpConnections()` after both daemon startup paths in `chat.ts` so tools are always available for the first prompt.

## Test plan

- [x] Tested locally: connected to GitHub hosted MCP server, discovered 43 tools, successfully queried repo issues via chat
- [x] MCP tools available on first message (no race)
- [ ] CI passes (lint, build, test)