### PR TITLE
feat(tools): default to ask for tool approval (secure-by-default)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,7 +50,7 @@ All three tiers are enforced. The default for tools matching no tier is
    Tools matching `auto_approve` patterns execute without pause.
    Tools matching neither tier default to **require approval** (secure-by-default,
    see DR-019). Users who want the previous auto-approve-all behavior can set
-   `tool_policy.auto_approve: ['*']`.
+   `tool_policy.auto_approve: ['*:*/*']`.
 
 6. **`max_tool_iterations` enforcement**
    Enforce the cap in the tool loop inside `streamChat` / `CoreState.chat()`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@ Status legend: **done** | **partial** | **stub** | **planned**
 
 ## 1. Tool Approval Tiers — done (M1–M2)
 
-The `ToolPolicyConfig` already defines three tiers (`auto_approve`, `require_approval`,
-`disabled_tools`) and the web dashboard already lets users assign per-tool policies.
-`disabled_tools` is enforced at chat time. The other two are **not enforced** — every
-non-disabled tool executes immediately.
+The `ToolPolicyConfig` defines three tiers (`auto_approve`, `require_approval`,
+`disabled_tools`) and the web dashboard lets users assign per-tool policies.
+All three tiers are enforced. The default for tools matching no tier is
+**require approval** (secure-by-default, DR-019).
 
 ### What exists
 
@@ -46,9 +46,11 @@ non-disabled tool executes immediately.
 4. **CLI chat command** (see section 2 below)
    The CLI `aby chat` command needs an interactive `readline` prompt for approvals.
 
-5. **`auto_approve` tier**
-   Tools matching `auto_approve` patterns execute without pause (current behavior).
-   Tools matching neither tier default to `auto_approve` (current behavior preserved).
+5. **`auto_approve` tier** — done
+   Tools matching `auto_approve` patterns execute without pause.
+   Tools matching neither tier default to **require approval** (secure-by-default,
+   see DR-019). Users who want the previous auto-approve-all behavior can set
+   `tool_policy.auto_approve: ['*']`.
 
 6. **`max_tool_iterations` enforcement**
    Enforce the cap in the tool loop inside `streamChat` / `CoreState.chat()`.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -220,3 +220,17 @@ have leading zeros (semver prohibits them).
 VS Code uses a separate `--pre-release` flag instead. CalVer was chosen over
 semver because the project is not yet stable enough for semver semantics to be
 meaningful, and date-based versions communicate recency at a glance.
+
+## DR-019: Secure-by-default tool approval
+
+**Date:** 2026-03-12  
+**Decision:** All tool calls require user approval unless the tool is explicitly
+listed in `tool_policy.auto_approve`. The previous default (auto-approve
+everything when no policy is configured) is replaced by ask-by-default.  
+**Rationale:** MCP servers can expose arbitrary tools. A malicious or
+misconfigured server could execute destructive operations without the user
+knowing. Defaulting to "ask" matches browser permission semantics — the user
+must grant trust explicitly. Friction is mitigated by session-scoped "allow
+always" in the CLI (not persisted) and "Allow & Remember" in the web UI
+(persisted to `config.yaml`). Users who want the previous behavior can set
+`tool_policy.auto_approve: ['*']`.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -233,4 +233,4 @@ knowing. Defaulting to "ask" matches browser permission semantics — the user
 must grant trust explicitly. Friction is mitigated by session-scoped "allow
 always" in the CLI (not persisted) and "Allow & Remember" in the web UI
 (persisted to `config.yaml`). Users who want the previous behavior can set
-`tool_policy.auto_approve: ['*']`.
+`tool_policy.auto_approve: ['*:*/*']`.

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -617,26 +617,25 @@ export class CoreState {
     }
 
     // ── Build tool validator from policy + caller's approval callback ──
+    // Secure-by-default: all tools require approval unless explicitly
+    // listed in auto_approve.  See DR-019.
     let toolValidator: ToolValidationCallback | undefined;
     if (toolOptions?.onToolApprovalNeeded && this.toolRegistry) {
       const registry = this.toolRegistry;
-      const requirePatterns = toolPolicy?.require_approval;
-      const _autoPatterns = toolPolicy?.auto_approve;
+      const autoPatterns = toolPolicy?.auto_approve;
 
-      if (requirePatterns && requirePatterns.length > 0) {
-        toolValidator = async (toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
-          const resolved = registry.resolve(toolName);
-          const nsName = resolved?.namespacedName || toolName;
+      toolValidator = async (toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
+        const resolved = registry.resolve(toolName);
+        const nsName = resolved?.namespacedName || toolName;
 
-          if (matchesAnyPattern(requirePatterns, nsName)) {
-            const requestId = crypto.randomUUID();
-            debug(`[State] Tool "${toolName}" (${nsName}) requires approval — requestId=${requestId}`);
-            return toolOptions.onToolApprovalNeeded!(requestId, toolName, args);
-          }
-
+        if (matchesAnyPattern(autoPatterns, nsName)) {
           return 'allow';
-        };
-      }
+        }
+
+        const requestId = crypto.randomUUID();
+        debug(`[State] Tool "${toolName}" (${nsName}) requires approval — requestId=${requestId}`);
+        return toolOptions.onToolApprovalNeeded!(requestId, toolName, args);
+      };
     }
 
     // ── Resolve maxSteps for tool loop ──

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -107,7 +107,7 @@ export interface ChatToolOptions {
    * blocks until the user responds; the CLI prompts via readline.
    * Return 'allow' to proceed, 'deny' to skip this call, 'abort' to stop all tools.
    */
-  onToolApprovalNeeded?: (requestId: string, toolName: string, args: unknown) => Promise<'allow' | 'deny' | 'abort'>;
+  onToolApprovalNeeded?: (requestId: string, toolName: string, args: unknown, namespacedName?: string) => Promise<'allow' | 'deny' | 'abort'>;
 }
 
 // ── Builder options ─────────────────────────────────────────────────────
@@ -619,22 +619,30 @@ export class CoreState {
     // ── Build tool validator from policy + caller's approval callback ──
     // Secure-by-default: all tools require approval unless explicitly
     // listed in auto_approve.  See DR-019.
+    // Precedence: require_approval > auto_approve > default (ask).
     let toolValidator: ToolValidationCallback | undefined;
     if (toolOptions?.onToolApprovalNeeded && this.toolRegistry) {
       const registry = this.toolRegistry;
+      const requirePatterns = toolPolicy?.require_approval;
       const autoPatterns = toolPolicy?.auto_approve;
 
       toolValidator = async (toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
         const resolved = registry.resolve(toolName);
         const nsName = resolved?.namespacedName || toolName;
 
+        if (matchesAnyPattern(requirePatterns, nsName)) {
+          const requestId = crypto.randomUUID();
+          debug(`[State] Tool "${toolName}" (${nsName}) requires approval (explicit) — requestId=${requestId}`);
+          return toolOptions.onToolApprovalNeeded!(requestId, toolName, args, nsName);
+        }
+
         if (matchesAnyPattern(autoPatterns, nsName)) {
           return 'allow';
         }
 
         const requestId = crypto.randomUUID();
-        debug(`[State] Tool "${toolName}" (${nsName}) requires approval — requestId=${requestId}`);
-        return toolOptions.onToolApprovalNeeded!(requestId, toolName, args);
+        debug(`[State] Tool "${toolName}" (${nsName}) requires approval (default) — requestId=${requestId}`);
+        return toolOptions.onToolApprovalNeeded!(requestId, toolName, args, nsName);
       };
     }
 

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -4,8 +4,9 @@
  * Starts the daemon in-process if not already running, then enters a
  * readline-based REPL that streams responses to stdout.
  *
- * Tool calls that match `require_approval` patterns pause and prompt the user
- * for approval before executing.
+ * All tool calls require approval by default (secure-by-default, DR-019).
+ * Users can choose "allow always" to session-approve a tool for the
+ * remainder of the chat session without persisting to config.
  */
 
 import * as readline from 'node:readline';
@@ -72,6 +73,8 @@ async function runInteractiveMode(
   messages: Array<{ role: string; content: string }>,
   rl: readline.Interface,
 ): Promise<void> {
+  const sessionApproved = new Set<string>();
+
   const prompt = (): Promise<string | null> => {
     return new Promise((resolve) => {
       rl.prompt();
@@ -95,9 +98,17 @@ async function runInteractiveMode(
     const toolOptions: ChatToolOptions = {
       toolMode: options.tools === false ? 'none' : 'auto',
       onToolApprovalNeeded: async (_requestId: string, toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
+        if (sessionApproved.has(toolName)) {
+          return 'allow';
+        }
         process.stderr.write(`\n${YELLOW}⚠ Tool approval required:${RESET} ${BOLD}${toolName}${RESET}\n`);
         process.stderr.write(`${DIM}Arguments:${RESET} ${JSON.stringify(args, null, 2)}\n`);
-        return promptApproval(rl);
+        const decision = await promptApproval(rl);
+        if (decision === 'allow-always') {
+          sessionApproved.add(toolName);
+          return 'allow';
+        }
+        return decision;
       },
     };
 
@@ -163,20 +174,23 @@ async function runJsonMode(
   }
 }
 
-function promptApproval(rl: readline.Interface): Promise<'allow' | 'deny' | 'abort'> {
+function promptApproval(rl: readline.Interface): Promise<'allow' | 'allow-always' | 'deny' | 'abort'> {
   return new Promise((resolve) => {
-    process.stderr.write(`${YELLOW}[a]llow / [d]eny / a[b]ort all?${RESET} `);
+    process.stderr.write(`${YELLOW}[a]llow once / allow [A]lways / [d]eny / a[b]ort all?${RESET} `);
 
     const handler = (line: string) => {
-      const answer = line.trim().toLowerCase();
-      if (answer === 'a' || answer === 'allow' || answer === 'y' || answer === 'yes') {
+      const answer = line.trim();
+      const lower = answer.toLowerCase();
+      if (lower === 'a' || lower === 'allow' || lower === 'y' || lower === 'yes') {
         resolve('allow');
-      } else if (answer === 'd' || answer === 'deny' || answer === 'n' || answer === 'no') {
+      } else if (answer === 'A' || lower === 'always') {
+        resolve('allow-always');
+      } else if (lower === 'd' || lower === 'deny' || lower === 'n' || lower === 'no') {
         resolve('deny');
-      } else if (answer === 'b' || answer === 'abort') {
+      } else if (lower === 'b' || lower === 'abort') {
         resolve('abort');
       } else {
-        process.stderr.write(`${YELLOW}[a]llow / [d]eny / a[b]ort all?${RESET} `);
+        process.stderr.write(`${YELLOW}[a]llow once / allow [A]lways / [d]eny / a[b]ort all?${RESET} `);
         rl.once('line', handler);
         return;
       }

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -97,7 +97,7 @@ async function runInteractiveMode(
 
     const toolOptions: ChatToolOptions = {
       toolMode: options.tools === false ? 'none' : 'auto',
-      onToolApprovalNeeded: async (_requestId: string, toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
+      onToolApprovalNeeded: async (_requestId: string, toolName: string, args: unknown, _namespacedName?: string): Promise<'allow' | 'deny' | 'abort'> => {
         if (sessionApproved.has(toolName)) {
           return 'allow';
         }
@@ -181,10 +181,10 @@ function promptApproval(rl: readline.Interface): Promise<'allow' | 'allow-always
     const handler = (line: string) => {
       const answer = line.trim();
       const lower = answer.toLowerCase();
-      if (lower === 'a' || lower === 'allow' || lower === 'y' || lower === 'yes') {
-        resolve('allow');
-      } else if (answer === 'A' || lower === 'always') {
+      if (answer === 'A' || lower === 'always') {
         resolve('allow-always');
+      } else if (lower === 'a' || lower === 'allow' || lower === 'y' || lower === 'yes') {
+        resolve('allow');
       } else if (lower === 'd' || lower === 'deny' || lower === 'n' || lower === 'no') {
         resolve('deny');
       } else if (lower === 'b' || lower === 'abort') {

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -562,8 +562,8 @@ export function createWebApp(state: DaemonState): Express {
     const toolOptions: ChatToolOptions = {
       toolMode: tool_mode || 'auto',
       tools: toolDefs && toolDefs.length > 0 ? toolDefs : undefined,
-      onToolApprovalNeeded: async (requestId: string, toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
-        safeWrite(`data: ${JSON.stringify({ type: 'approval_request', chatId, requestId, toolName, args })}\n\n`);
+      onToolApprovalNeeded: async (requestId: string, toolName: string, args: unknown, namespacedName?: string): Promise<'allow' | 'deny' | 'abort'> => {
+        safeWrite(`data: ${JSON.stringify({ type: 'approval_request', chatId, requestId, toolName, namespacedName, args })}\n\n`);
         return new Promise((resolve) => {
           pendingApprovals.set(requestId, { resolve, toolName, args, chatId });
         });

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -554,7 +554,8 @@
                   <pre style="margin-top: 4px; padding: 8px; background: #f5f5f5; border-radius: 4px; font-size: 0.85em; overflow-x: auto;" x-text="JSON.stringify(pendingApproval.args, null, 2)"></pre>
                 </details>
                 <div style="display: flex; gap: 8px;">
-                  <button class="btn btn-primary" @click="resolveApproval('allow')">Allow</button>
+                  <button class="btn btn-primary" @click="resolveApproval('allow')">Allow Once</button>
+                  <button class="btn btn-primary" @click="resolveApprovalAndRemember()" style="background: #0a6640;">Allow &amp; Remember</button>
                   <button class="btn btn-secondary" @click="resolveApproval('deny')">Deny</button>
                   <button class="btn btn-secondary" @click="resolveApproval('abort')" style="color: #c00;">Abort All</button>
                 </div>
@@ -775,7 +776,7 @@
                         <select :value="getToolPolicy(tool.name)" @change="setToolPolicy(tool.name, $event.target.value)"
                                 style="width: auto; padding: 2px 6px; font-size: 0.8rem;">
                           <option value="always">Always</option>
-                          <option value="ask">Ask (soon)</option>
+                          <option value="ask">Ask</option>
                           <option value="disable">Disable</option>
                         </select>
                       </td>
@@ -1913,7 +1914,7 @@ function dashboard() {
     },
     
     getToolPolicy(toolName) {
-      return this.toolPolicy[toolName] || 'always';
+      return this.toolPolicy[toolName] || 'ask';
     },
     
     async setToolPolicy(toolName, policy) {
@@ -1927,11 +1928,9 @@ function dashboard() {
         else if (p === 'ask') require_approval.push(name);
         else if (p === 'always') auto_approve.push(name);
       }
-      // Only write non-default entries (default is 'always', so no need to save those)
       const tool_policy = {};
       if (disabled_tools.length > 0) tool_policy.disabled_tools = disabled_tools;
       if (require_approval.length > 0) tool_policy.require_approval = require_approval;
-      // auto_approve is the default, only include if explicitly set
       if (auto_approve.length > 0) tool_policy.auto_approve = auto_approve;
       
       try {
@@ -2149,6 +2148,13 @@ function dashboard() {
       } catch (e) {
         console.error('Failed to send approval:', e);
       }
+    },
+
+    async resolveApprovalAndRemember() {
+      if (!this.pendingApproval) return;
+      const toolName = this.pendingApproval.toolName;
+      await this.resolveApproval('allow');
+      await this.setToolPolicy(toolName, 'always');
     },
   };
 }

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -1919,7 +1919,6 @@ function dashboard() {
     
     async setToolPolicy(toolName, policy) {
       this.toolPolicy[toolName] = policy;
-      // Rebuild the tool_policy config arrays
       const disabled_tools = [];
       const require_approval = [];
       const auto_approve = [];
@@ -1928,17 +1927,16 @@ function dashboard() {
         else if (p === 'ask') require_approval.push(name);
         else if (p === 'always') auto_approve.push(name);
       }
-      const tool_policy = {};
-      if (disabled_tools.length > 0) tool_policy.disabled_tools = disabled_tools;
-      if (require_approval.length > 0) tool_policy.require_approval = require_approval;
-      if (auto_approve.length > 0) tool_policy.auto_approve = auto_approve;
       
       try {
-        // Read current config, update tool_policy, save
         const resp = await fetch('/api/config?location=user');
         const data = await resp.json();
         const config = data.config || {};
-        config.tool_policy = tool_policy;
+        const existing = config.tool_policy || {};
+        existing.disabled_tools = disabled_tools.length > 0 ? disabled_tools : undefined;
+        existing.require_approval = require_approval.length > 0 ? require_approval : undefined;
+        existing.auto_approve = auto_approve.length > 0 ? auto_approve : undefined;
+        config.tool_policy = existing;
         await fetch('/api/config', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -2109,6 +2107,7 @@ function dashboard() {
                     chatId: data.chatId,
                     requestId: data.requestId,
                     toolName: data.toolName,
+                    namespacedName: data.namespacedName,
                     args: data.args,
                   };
                   this.chatMessages[idx].content += `\n\n⏸️ **Waiting for approval:** \`${data.toolName}\`\n`;
@@ -2152,9 +2151,9 @@ function dashboard() {
 
     async resolveApprovalAndRemember() {
       if (!this.pendingApproval) return;
-      const toolName = this.pendingApproval.toolName;
+      const policyKey = this.pendingApproval.namespacedName || this.pendingApproval.toolName;
       await this.resolveApproval('allow');
-      await this.setToolPolicy(toolName, 'always');
+      await this.setToolPolicy(policyKey, 'always');
     },
   };
 }


### PR DESCRIPTION
## Summary

- Flip tool approval default from auto-approve-all to **ask-by-default** (DR-019). All tool calls now require user approval unless explicitly listed in `tool_policy.auto_approve`.
- CLI chat prompt extended to `[a]llow once / allow [A]lways / [d]eny / a[b]ort all?` with session-scoped "allow always" that avoids prompt fatigue without persisting to config.
- Web UI approval card gains an **"Allow & Remember"** button that persists the choice to `config.yaml`. Default tool policy display changed from "Always" to "Ask".

## Changes

| File | Change |
|------|--------|
| `packages/daemon/src/core/state.ts` | Validator always created when approval callback + registry exist; checks `auto_approve` first, asks for everything else |
| `packages/daemon/src/daemon/chat.ts` | Session-scoped `Set<string>` for "allow always"; extended prompt |
| `packages/daemon/static/index.html` | Default `getToolPolicy()` → `'ask'`; removed "(soon)" label; added "Allow & Remember" button |
| `docs/decisions.md` | DR-019: secure-by-default tool approval rationale |
| `docs/ROADMAP.md` | Updated section 1 to reflect enforced tiers and new default |

## Migration

Users who want the previous auto-approve-all behavior can add to their `config.yaml`:

```yaml
tool_policy:
  auto_approve: ['*']
```

## Test plan

- [ ] Start daemon with MCP servers configured and no `tool_policy` — verify tools prompt for approval
- [ ] CLI: approve with `a` (allow once) — verify same tool prompts again on next call
- [ ] CLI: approve with `A` (allow always) — verify same tool auto-approves for rest of session
- [ ] Web UI: click "Allow Once" — verify same tool prompts again
- [ ] Web UI: click "Allow & Remember" — verify tool policy persisted to `config.yaml` as `auto_approve`
- [ ] Set `tool_policy.auto_approve: ['*']` — verify all tools auto-approve (backward compat)
- [ ] Web UI Tools tab: verify default dropdown shows "Ask" for unconfigured tools