### PR TITLE
docs: add AI gateway landscape comparison

### DIFF
--- a/docs/LANDSCAPE.md
+++ b/docs/LANDSCAPE.md
@@ -1,0 +1,164 @@
+# AI Gateway & LLM Routing Landscape
+
+A fair comparison of open-source projects that solve multi-provider LLM
+routing, and where Abbenay fits among them.
+
+Last updated: March 2026
+
+---
+
+## Projects Compared
+
+| Project | Stars | Language | License |
+|---------|-------|----------|---------|
+| [LiteLLM](https://github.com/BerriAI/litellm) | ~38k | Python | MIT |
+| [Portkey AI Gateway](https://github.com/Portkey-AI/gateway) | ~11k | TypeScript | MIT |
+| [LLM Gateway](https://github.com/theopenco/llmgateway) | ~950 | TypeScript | AGPL-3 / Enterprise |
+| [ngrok](https://ngrok.com/) | N/A (SaaS) | Go | Proprietary |
+| Abbenay | Early | TypeScript | Apache-2.0 |
+
+---
+
+## Architecture Models
+
+### Centralized Proxy (LiteLLM, Portkey, LLM Gateway)
+
+All three follow the same pattern: deploy a proxy server, point your
+application at it instead of the LLM provider, and the proxy handles
+routing, retries, caching, and observability.
+
+```
+┌──────────┐      ┌──────────────┐      ┌──────────────┐
+│  Your    │─────▶│  AI Gateway  │─────▶│  LLM Provider│
+│  App     │◀─────│  (proxy)     │◀─────│  (OpenAI,...)│
+└──────────┘      └──────────────┘      └──────────────┘
+```
+
+**Strengths:** centralized cost tracking, team-wide policy enforcement,
+single point for logging and guardrails, easy to add to existing apps
+via base URL swap.
+
+**Trade-offs:** extra infrastructure to deploy and operate, network hop
+adds latency, proxy becomes a single point of failure, secrets must be
+stored in the proxy.
+
+### Tunnel / Edge Gateway (ngrok)
+
+ngrok is a networking platform, not an LLM-specific tool. It exposes
+local services to the internet via secure tunnels. Their newer AI
+Gateway product adds LLM-specific traffic policies (rate limiting, WAF,
+routing) at the edge.
+
+**Strengths:** zero-config public URLs for local development, built-in
+DDoS protection, traffic inspection, useful for exposing local MCP
+servers to remote clients.
+
+**Trade-offs:** not an LLM routing layer on its own, requires a
+separate LLM client/gateway behind it, SaaS pricing model.
+
+### Embeddable Library + Local Daemon (Abbenay)
+
+Abbenay takes a different approach: a reusable core library
+(`@abbenay/core`) that can be embedded directly in any Node.js process,
+plus an optional daemon that adds gRPC transport, MCP server
+aggregation, and a web dashboard.
+
+```
+┌─────────────────────────────────────────────────┐
+│  Your App / CLI / VS Code Extension             │
+│                                                 │
+│  ┌─────────────────────────────────────────┐    │
+│  │  @abbenay/core (in-process)             │    │
+│  │  Engine routing, streaming, policies    │────▶ LLM Providers
+│  │  Config, secrets (injected)             │    │
+│  └─────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────┘
+```
+
+**Strengths:** no infrastructure to deploy, works offline with local
+models, secrets stay on the developer's machine, same core powers CLI /
+daemon / extension / web, in-process tool execution with approval
+policies.
+
+**Trade-offs:** not designed for team-wide centralized control, no
+built-in cost tracking or billing, fewer providers than mature gateways,
+earlier in development.
+
+---
+
+## Feature Comparison
+
+| Capability | LiteLLM | Portkey | LLM Gateway | Abbenay |
+|------------|---------|---------|-------------|---------|
+| **Provider count** | 100+ | 250+ | ~15 | 19 |
+| **OpenAI-compatible API** | Yes | Yes | Yes | No (gRPC + library) |
+| **Embeddable library** | Python SDK | No | No | Yes (`@abbenay/core`) |
+| **Standalone daemon** | Proxy server | Proxy server | Proxy server | Optional daemon |
+| **CLI chat** | No | No | No | Yes |
+| **VS Code integration** | No | No | No | Language Model API |
+| **MCP tool aggregation** | MCP Gateway | MCP Gateway | No | MCP client pool |
+| **Tool approval policies** | No | No | No | Yes (per-tool tiers) |
+| **Streaming** | Yes | Yes | Yes | Yes (Vercel AI SDK) |
+| **Retries / fallbacks** | Yes | Yes | Limited | Not yet |
+| **Load balancing** | Yes | Yes | No | Not yet |
+| **Caching** | Simple + semantic | Simple + semantic | No | Not yet |
+| **Guardrails** | Via plugins | 50+ built-in | No | Via policies |
+| **Cost tracking** | Yes | Yes | Yes | Not yet |
+| **Team / RBAC** | Enterprise | Enterprise | Enterprise | Not yet |
+| **Local model support** | Ollama, vLLM | Ollama | No | Ollama, LM Studio |
+| **SEA binary** | No | No | No | Yes (single executable) |
+| **Config format** | YAML | JSON / API | Web UI | YAML (user + workspace) |
+
+---
+
+## When to Use What
+
+**Use LiteLLM** when you need a battle-tested Python proxy with the
+widest provider support, enterprise features, and you're comfortable
+running centralized infrastructure. Good for platform teams serving
+multiple internal consumers.
+
+**Use Portkey** when you want a fast TypeScript proxy with built-in
+guardrails, load balancing, and an MCP Gateway for managing MCP servers
+across an organization. Strong enterprise offering.
+
+**Use LLM Gateway** when you want a lightweight, self-hosted proxy with
+usage analytics and a clean dashboard. Smaller project, fewer features,
+but simpler to operate.
+
+**Use ngrok** when you need to expose a local service (including
+Abbenay's daemon or a local MCP server) to the internet for development,
+demos, or webhook testing. Complements rather than replaces an LLM
+router.
+
+**Use Abbenay** when you want an embeddable library for your Node.js
+app, a developer workstation daemon with CLI chat and VS Code
+integration, or in-process tool execution with approval policies. Best
+for individual developers and small teams who want to keep secrets local
+and avoid deploying proxy infrastructure.
+
+---
+
+## Complementary Use
+
+These tools are not mutually exclusive. Example combinations:
+
+- **Abbenay + ngrok**: Expose the Abbenay web dashboard or MCP server to
+  a remote collaborator during pair programming.
+- **Abbenay + LiteLLM**: Use LiteLLM as a centralized proxy for
+  team-wide cost tracking, with Abbenay as the developer-facing tool
+  that routes through it via a custom `base_url`.
+- **Abbenay + Portkey**: Use Portkey's MCP Gateway for org-wide MCP
+  server management, while developers use Abbenay locally for chat and
+  tool approval workflows.
+
+---
+
+## Notes on Methodology
+
+- Star counts are approximate as of March 2026.
+- Feature comparisons are based on public documentation and README files.
+- "Not yet" means the feature is planned or on the roadmap, not that it
+  is architecturally impossible.
+- This document aims to be objective. Contributions and corrections are
+  welcome.

--- a/docs/LANDSCAPE.md
+++ b/docs/LANDSCAPE.md
@@ -81,8 +81,7 @@ daemon / extension / web, in-process tool execution with approval
 policies.
 
 **Trade-offs:** not designed for team-wide centralized control, no
-built-in cost tracking or billing, fewer providers than mature gateways,
-earlier in development.
+built-in cost tracking or billing, earlier in development.
 
 ---
 
@@ -90,8 +89,8 @@ earlier in development.
 
 | Capability | LiteLLM | Portkey | LLM Gateway | Abbenay |
 |------------|---------|---------|-------------|---------|
-| **Provider count** | 100+ | 250+ | ~15 | 19 |
-| **OpenAI-compatible API** | Yes | Yes | Yes | No (gRPC + library) |
+| **Built-in engines** | 100+ | 250+ | ~15 | 18 + any OpenAI-compatible¹ |
+| **OpenAI-compatible API** | Yes | Yes | Yes | No (gRPC + library)² |
 | **Embeddable library** | Python SDK | No | No | Yes (`@abbenay/core`) |
 | **Standalone daemon** | Proxy server | Proxy server | Proxy server | Optional daemon |
 | **CLI chat** | No | No | No | Yes |
@@ -99,7 +98,7 @@ earlier in development.
 | **MCP tool aggregation** | MCP Gateway | MCP Gateway | No | MCP client pool |
 | **Tool approval policies** | No | No | No | Yes (per-tool tiers) |
 | **Streaming** | Yes | Yes | Yes | Yes (Vercel AI SDK) |
-| **Retries / fallbacks** | Yes | Yes | Limited | Not yet |
+| **Retries / fallbacks** | Yes | Yes | Limited | Limited (JSON retry) |
 | **Load balancing** | Yes | Yes | No | Not yet |
 | **Caching** | Simple + semantic | Simple + semantic | No | Not yet |
 | **Guardrails** | Via plugins | 50+ built-in | No | Via policies |
@@ -151,6 +150,21 @@ These tools are not mutually exclusive. Example combinations:
 - **Abbenay + Portkey**: Use Portkey's MCP Gateway for org-wide MCP
   server management, while developers use Abbenay locally for chat and
   tool approval workflows.
+
+---
+
+## Footnotes
+
+¹ Abbenay ships 18 pre-configured engines (OpenAI, Anthropic, Gemini,
+Mistral, xAI, DeepSeek, Groq, Cohere, Amazon Bedrock, Fireworks,
+Together AI, Perplexity, Azure, OpenRouter, Ollama, LM Studio, Cerebras,
+Meta). Any provider that exposes an OpenAI-compatible REST API can be
+used by pointing a configured engine's `base_url` at it — no code
+changes required.
+
+² Abbenay *consumes* OpenAI-compatible provider APIs but does not
+*expose* one. Client access is via the `@abbenay/core` library
+(in-process), gRPC (daemon), or the CLI.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/LANDSCAPE.md` with an objective analysis of Abbenay alongside LiteLLM, Portkey AI Gateway, LLM Gateway, and ngrok.
- Covers architecture models (centralized proxy vs embeddable library + local daemon), a feature comparison matrix, and guidance on when to use each tool.
- Includes complementary use patterns showing how these tools can work together.

## Test plan

- [ ] Review `docs/LANDSCAPE.md` for accuracy and fairness
- [ ] Verify feature matrix entries against current project documentation