### PR TITLE
feat(web): add OpenAI-compatible API server (/v1/models, /v1/chat/completions)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,6 +81,7 @@ Full application layer. Extends core with transport, UI, and CLI.
 | `daemon/index.ts` | CLI entry point (Commander) |
 | `daemon/server/abbenay-service.ts` | gRPC service handlers |
 | `daemon/web/server.ts` | Express web server + REST API |
+| `daemon/web/openai-compat.ts` | OpenAI-compatible `/v1/*` routes (models, chat completions) |
 | `daemon/web/grpc-web-control.ts` | gRPC client for web server control |
 | `daemon/secrets/keychain.ts` | `KeychainSecretStore` (keytar native addon) |
 
@@ -93,6 +94,7 @@ The core TypeScript/Node.js process that runs as a background daemon.
 **Subcommands:**
 - `abbenay daemon` - Start the gRPC server on Unix socket (or named pipe on Windows)
 - `abbenay web` - Start the web dashboard (embedded in daemon or started via gRPC if daemon already running)
+- `abbenay serve` - Start the OpenAI-compatible API server (same as `web` but framed for API use)
 - `abbenay status` - Check if daemon is running
 - `abbenay stop` - Stop the running daemon
 
@@ -108,10 +110,11 @@ The web dashboard runs inside the daemon process via Express:
 - **Static assets**: Served from `packages/daemon/static/`
 - **API routes**: `/api/*` -> Direct calls to `DaemonState` (no gRPC in the loop)
 - **Chat SSE**: `POST /api/chat` -> Streaming responses via Server-Sent Events
+- **OpenAI-compatible API**: `/v1/models`, `/v1/chat/completions` -> Drop-in replacement for any OpenAI-compatible client (see DR-020)
 
 The web server is started either:
-1. In-process when `abbenay web` runs and no daemon is running
-2. Via gRPC `StartWebServer` when a daemon is already running and `abbenay web` is invoked
+1. In-process when `abbenay web` or `abbenay serve` runs and no daemon is running
+2. Via gRPC `StartWebServer` when a daemon is already running and `abbenay web`/`abbenay serve` is invoked
 
 ### VS Code Extension
 
@@ -429,6 +432,8 @@ Session management is **deferred**. Stub RPCs exist in the proto and service han
    - POST /api/config → saveConfig()
    - POST /api/secrets → state.secretStore.set()
    - POST /api/chat → state.chat() (SSE stream)
+   - GET /v1/models → state.listModels() (OpenAI format)
+   - POST /v1/chat/completions → state.chat() (OpenAI format, streaming or JSON)
    ↓
 4. Web server has direct DaemonState access (no gRPC in the loop)
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,36 +96,45 @@ Pipe mode (`--json`): emit newline-delimited JSON chunks for scripting.
 
 ---
 
-## 3. OpenAI-Compatible HTTP Server — planned
+## 3. OpenAI-Compatible HTTP Server — partial (M1 done)
 
-Abbenay acts as a *client* to OpenAI-compatible providers but does not expose its own
-OpenAI-compatible API. The existing `POST /api/chat` uses a custom SSE format.
+Abbenay now exposes an OpenAI-compatible API alongside the existing `/api/*` routes,
+making it a drop-in replacement for any OpenAI-compatible client (Cursor, Continue,
+aider, any `openai` SDK script, etc.). See DR-020.
 
-### Endpoints to implement
+### What exists
+
+| Layer | Status |
+|---|---|
+| `GET /v1/models` — list virtual models in OpenAI format | done |
+| `POST /v1/chat/completions` — streaming SSE (`data: {...}\ndata: [DONE]`) | done |
+| `POST /v1/chat/completions` — non-streaming JSON response | done |
+| Tool calls mapped to OpenAI `tool_calls` format in stream | done |
+| `aby serve` CLI command (starts OpenAI-compat server) | done |
+| Format translation helpers with unit tests | done |
+| Integration tests (models, streaming, non-streaming, errors, tools) | done |
+
+### What needs to happen
 
 | Endpoint | Priority |
 |---|---|
-| `GET  /v1/models` | high — list virtual models |
-| `POST /v1/chat/completions` | high — streaming + non-streaming |
 | `POST /v1/completions` | low — legacy |
 | `POST /v1/embeddings` | low — if engines support it |
+| Usage/token stats (real counts from providers) | medium |
+| Optional Bearer token auth (`config.yaml → server.api_key`) | medium |
+| Rate limiting | low |
 
-### Design notes
+### Key files
 
-- Mount at `/v1/` on the existing Express app (alongside `/api/`)
-- Map Abbenay virtual model IDs to OpenAI `model` field
-- Translate tool calls to OpenAI `tool_calls` format in response chunks
-- Support `stream: true` (SSE with `data: {...}\ndata: [DONE]`) and `stream: false`
-- API key auth: optional Bearer token configurable via `config.yaml → server.api_key`
-- This makes Abbenay a drop-in replacement for any OpenAI-compatible client
-  (Cursor, Continue, aider, etc.)
+- `packages/daemon/src/daemon/web/openai-compat.ts` — route registration + format helpers
+- `packages/daemon/src/daemon/web/openai-compat.test.ts` — unit tests
+- `packages/daemon/tests/integration/openai-compat.test.ts` — integration tests
 
 ### Milestones
 
-- **M1**: `/v1/models` + `/v1/chat/completions` (streaming)
-- **M2**: Non-streaming completions, usage stats
-- **M3**: Tool calls in OpenAI format
-- **M4**: Optional auth, rate limiting
+- **M1**: `/v1/models` + `/v1/chat/completions` (streaming + non-streaming + tools) — **done**
+- **M2**: Usage stats, optional auth
+- **M3**: Rate limiting, `/v1/completions` (legacy)
 
 ---
 
@@ -273,7 +282,7 @@ by wiring to `ToolRegistry`.
 | Phase | Sections | Rationale | Status |
 |---|---|---|---|
 | **Phase 1** | 1 (M1–M2, M4) + 2 | Tool approval in web + CLI chat | **done** |
-| **Phase 2** | 5 (M1–M3) | Session CRUD + UI — enables persistent conversations | next |
-| **Phase 3** | 3 (M1–M2) | OpenAI-compatible server — unlocks third-party integrations | |
+| **Phase 2** | 3 (M1) | OpenAI-compatible server — unlocks third-party integrations | **done** |
+| **Phase 3** | 5 (M1–M3) | Session CRUD + UI — enables persistent conversations | next |
 | **Phase 4** | 6 + 5 (M4–M5) | Session sharing, fork, replay | |
 | **Phase 5** | 4 + 7 | Policy Phase 2 (context.*) + remaining gRPC stubs | |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,12 +14,19 @@ packages/daemon/
 │   │   ├── mock.ts
 │   │   ├── mock.test.ts              <- Unit test (co-located)
 │   │   ├── config.ts
-│   │   └── config.test.ts            <- Unit test (co-located)
+│   │   ├── config.test.ts            <- Unit test (co-located)
+│   │   ├── tool-registry.test.ts     <- Unit test (glob matching, registry)
+│   │   └── tool-approval.test.ts     <- Unit test (3-tier approval logic)
+│   ├── daemon/
+│   │   ├── chat-prompt.test.ts       <- Unit test (parseApprovalInput)
+│   │   └── web/
+│   │       └── openai-compat.test.ts <- Unit test (OpenAI format mapping)
 │   └── state.test.ts                 <- Unit test (DaemonState)
 ├── tests/
 │   └── integration/
 │       ├── grpc-streaming.test.ts    <- Integration (real gRPC server/client)
 │       ├── web-sse.test.ts           <- Integration (real Express + HTTP)
+│       ├── openai-compat.test.ts     <- Integration (OpenAI-compat API)
 │       └── helpers/
 │           └── mock-daemon.ts        <- Shared mock gRPC server
 ├── vitest.config.ts
@@ -56,7 +63,11 @@ Pure unit tests with no I/O, no network, no processes.
 |------|----------------|
 | `src/core/mock.test.ts` | Mock engine: echo, fixed, error, empty, slow modes |
 | `src/core/config.test.ts` | Config loading, merging, validation |
+| `src/core/tool-registry.test.ts` | Glob matching, tool registration, resolution, policy filtering |
+| `src/core/tool-approval.test.ts` | 3-tier approval precedence (auto_approve, require_approval, default) |
 | `src/state.test.ts` | DaemonState: provider listing, model listing, chat flow |
+| `src/daemon/chat-prompt.test.ts` | `parseApprovalInput` case-sensitive routing |
+| `src/daemon/web/openai-compat.test.ts` | OpenAI format mapping: models, finish reasons, stream chunks, complete responses |
 
 ### Layer 2: Integration Tests
 
@@ -66,6 +77,7 @@ Tests that start real servers, make real HTTP/gRPC calls.
 |------|----------------|
 | `tests/integration/grpc-streaming.test.ts` | gRPC unary RPCs + streaming + cancellation + concurrency |
 | `tests/integration/web-sse.test.ts` | Web API endpoints + SSE chat streaming + errors + disconnect |
+| `tests/integration/openai-compat.test.ts` | OpenAI-compatible API: /v1/models, streaming, non-streaming, errors, tool calls |
 
 ### Mock Engine
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -234,3 +234,16 @@ must grant trust explicitly. Friction is mitigated by session-scoped "allow
 always" in the CLI (not persisted) and "Allow & Remember" in the web UI
 (persisted to `config.yaml`). Users who want the previous behavior can set
 `tool_policy.auto_approve: ['*:*/*']`.
+
+## DR-020: OpenAI-compatible API on the existing Express server
+
+**Date:** 2026-03-12  
+**Decision:** Mount OpenAI-compatible `/v1/` routes (`GET /v1/models`,
+`POST /v1/chat/completions`) on the existing Express server rather than a
+separate process or server.  
+**Rationale:** Single server, single port, no extra process management. The
+existing Express app already handles CORS, static assets, and SSE. Adding `/v1/`
+routes is purely additive and doesn't affect existing `/api/` behavior. Abbenay
+composite model IDs (e.g., `openai/gpt-4o`) serve as the `model` field in
+OpenAI requests. A new `aby serve` CLI command highlights the OpenAI-compat
+angle while reusing the same `startEmbeddedWebServer()` lifecycle.

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -7,6 +7,7 @@
  *   abbenay status        # Check daemon status
  *   abbenay stop          # Stop running daemon
  *   abbenay web           # Start web dashboard
+ *   abbenay serve         # Start OpenAI-compatible API server
  *   abbenay chat          # Interactive chat
  *   abbenay list-engines  # List supported engines
  *   abbenay list-models   # List configured models
@@ -143,6 +144,55 @@ program
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error('Failed to start web server:', msg);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('serve')
+  .description('Start OpenAI-compatible API server (serves /v1/models, /v1/chat/completions)')
+  .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('--host <host>', 'Host to bind to', '127.0.0.1')
+  .option('--mcp', 'Start MCP server on /mcp endpoint')
+  .action(async (options) => {
+    const port = parseInt(options.port, 10);
+
+    try {
+      if (isDaemonRunningSync()) {
+        console.log('Daemon is running, requesting web server start via gRPC...');
+        const { sendStartWebServer, sendStopWebServer } = await import('./web/grpc-web-control.js');
+        const result = await sendStartWebServer(port);
+        console.log(`Abbenay API server: ${result.url}`);
+        console.log(`OpenAI-compatible endpoint: ${result.url}/v1/chat/completions`);
+        if (result.already_running) console.log('(server was already running)');
+
+        await new Promise<void>((resolve) => {
+          const shutdown = async () => {
+            console.log('\nStopping server...');
+            try { await sendStopWebServer(); } catch { /* ignore */ }
+            resolve();
+          };
+          process.on('SIGINT', shutdown);
+          process.on('SIGTERM', shutdown);
+        });
+      } else {
+        console.log('No daemon running, starting daemon + API server...');
+        const daemonState = await startDaemon({ keepAlive: false });
+        const { url, app } = await startEmbeddedWebServer(daemonState, port);
+        console.log(`Abbenay API server: ${url}`);
+        console.log(`OpenAI-compatible endpoint: ${url}/v1/chat/completions`);
+
+        if (options.mcp && app) {
+          await daemonState.mcpServer.start(app);
+          console.log(`MCP Server: ${url}/mcp`);
+        }
+
+        console.log('Press Ctrl+C to stop');
+        await new Promise(() => {});
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error('Failed to start API server:', msg);
       process.exit(1);
     }
   });

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -152,10 +152,13 @@ program
   .command('serve')
   .description('Start OpenAI-compatible API server (serves /v1/models, /v1/chat/completions)')
   .option('-p, --port <port>', 'Port to listen on', '8787')
-  .option('--host <host>', 'Host to bind to', '127.0.0.1')
   .option('--mcp', 'Start MCP server on /mcp endpoint')
   .action(async (options) => {
     const port = parseInt(options.port, 10);
+    if (!Number.isFinite(port) || port < 0 || port > 65535) {
+      console.error(`Invalid port: "${options.port}". Must be an integer between 0 and 65535.`);
+      process.exit(1);
+    }
 
     try {
       if (isDaemonRunningSync()) {

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -1,0 +1,236 @@
+/**
+ * OpenAI-compatible API format translation tests
+ *
+ * Tests the pure mapping functions in isolation (no HTTP server):
+ * model mapping, finish reason mapping, stream chunk building,
+ * and complete response building.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  mapModelToOpenAI,
+  mapFinishReason,
+  buildStreamChunk,
+  buildCompleteResponse,
+  generateChatId,
+  type StreamChunkOptions,
+} from './openai-compat.js';
+import type { ModelInfo } from '../../core/state.js';
+import type { ChatChunk } from '../../core/engines.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- test assertions need flexible access to untyped response shapes */
+
+// ── mapModelToOpenAI ────────────────────────────────────────────────────
+
+describe('mapModelToOpenAI', () => {
+  const model: ModelInfo = {
+    id: 'openai/gpt-4o',
+    name: 'gpt-4o',
+    engineModelId: 'gpt-4o',
+    provider: 'openai',
+    engine: 'openai',
+    contextWindow: 128000,
+    capabilities: { supportsTools: true, supportsVision: true },
+  };
+
+  it('maps id from Abbenay composite ID', () => {
+    const result = mapModelToOpenAI(model);
+    expect(result.id).toBe('openai/gpt-4o');
+  });
+
+  it('sets object to "model"', () => {
+    expect(mapModelToOpenAI(model).object).toBe('model');
+  });
+
+  it('sets owned_by from engine', () => {
+    expect(mapModelToOpenAI(model).owned_by).toBe('openai');
+  });
+
+  it('sets created to 0 (unknown)', () => {
+    expect(mapModelToOpenAI(model).created).toBe(0);
+  });
+
+  it('maps different engines correctly', () => {
+    const anthropicModel: ModelInfo = {
+      id: 'my-anthropic/claude-3-5-sonnet',
+      name: 'claude-3-5-sonnet',
+      engineModelId: 'claude-3-5-sonnet-20241022',
+      provider: 'my-anthropic',
+      engine: 'anthropic',
+      contextWindow: 200000,
+    };
+    const result = mapModelToOpenAI(anthropicModel);
+    expect(result.id).toBe('my-anthropic/claude-3-5-sonnet');
+    expect(result.owned_by).toBe('anthropic');
+  });
+});
+
+// ── mapFinishReason ─────────────────────────────────────────────────────
+
+describe('mapFinishReason', () => {
+  it('maps stop -> stop', () => {
+    expect(mapFinishReason('stop')).toBe('stop');
+  });
+
+  it('maps length -> length', () => {
+    expect(mapFinishReason('length')).toBe('length');
+  });
+
+  it('maps tool-calls -> tool_calls', () => {
+    expect(mapFinishReason('tool-calls')).toBe('tool_calls');
+  });
+
+  it('maps unknown reasons to stop', () => {
+    expect(mapFinishReason('other')).toBe('stop');
+    expect(mapFinishReason('')).toBe('stop');
+    expect(mapFinishReason('content-filter')).toBe('stop');
+  });
+});
+
+// ── generateChatId ──────────────────────────────────────────────────────
+
+describe('generateChatId', () => {
+  it('starts with chatcmpl- prefix', () => {
+    expect(generateChatId()).toMatch(/^chatcmpl-/);
+  });
+
+  it('generates unique ids', () => {
+    const ids = new Set(Array.from({ length: 10 }, () => generateChatId()));
+    expect(ids.size).toBe(10);
+  });
+});
+
+// ── buildStreamChunk ────────────────────────────────────────────────────
+
+describe('buildStreamChunk', () => {
+  const opts: StreamChunkOptions = {
+    id: 'chatcmpl-test123',
+    model: 'openai/gpt-4o',
+    created: 1710000000,
+  };
+
+  describe('text chunks', () => {
+    it('maps text chunk to delta with content', () => {
+      const chunk: ChatChunk = { type: 'text', text: 'Hello' };
+      const result = buildStreamChunk(chunk, opts, 0, false) as any;
+
+      expect(result.id).toBe('chatcmpl-test123');
+      expect(result.object).toBe('chat.completion.chunk');
+      expect(result.model).toBe('openai/gpt-4o');
+      expect(result.choices[0].delta.content).toBe('Hello');
+      expect(result.choices[0].finish_reason).toBeNull();
+    });
+
+    it('includes role on first chunk', () => {
+      const chunk: ChatChunk = { type: 'text', text: 'Hi' };
+      const result = buildStreamChunk(chunk, opts, 0, true) as any;
+
+      expect(result.choices[0].delta.role).toBe('assistant');
+      expect(result.choices[0].delta.content).toBe('Hi');
+    });
+
+    it('omits role on subsequent chunks', () => {
+      const chunk: ChatChunk = { type: 'text', text: 'world' };
+      const result = buildStreamChunk(chunk, opts, 0, false) as any;
+
+      expect(result.choices[0].delta.role).toBeUndefined();
+    });
+  });
+
+  describe('tool call chunks', () => {
+    it('maps running tool chunk to tool_calls delta', () => {
+      const chunk: ChatChunk = {
+        type: 'tool',
+        name: 'search',
+        state: 'running',
+        call: { params: { q: 'test' }, result: undefined },
+        done: false,
+      };
+      const result = buildStreamChunk(chunk, opts, 0, false) as any;
+
+      expect(result.choices[0].delta.tool_calls).toHaveLength(1);
+      expect(result.choices[0].delta.tool_calls[0].index).toBe(0);
+      expect(result.choices[0].delta.tool_calls[0].type).toBe('function');
+      expect(result.choices[0].delta.tool_calls[0].function.name).toBe('search');
+      expect(result.choices[0].delta.tool_calls[0].function.arguments).toBe('{"q":"test"}');
+    });
+
+    it('returns null for completed tool chunks (results)', () => {
+      const chunk: ChatChunk = {
+        type: 'tool',
+        name: 'search',
+        state: 'completed',
+        call: { params: { q: 'test' }, result: 'found it' },
+        done: true,
+      };
+      expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
+    });
+  });
+
+  describe('done chunks', () => {
+    it('maps done chunk with empty delta and finish_reason', () => {
+      const chunk: ChatChunk = { type: 'done', finishReason: 'stop' };
+      const result = buildStreamChunk(chunk, opts, 0, false) as any;
+
+      expect(result.choices[0].delta).toEqual({});
+      expect(result.choices[0].finish_reason).toBe('stop');
+    });
+
+    it('maps tool-calls finish reason', () => {
+      const chunk: ChatChunk = { type: 'done', finishReason: 'tool-calls' };
+      const result = buildStreamChunk(chunk, opts, 0, false) as any;
+
+      expect(result.choices[0].finish_reason).toBe('tool_calls');
+    });
+  });
+
+  describe('non-mapped chunks', () => {
+    it('returns null for error chunks', () => {
+      const chunk: ChatChunk = { type: 'error', error: 'boom' };
+      expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
+    });
+
+    it('returns null for approval_request chunks', () => {
+      const chunk: ChatChunk = { type: 'approval_request', requestId: 'r1', toolName: 'x', args: {} };
+      expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
+    });
+  });
+});
+
+// ── buildCompleteResponse ───────────────────────────────────────────────
+
+describe('buildCompleteResponse', () => {
+  it('builds a valid non-streaming response', () => {
+    const result = buildCompleteResponse(
+      'chatcmpl-abc',
+      'openai/gpt-4o',
+      1710000000,
+      'Hello world',
+      'stop',
+    ) as any;
+
+    expect(result.id).toBe('chatcmpl-abc');
+    expect(result.object).toBe('chat.completion');
+    expect(result.model).toBe('openai/gpt-4o');
+    expect(result.created).toBe(1710000000);
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices[0].index).toBe(0);
+    expect(result.choices[0].message.role).toBe('assistant');
+    expect(result.choices[0].message.content).toBe('Hello world');
+    expect(result.choices[0].finish_reason).toBe('stop');
+  });
+
+  it('includes usage with zeros', () => {
+    const result = buildCompleteResponse('id', 'model', 0, '', 'stop') as any;
+    expect(result.usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+
+  it('maps finish reason correctly', () => {
+    const result = buildCompleteResponse('id', 'model', 0, '', 'length') as any;
+    expect(result.choices[0].finish_reason).toBe('length');
+  });
+});

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -151,7 +151,6 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
       top_p,
       max_tokens,
       max_completion_tokens,
-      tools,
     } = req.body;
 
     if (!model) {
@@ -163,12 +162,15 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
       return;
     }
 
-    const chatMessages = messages.map((m: { role?: string; content?: string; name?: string; tool_call_id?: string }) => ({
-      role: m.role || 'user',
-      content: m.content || '',
-      name: m.name || undefined,
-      tool_call_id: m.tool_call_id || undefined,
-    }));
+    const chatMessages = messages.map(
+      (m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown }) => ({
+        role: m.role || 'user',
+        content: m.content || '',
+        name: m.name || undefined,
+        tool_call_id: m.tool_call_id || undefined,
+        tool_calls: m.tool_calls || undefined,
+      }),
+    );
 
     const requestParams: Record<string, unknown> = {};
     if (temperature != null) requestParams.temperature = temperature;
@@ -177,24 +179,12 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
     if (effectiveMaxTokens != null) requestParams.maxTokens = effectiveMaxTokens;
     const hasParams = Object.keys(requestParams).length > 0;
 
-    interface OpenAIToolDef {
-      type?: string;
-      function?: { name?: string; description?: string; parameters?: unknown };
-    }
-    const toolDefs = Array.isArray(tools)
-      ? (tools as OpenAIToolDef[])
-          .filter((t) => t.type === 'function' && t.function)
-          .map((t) => ({
-            name: t.function!.name || '',
-            description: t.function!.description || '',
-            inputSchema: JSON.stringify(t.function!.parameters ?? {}),
-          }))
-          .filter((t) => t.name)
-      : undefined;
-
+    // OpenAI-compatible transport has no approval UI, so tools are disabled
+    // to preserve secure-by-default (DR-019). M2 can add opt-in via config
+    // that would parse `tools` from the request and wire onToolApprovalNeeded.
     const toolOptions: ChatToolOptions = {
-      toolMode: toolDefs && toolDefs.length > 0 ? 'auto' : 'none',
-      tools: toolDefs && toolDefs.length > 0 ? toolDefs : undefined,
+      toolMode: 'none',
+      tools: undefined,
     };
 
     const chatId = generateChatId();

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -1,0 +1,311 @@
+/**
+ * OpenAI-compatible API routes — `/v1/models` and `/v1/chat/completions`.
+ *
+ * Translates between the OpenAI wire format and Abbenay's DaemonState,
+ * making Abbenay a drop-in replacement for any OpenAI-compatible client
+ * (Cursor, Continue, aider, any `openai` SDK script, etc.).
+ */
+
+import * as crypto from 'node:crypto';
+import type { Express, Request, Response } from 'express';
+import type { DaemonState } from '../../daemon/state.js';
+import type { ModelInfo, ChatToolOptions } from '../../core/state.js';
+import type { ChatChunk } from '../../core/engines.js';
+
+// ── Format helpers (exported for unit testing) ──────────────────────────
+
+export function mapModelToOpenAI(model: ModelInfo): {
+  id: string;
+  object: 'model';
+  created: number;
+  owned_by: string;
+} {
+  return {
+    id: model.id,
+    object: 'model',
+    created: 0,
+    owned_by: model.engine,
+  };
+}
+
+export function mapFinishReason(reason: string): string {
+  if (reason === 'stop') return 'stop';
+  if (reason === 'length') return 'length';
+  if (reason === 'tool-calls') return 'tool_calls';
+  return 'stop';
+}
+
+export function generateChatId(): string {
+  return `chatcmpl-${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+}
+
+export interface StreamChunkOptions {
+  id: string;
+  model: string;
+  created: number;
+}
+
+export function buildStreamChunk(
+  chunk: ChatChunk,
+  opts: StreamChunkOptions,
+  toolCallIndex: number,
+  isFirstChunk: boolean,
+): object | null {
+  const base = {
+    id: opts.id,
+    object: 'chat.completion.chunk' as const,
+    created: opts.created,
+    model: opts.model,
+  };
+
+  if (chunk.type === 'text') {
+    const delta: Record<string, unknown> = { content: chunk.text };
+    if (isFirstChunk) delta.role = 'assistant';
+    return { ...base, choices: [{ index: 0, delta, finish_reason: null }] };
+  }
+
+  if (chunk.type === 'tool' && chunk.state === 'running' && chunk.call) {
+    const delta: Record<string, unknown> = {};
+    if (isFirstChunk) delta.role = 'assistant';
+    delta.tool_calls = [{
+      index: toolCallIndex,
+      id: `call_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+      type: 'function',
+      function: {
+        name: chunk.name,
+        arguments: typeof chunk.call.params === 'string'
+          ? chunk.call.params
+          : JSON.stringify(chunk.call.params ?? {}),
+      },
+    }];
+    return { ...base, choices: [{ index: 0, delta, finish_reason: null }] };
+  }
+
+  if (chunk.type === 'done') {
+    return {
+      ...base,
+      choices: [{ index: 0, delta: {}, finish_reason: mapFinishReason(chunk.finishReason) }],
+    };
+  }
+
+  // approval_request, approval_result, tool results, errors — not mapped to OpenAI streaming
+  return null;
+}
+
+export function buildCompleteResponse(
+  id: string,
+  model: string,
+  created: number,
+  content: string,
+  finishReason: string,
+): object {
+  return {
+    id,
+    object: 'chat.completion',
+    created,
+    model,
+    choices: [{
+      index: 0,
+      message: { role: 'assistant', content },
+      finish_reason: mapFinishReason(finishReason),
+    }],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
+
+function openAIError(res: Response, status: number, message: string, type: string): void {
+  res.status(status).json({ error: { message, type } });
+}
+
+// ── Route registration ──────────────────────────────────────────────────
+
+// Future M2: add optional Bearer token auth here by reading config.yaml -> server.api_key
+// and checking the Authorization header before each route handler.
+
+export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
+  /**
+   * GET /v1/models — list available models in OpenAI format.
+   */
+  app.get('/v1/models', async (_req: Request, res: Response) => {
+    try {
+      const models = await state.listModels();
+      res.json({
+        object: 'list',
+        data: models.map(mapModelToOpenAI),
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      openAIError(res, 500, msg, 'server_error');
+    }
+  });
+
+  /**
+   * POST /v1/chat/completions — chat with streaming or non-streaming response.
+   */
+  app.post('/v1/chat/completions', (req: Request, res: Response) => {
+    const {
+      model,
+      messages,
+      stream,
+      temperature,
+      top_p,
+      max_tokens,
+      max_completion_tokens,
+      tools,
+    } = req.body;
+
+    if (!model) {
+      openAIError(res, 400, 'model is required', 'invalid_request_error');
+      return;
+    }
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      openAIError(res, 400, 'messages is required and must be a non-empty array', 'invalid_request_error');
+      return;
+    }
+
+    const chatMessages = messages.map((m: { role?: string; content?: string; name?: string; tool_call_id?: string }) => ({
+      role: m.role || 'user',
+      content: m.content || '',
+      name: m.name || undefined,
+      tool_call_id: m.tool_call_id || undefined,
+    }));
+
+    const requestParams: Record<string, unknown> = {};
+    if (temperature != null) requestParams.temperature = temperature;
+    if (top_p != null) requestParams.top_p = top_p;
+    const effectiveMaxTokens = max_tokens ?? max_completion_tokens;
+    if (effectiveMaxTokens != null) requestParams.maxTokens = effectiveMaxTokens;
+    const hasParams = Object.keys(requestParams).length > 0;
+
+    interface OpenAIToolDef {
+      type?: string;
+      function?: { name?: string; description?: string; parameters?: unknown };
+    }
+    const toolDefs = Array.isArray(tools)
+      ? (tools as OpenAIToolDef[])
+          .filter((t) => t.type === 'function' && t.function)
+          .map((t) => ({
+            name: t.function!.name || '',
+            description: t.function!.description || '',
+            inputSchema: JSON.stringify(t.function!.parameters ?? {}),
+          }))
+          .filter((t) => t.name)
+      : undefined;
+
+    const toolOptions: ChatToolOptions = {
+      toolMode: toolDefs && toolDefs.length > 0 ? 'auto' : 'none',
+      tools: toolDefs && toolDefs.length > 0 ? toolDefs : undefined,
+    };
+
+    const chatId = generateChatId();
+    const created = Math.floor(Date.now() / 1000);
+
+    if (stream) {
+      handleStreaming(res, state, model, chatMessages, hasParams ? requestParams : undefined, toolOptions, chatId, created);
+    } else {
+      handleNonStreaming(res, state, model, chatMessages, hasParams ? requestParams : undefined, toolOptions, chatId, created);
+    }
+  });
+}
+
+// ── Streaming handler ───────────────────────────────────────────────────
+
+function handleStreaming(
+  res: Response,
+  state: DaemonState,
+  model: string,
+  messages: Array<{ role: string; content: string }>,
+  params: Record<string, unknown> | undefined,
+  toolOptions: ChatToolOptions,
+  chatId: string,
+  created: number,
+): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  });
+  res.flushHeaders();
+
+  let ended = false;
+  let isFirstChunk = true;
+  let toolCallIndex = 0;
+
+  const safeWrite = (data: string): boolean => {
+    if (ended || res.writableEnded) return false;
+    try { res.write(data); return true; } catch { return false; }
+  };
+
+  const safeEnd = () => {
+    if (!ended && !res.writableEnded) {
+      ended = true;
+      try { res.end(); } catch { /* ignore */ }
+    }
+  };
+
+  res.on('close', () => { ended = true; });
+
+  const opts: StreamChunkOptions = { id: chatId, model, created };
+
+  (async () => {
+    try {
+      for await (const chunk of state.chat(model, messages, params, toolOptions)) {
+        if (ended) break;
+
+        if (chunk.type === 'tool' && chunk.state === 'running') {
+          toolCallIndex++;
+        }
+
+        const mapped = buildStreamChunk(chunk, opts, toolCallIndex - 1, isFirstChunk);
+        if (mapped) {
+          safeWrite(`data: ${JSON.stringify(mapped)}\n\n`);
+          isFirstChunk = false;
+        }
+
+        if (chunk.type === 'error') {
+          safeWrite(`data: ${JSON.stringify({ error: { message: chunk.error, type: 'server_error' } })}\n\n`);
+        }
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      safeWrite(`data: ${JSON.stringify({ error: { message: msg, type: 'server_error' } })}\n\n`);
+    } finally {
+      safeWrite('data: [DONE]\n\n');
+      safeEnd();
+    }
+  })();
+}
+
+// ── Non-streaming handler ───────────────────────────────────────────────
+
+async function handleNonStreaming(
+  res: Response,
+  state: DaemonState,
+  model: string,
+  messages: Array<{ role: string; content: string }>,
+  params: Record<string, unknown> | undefined,
+  toolOptions: ChatToolOptions,
+  chatId: string,
+  created: number,
+): Promise<void> {
+  try {
+    let content = '';
+    let finishReason = 'stop';
+
+    for await (const chunk of state.chat(model, messages, params, toolOptions)) {
+      if (chunk.type === 'text') {
+        content += chunk.text;
+      } else if (chunk.type === 'done') {
+        finishReason = chunk.finishReason;
+      } else if (chunk.type === 'error') {
+        openAIError(res, 500, chunk.error, 'server_error');
+        return;
+      }
+    }
+
+    res.json(buildCompleteResponse(chatId, model, created, content, finishReason));
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    openAIError(res, 500, msg, 'server_error');
+  }
+}

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -21,6 +21,7 @@ import { listAllPolicies, loadCustomPolicies, saveCustomPolicies, BUILTIN_POLICY
 import type { DaemonState } from '../state.js';
 import type { ChatToolOptions } from '../../core/state.js';
 import { getEngines, getProviderTemplates } from '../../core/engines.js';
+import { registerOpenAIRoutes } from './openai-compat.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -890,6 +891,9 @@ export function createWebApp(state: DaemonState): Express {
       res.status(500).json({ error: msg });
     }
   });
+
+  // ── OpenAI-compatible API (/v1/*) ─────────────────────────────────────
+  registerOpenAIRoutes(app, state);
 
   return app;
 }

--- a/packages/daemon/tests/integration/openai-compat.test.ts
+++ b/packages/daemon/tests/integration/openai-compat.test.ts
@@ -1,0 +1,478 @@
+/**
+ * OpenAI-compatible API integration tests
+ *
+ * Tests the /v1/models and /v1/chat/completions endpoints against
+ * a real Express server with a mock DaemonState (same pattern as
+ * web-sse.test.ts). Verifies OpenAI wire format compliance for
+ * streaming, non-streaming, error handling, and tool calls.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import * as http from 'node:http';
+import { createWebApp } from '../../src/daemon/web/server.js';
+import type { DaemonState } from '../../src/daemon/state.js';
+import type { ProviderInfo, ModelInfo } from '../../src/core/state.js';
+import type { ConnectedClient } from '../../src/daemon/state.js';
+import type { SecretStore } from '../../src/core/secrets.js';
+
+// ── Mock DaemonState ────────────────────────────────────────────────────
+
+interface MockChatConfig {
+  chunks: Array<{ type: 'text'; text: string } | { type: 'tool'; name: string; state: string; call?: { params: unknown; result: unknown }; done: boolean } | { type: 'done'; finishReason: string } | { type: 'error'; error: string }>;
+  chunkDelayMs: number;
+  throwError?: string;
+}
+
+let mockChatConfig: MockChatConfig = {
+  chunks: [
+    { type: 'text', text: 'Hello' },
+    { type: 'text', text: ' world' },
+    { type: 'done', finishReason: 'stop' },
+  ],
+  chunkDelayMs: 0,
+};
+
+const mockSecretStore: SecretStore = {
+  async get() { return null; },
+  async set() {},
+  async delete() { return true; },
+  async has() { return false; },
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function createMockState(): DaemonState {
+  return {
+    version: '0.1.0-test',
+    startedAt: new Date(),
+    secretStore: mockSecretStore,
+    get clientCount() { return 0; },
+    getClients(): ConnectedClient[] { return []; },
+    getVSCodeWorkspaces(): string[] { return []; },
+    notifyModelsChanged(): void {},
+
+    async listProviders(): Promise<ProviderInfo[]> {
+      return [
+        { id: 'openai', engine: 'openai', displayName: 'OpenAI', configured: true, healthy: true, requiresKey: true },
+      ] as ProviderInfo[];
+    },
+
+    async listModels(): Promise<ModelInfo[]> {
+      return [
+        { id: 'openai/gpt-4o', name: 'gpt-4o', engineModelId: 'gpt-4o', provider: 'openai', engine: 'openai', contextWindow: 128000, capabilities: { supportsTools: true, supportsVision: true } },
+        { id: 'anthropic/claude-3', name: 'claude-3', engineModelId: 'claude-3', provider: 'anthropic', engine: 'anthropic', contextWindow: 200000 },
+      ] as ModelInfo[];
+    },
+
+    async* chat() {
+      if (mockChatConfig.throwError) {
+        throw new Error(mockChatConfig.throwError);
+      }
+      for (const chunk of mockChatConfig.chunks) {
+        yield chunk;
+        if (mockChatConfig.chunkDelayMs > 0) await sleep(mockChatConfig.chunkDelayMs);
+      }
+    },
+  } as any as DaemonState;
+}
+
+// ── Test Setup ──────────────────────────────────────────────────────────
+
+let httpServer: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const state = createMockState();
+  const app = createWebApp(state);
+  const port = await new Promise<number>((resolve) => {
+    httpServer = app.listen(0, () => {
+      const addr = httpServer.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  if (httpServer) {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  }
+});
+
+beforeEach(() => {
+  mockChatConfig = {
+    chunks: [
+      { type: 'text', text: 'Hello' },
+      { type: 'text', text: ' world' },
+      { type: 'done', finishReason: 'stop' },
+    ],
+    chunkDelayMs: 0,
+  };
+});
+
+// ── HTTP helpers ────────────────────────────────────────────────────────
+
+function httpRequest(
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<{ statusCode: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const postData = body ? JSON.stringify(body) : '';
+    const headers: Record<string, string> = { Connection: 'close' };
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+      headers['Content-Length'] = String(Buffer.byteLength(postData));
+    }
+    const req = http.request({
+      hostname: urlObj.hostname,
+      port: urlObj.port,
+      path: urlObj.pathname + urlObj.search,
+      method,
+      headers,
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => {
+        try { resolve({ statusCode: res.statusCode || 0, body: JSON.parse(data) }); }
+        catch { resolve({ statusCode: res.statusCode || 0, body: data }); }
+      });
+    });
+    req.on('error', reject);
+    const timer = setTimeout(() => { req.destroy(); reject(new Error('timeout')); }, 5000);
+    req.on('close', () => clearTimeout(timer));
+    if (postData) req.write(postData);
+    req.end();
+  });
+}
+
+function postSSE(
+  url: string,
+  body: unknown,
+): Promise<{ events: any[]; statusCode: number; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const events: any[] = [];
+    let buffer = '';
+    const postData = JSON.stringify(body);
+    const urlObj = new URL(url);
+
+    const req = http.request({
+      hostname: urlObj.hostname,
+      port: urlObj.port,
+      path: urlObj.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': String(Buffer.byteLength(postData)),
+      },
+    }, (res) => {
+      const statusCode = res.statusCode || 0;
+      const headers = res.headers;
+      res.setEncoding('utf-8');
+
+      res.on('data', (chunk: string) => {
+        buffer += chunk;
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          if (trimmed.startsWith('data: ')) {
+            const data = trimmed.substring(6);
+            if (data === '[DONE]') {
+              events.push({ _done: true });
+            } else {
+              try { events.push(JSON.parse(data)); }
+              catch { events.push({ _raw: data }); }
+            }
+          }
+        }
+      });
+
+      res.on('end', () => resolve({ events, statusCode, headers }));
+      res.on('error', (err) => reject(err));
+    });
+
+    req.on('error', reject);
+    const timer = setTimeout(() => { req.destroy(); reject(new Error('SSE timeout')); }, 10000);
+    req.on('close', () => clearTimeout(timer));
+    req.write(postData);
+    req.end();
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('GET /v1/models', () => {
+  it('returns models in OpenAI list format', async () => {
+    const { statusCode, body } = await httpRequest('GET', `${baseUrl}/v1/models`);
+    expect(statusCode).toBe(200);
+    expect(body.object).toBe('list');
+    expect(body.data).toHaveLength(2);
+  });
+
+  it('each model has id, object, owned_by', async () => {
+    const { body } = await httpRequest('GET', `${baseUrl}/v1/models`);
+    for (const model of body.data) {
+      expect(model).toHaveProperty('id');
+      expect(model.object).toBe('model');
+      expect(model).toHaveProperty('owned_by');
+      expect(typeof model.created).toBe('number');
+    }
+  });
+
+  it('maps owned_by from engine', async () => {
+    const { body } = await httpRequest('GET', `${baseUrl}/v1/models`);
+    const openai = body.data.find((m: any) => m.id === 'openai/gpt-4o');
+    const anthropic = body.data.find((m: any) => m.id === 'anthropic/claude-3');
+    expect(openai.owned_by).toBe('openai');
+    expect(anthropic.owned_by).toBe('anthropic');
+  });
+});
+
+describe('POST /v1/chat/completions (streaming)', () => {
+  it('streams text chunks in OpenAI format', async () => {
+    const { events, statusCode, headers } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    expect(statusCode).toBe(200);
+    expect(headers['content-type']).toBe('text/event-stream');
+
+    const chunks = events.filter(e => e.choices);
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+
+    expect(chunks[0].object).toBe('chat.completion.chunk');
+    expect(chunks[0].model).toBe('openai/gpt-4o');
+  });
+
+  it('first chunk includes role: assistant', async () => {
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    const firstChunk = events.find(e => e.choices?.[0]?.delta?.content);
+    expect(firstChunk.choices[0].delta.role).toBe('assistant');
+  });
+
+  it('intermediate chunks have content but no role', async () => {
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    const contentChunks = events.filter(e => e.choices?.[0]?.delta?.content);
+    expect(contentChunks).toHaveLength(2);
+    expect(contentChunks[0].choices[0].delta.content).toBe('Hello');
+    expect(contentChunks[1].choices[0].delta.content).toBe(' world');
+    expect(contentChunks[1].choices[0].delta.role).toBeUndefined();
+  });
+
+  it('last content chunk has finish_reason: stop', async () => {
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    const doneChunk = events.find(e => e.choices?.[0]?.finish_reason === 'stop');
+    expect(doneChunk).toBeDefined();
+    expect(doneChunk.choices[0].delta).toEqual({});
+  });
+
+  it('stream ends with data: [DONE]', async () => {
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    const doneSignals = events.filter(e => e._done);
+    expect(doneSignals).toHaveLength(1);
+  });
+
+  it('each chunk has consistent id and model', async () => {
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    const chunks = events.filter(e => e.id);
+    const ids = new Set(chunks.map(c => c.id));
+    expect(ids.size).toBe(1);
+    for (const c of chunks) {
+      expect(c.model).toBe('openai/gpt-4o');
+      expect(c.id).toMatch(/^chatcmpl-/);
+    }
+  });
+});
+
+describe('POST /v1/chat/completions (non-streaming)', () => {
+  it('returns complete response as JSON', async () => {
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(statusCode).toBe(200);
+    expect(body.object).toBe('chat.completion');
+    expect(body.model).toBe('openai/gpt-4o');
+    expect(body.id).toMatch(/^chatcmpl-/);
+  });
+
+  it('concatenates all text chunks into message content', async () => {
+    const { body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(body.choices).toHaveLength(1);
+    expect(body.choices[0].message.role).toBe('assistant');
+    expect(body.choices[0].message.content).toBe('Hello world');
+    expect(body.choices[0].finish_reason).toBe('stop');
+  });
+
+  it('includes usage field (zeros for now)', async () => {
+    const { body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(body.usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+
+  it('stream: false behaves same as omitting stream', async () => {
+    const { body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: false,
+    });
+
+    expect(body.object).toBe('chat.completion');
+    expect(body.choices[0].message.content).toBe('Hello world');
+  });
+});
+
+describe('POST /v1/chat/completions — error cases', () => {
+  it('returns 400 for missing model', async () => {
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(statusCode).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+    expect(body.error.message).toContain('model');
+  });
+
+  it('returns 400 for missing messages', async () => {
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+    });
+
+    expect(statusCode).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+    expect(body.error.message).toContain('messages');
+  });
+
+  it('returns 400 for empty messages array', async () => {
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [],
+    });
+
+    expect(statusCode).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+  });
+
+  it('returns error in OpenAI format for chat exceptions (non-streaming)', async () => {
+    mockChatConfig = { chunks: [], chunkDelayMs: 0, throwError: 'Provider unavailable' };
+
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'bad/model',
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(statusCode).toBe(500);
+    expect(body.error.type).toBe('server_error');
+    expect(body.error.message).toBe('Provider unavailable');
+  });
+
+  it('returns error in SSE for chat exceptions (streaming)', async () => {
+    mockChatConfig = { chunks: [], chunkDelayMs: 0, throwError: 'Provider unavailable' };
+
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'bad/model',
+      messages: [{ role: 'user', content: 'Hi' }],
+      stream: true,
+    });
+
+    const errorEvent = events.find(e => e.error);
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent.error.message).toBe('Provider unavailable');
+  });
+});
+
+describe('POST /v1/chat/completions — tool calls', () => {
+  it('streams tool calls in OpenAI tool_calls format', async () => {
+    mockChatConfig = {
+      chunks: [
+        { type: 'tool', name: 'search', state: 'running', call: { params: { q: 'test' }, result: undefined }, done: false },
+        { type: 'tool', name: 'search', state: 'completed', call: { params: { q: 'test' }, result: 'found' }, done: true },
+        { type: 'done', finishReason: 'tool-calls' },
+      ],
+      chunkDelayMs: 0,
+    };
+
+    const { events } = await postSSE(`${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Search for test' }],
+      stream: true,
+    });
+
+    const toolChunks = events.filter(e => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunks).toHaveLength(1);
+    expect(toolChunks[0].choices[0].delta.tool_calls[0].function.name).toBe('search');
+    expect(toolChunks[0].choices[0].delta.tool_calls[0].function.arguments).toBe('{"q":"test"}');
+
+    const doneChunk = events.find(e => e.choices?.[0]?.finish_reason === 'tool_calls');
+    expect(doneChunk).toBeDefined();
+  });
+});
+
+describe('POST /v1/chat/completions — request params', () => {
+  it('accepts temperature, top_p, max_tokens without error', async () => {
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      temperature: 0.5,
+      top_p: 0.9,
+      max_tokens: 100,
+    });
+
+    expect(statusCode).toBe(200);
+    expect(body.choices[0].message.content).toBe('Hello world');
+  });
+
+  it('accepts max_completion_tokens as alias for max_tokens', async () => {
+    const { statusCode } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      max_completion_tokens: 200,
+    });
+
+    expect(statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

- Add OpenAI-compatible `/v1/models` and `/v1/chat/completions` endpoints to the existing Express server, making Abbenay a drop-in replacement for any OpenAI-compatible client (Cursor, Continue, aider, `openai` SDK scripts, etc.)
- New `aby serve` CLI command for API-first usage (thin wrapper over `aby web` with OpenAI-compat framing)
- Comprehensive test coverage: 20 unit tests for format mapping functions + 24 integration tests for HTTP endpoints

## Commits

- `feat(web): add OpenAI-compatible API (/v1/models, /v1/chat/completions)` — new `openai-compat.ts` with route registration and format translation helpers (streaming SSE + non-streaming JSON), wired into `server.ts`; `aby serve` command added to CLI; unit and integration tests
- `docs: add DR-020, update ROADMAP/ARCHITECTURE/TESTING for OpenAI API` — DR-020 decision record, ROADMAP section 3 marked M1 done, ARCHITECTURE and TESTING updated with new files
- `fix(web): address Copilot review feedback on OpenAI-compat API` — disable tools in OpenAI transport (no approval UI = bypass DR-019), add `tool_calls` to message mapping, remove unplumbed `--host` option, add port validation

## Key files

| File | Purpose |
|---|---|
| `packages/daemon/src/daemon/web/openai-compat.ts` | Route registration + format mapping helpers |
| `packages/daemon/src/daemon/web/server.ts` | Wires `registerOpenAIRoutes()` after existing `/api/*` |
| `packages/daemon/src/daemon/index.ts` | New `aby serve` CLI command |
| `packages/daemon/src/daemon/web/openai-compat.test.ts` | 20 unit tests (format functions) |
| `packages/daemon/tests/integration/openai-compat.test.ts` | 24 integration tests (HTTP) |

## Out of scope (deferred to M2)

- Bearer token auth (`config.yaml → server.api_key`)
- Real usage/token stats (zeros for now)
- Tool execution via OpenAI API (requires approval UI wiring)
- `POST /v1/completions` (legacy), `POST /v1/embeddings`

## Test plan

- [x] `npm run lint` passes locally (0 errors, 0 warnings)
- [x] `npm test` passes locally (233/233 daemon tests pass)
- [x] `npm run build -w packages/daemon` (tsc) passes locally
- [x] 20 new unit tests for format mapping functions
- [x] 24 new integration tests (GET /v1/models, streaming completions, non-streaming completions, error cases, tool calls, request params)
- [x] Docs updated: DR-020, ROADMAP, ARCHITECTURE, TESTING