### PR TITLE
fix(session): persist tool call data in session history

### DIFF
--- a/packages/daemon/src/core/session-store.test.ts
+++ b/packages/daemon/src/core/session-store.test.ts
@@ -87,8 +87,12 @@ describe('SessionStore.get', () => {
     expect(session.messages).toEqual([]);
   });
 
-  it('throws for unknown ID', async () => {
-    await expect(store.get('nonexistent-id')).rejects.toThrow('Session not found');
+  it('throws for invalid ID', async () => {
+    await expect(store.get('nonexistent-id')).rejects.toThrow('Invalid session ID');
+  });
+
+  it('throws for unknown UUID', async () => {
+    await expect(store.get('00000000-0000-0000-0000-000000000000')).rejects.toThrow('Session not found');
   });
 });
 
@@ -151,8 +155,12 @@ describe('SessionStore.delete', () => {
     expect(result.sessions).toHaveLength(0);
   });
 
-  it('throws for unknown ID', async () => {
-    await expect(store.delete('nonexistent-id')).rejects.toThrow('Session not found');
+  it('throws for invalid ID', async () => {
+    await expect(store.delete('nonexistent-id')).rejects.toThrow('Invalid session ID');
+  });
+
+  it('throws for unknown UUID', async () => {
+    await expect(store.delete('00000000-0000-0000-0000-000000000000')).rejects.toThrow('Session not found');
   });
 });
 

--- a/packages/daemon/src/core/session-store.ts
+++ b/packages/daemon/src/core/session-store.ts
@@ -187,7 +187,16 @@ export class SessionStore {
 
   // ── Private helpers ───────────────────────────────────────────────────
 
+  private static readonly VALID_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  private validateId(id: string): void {
+    if (!SessionStore.VALID_ID.test(id)) {
+      throw new Error(`Invalid session ID: ${id}`);
+    }
+  }
+
   private sessionPath(id: string): string {
+    this.validateId(id);
     return path.join(this.sessionsDir, `${id}.json`);
   }
 
@@ -196,13 +205,13 @@ export class SessionStore {
   }
 
   private async ensureDir(): Promise<void> {
-    await fs.promises.mkdir(this.sessionsDir, { recursive: true });
+    await fs.promises.mkdir(this.sessionsDir, { recursive: true, mode: 0o700 });
   }
 
   private async writeSession(session: Session): Promise<void> {
     const filePath = this.sessionPath(session.id);
     const tmpPath = `${filePath}.tmp`;
-    await fs.promises.writeFile(tmpPath, JSON.stringify(session, null, 2));
+    await fs.promises.writeFile(tmpPath, JSON.stringify(session, null, 2), { mode: 0o600 });
     await fs.promises.rename(tmpPath, filePath);
   }
 
@@ -221,7 +230,7 @@ export class SessionStore {
   private async writeIndex(index: IndexFile): Promise<void> {
     await this.ensureDir();
     const tmpPath = `${this.indexPath()}.tmp`;
-    await fs.promises.writeFile(tmpPath, JSON.stringify(index, null, 2));
+    await fs.promises.writeFile(tmpPath, JSON.stringify(index, null, 2), { mode: 0o600 });
     await fs.promises.rename(tmpPath, this.indexPath());
   }
 

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -86,11 +86,15 @@ export async function runInteractiveChat(options: ChatOptions): Promise<void> {
 
   const messages: Array<{ role: string; content: string }> = [];
 
-  // Load existing session messages
+  // Load existing session messages (including tool call data)
   if (sessionId && options.session !== 'new') {
     const session = await store.get(sessionId, true);
     for (const msg of session.messages) {
-      messages.push({ role: msg.role, content: msg.content });
+      const loaded: Record<string, unknown> = { role: msg.role, content: msg.content };
+      if (msg.tool_calls) loaded.tool_calls = msg.tool_calls;
+      if (msg.tool_call_id) loaded.tool_call_id = msg.tool_call_id;
+      if (msg.name) loaded.name = msg.name;
+      messages.push(loaded as { role: string; content: string });
     }
     if (messages.length > 0) {
       console.error(`${DIM}Loaded ${messages.length} message(s) from session${RESET}`);
@@ -180,6 +184,23 @@ async function runInteractiveMode(
               ? chunk.call.result.substring(0, 200)
               : JSON.stringify(chunk.call?.result || {}).substring(0, 200);
             process.stderr.write(`${GREEN}✓${RESET} ${DIM}${result}${RESET}\n`);
+
+            if (chunk.call && sessionId && store) {
+              const callId = `call_${chunk.name}_${Date.now()}`;
+              const toolCallMsg = {
+                role: 'assistant',
+                content: '',
+                tool_calls: [{ id: callId, type: 'function', function: { name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' } }],
+              };
+              const toolResultMsg = {
+                role: 'tool',
+                content: typeof chunk.call.result === 'string' ? chunk.call.result : JSON.stringify(chunk.call.result || {}),
+                tool_call_id: callId,
+              };
+              messages.push(toolCallMsg, toolResultMsg);
+              await store.appendMessage(sessionId, toolCallMsg);
+              await store.appendMessage(sessionId, toolResultMsg);
+            }
           }
         } else if (chunk.type === 'error') {
           process.stderr.write(`\n${RED}Error: ${chunk.error}${RESET}\n`);

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -190,10 +190,11 @@ async function runInteractiveMode(
               const toolCallMsg = {
                 role: 'assistant',
                 content: '',
-                tool_calls: [{ id: callId, type: 'function', function: { name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' } }],
+                tool_calls: [{ id: callId, name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' }],
               };
               const toolResultMsg = {
                 role: 'tool',
+                name: chunk.name,
                 content: typeof chunk.call.result === 'string' ? chunk.call.result : JSON.stringify(chunk.call.result || {}),
                 tool_call_id: callId,
               };

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -200,16 +200,16 @@ function toClientType(protoType: string | number): ClientType {
 function toRole(protoRole: string | number): string {
   switch (protoRole) {
     case 'ROLE_SYSTEM':
-    case 0:
+    case 1:
       return 'system';
     case 'ROLE_USER':
-    case 1:
+    case 2:
       return 'user';
     case 'ROLE_ASSISTANT':
-    case 2:
+    case 3:
       return 'assistant';
     case 'ROLE_TOOL':
-    case 3:
+    case 4:
       return 'tool';
     default:
       return 'user';
@@ -944,7 +944,6 @@ export function createAbbenayService(state: DaemonState) {
           const toolOptions: ChatToolOptions = { toolMode, maxToolIterations };
 
           let fullText = '';
-          const pendingToolCalls: Array<{ id: string; name: string; arguments: string }> = [];
 
           for await (const chunk of state.chat(session.model, allMessages, hasParams ? requestParams : undefined, toolOptions)) {
             if (chunk.type === 'text' && chunk.text) {
@@ -953,20 +952,15 @@ export function createAbbenayService(state: DaemonState) {
             } else if (chunk.type === 'tool') {
               if (chunk.done && chunk.call) {
                 const callId = `call_${chunk.name}_${Date.now()}`;
-                pendingToolCalls.push({
-                  id: callId,
-                  name: chunk.name || '',
-                  arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}',
-                });
 
-                // Persist assistant tool_calls message + tool result
                 await state.sessionStore.appendMessage(sessionId, {
                   role: 'assistant',
                   content: '',
-                  tool_calls: [{ id: callId, type: 'function', function: { name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' } }],
+                  tool_calls: [{ id: callId, name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' }],
                 });
                 await state.sessionStore.appendMessage(sessionId, {
                   role: 'tool',
+                  name: chunk.name,
                   content: typeof chunk.call.result === 'string' ? chunk.call.result : JSON.stringify(chunk.call.result || {}),
                   tool_call_id: callId,
                 });
@@ -1071,11 +1065,14 @@ function sessionToProto(session: import('../../core/session-store.js').Session) 
     model: session.model,
     topic: session.title,
     messages: session.messages.map((m) => ({
-      role: m.role === 'system' ? 0 : m.role === 'user' ? 1 : m.role === 'assistant' ? 2 : m.role === 'tool' ? 3 : 1,
+      role: m.role === 'system' ? 1 : m.role === 'user' ? 2 : m.role === 'assistant' ? 3 : m.role === 'tool' ? 4 : 2,
       content: m.content,
       name: m.name,
       tool_call_id: m.tool_call_id,
-      tool_calls: m.tool_calls,
+      tool_calls: m.tool_calls?.map((tc: unknown) => {
+        const item = tc as Record<string, unknown>;
+        return { id: item.id, name: item.name, arguments: item.arguments };
+      }),
     })),
     metadata: session.metadata,
     created_at: toTimestamp(session.createdAt),

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -944,10 +944,33 @@ export function createAbbenayService(state: DaemonState) {
           const toolOptions: ChatToolOptions = { toolMode, maxToolIterations };
 
           let fullText = '';
+          const pendingToolCalls: Array<{ id: string; name: string; arguments: string }> = [];
+
           for await (const chunk of state.chat(session.model, allMessages, hasParams ? requestParams : undefined, toolOptions)) {
             if (chunk.type === 'text' && chunk.text) {
               fullText += chunk.text;
               call.write({ text: { text: chunk.text } });
+            } else if (chunk.type === 'tool') {
+              if (chunk.done && chunk.call) {
+                const callId = `call_${chunk.name}_${Date.now()}`;
+                pendingToolCalls.push({
+                  id: callId,
+                  name: chunk.name || '',
+                  arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}',
+                });
+
+                // Persist assistant tool_calls message + tool result
+                await state.sessionStore.appendMessage(sessionId, {
+                  role: 'assistant',
+                  content: '',
+                  tool_calls: [{ id: callId, type: 'function', function: { name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' } }],
+                });
+                await state.sessionStore.appendMessage(sessionId, {
+                  role: 'tool',
+                  content: typeof chunk.call.result === 'string' ? chunk.call.result : JSON.stringify(chunk.call.result || {}),
+                  tool_call_id: callId,
+                });
+              }
             } else if (chunk.type === 'error') {
               call.write({ error: { code: 'INTERNAL', message: chunk.error } });
             } else if (chunk.type === 'done') {

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -948,7 +948,7 @@ export function createWebApp(state: DaemonState): Express {
       res.json(session);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('not found')) {
+      if (msg.includes('not found') || msg.includes('Invalid session ID')) {
         res.status(404).json({ error: msg });
       } else {
         console.error('[Web] GET /api/sessions/:id error:', msg);
@@ -963,7 +963,7 @@ export function createWebApp(state: DaemonState): Express {
       res.json({ success: true });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('not found')) {
+      if (msg.includes('not found') || msg.includes('Invalid session ID')) {
         res.status(404).json({ error: msg });
       } else {
         console.error('[Web] DELETE /api/sessions/:id error:', msg);
@@ -985,6 +985,20 @@ export function createWebApp(state: DaemonState): Express {
       role: (message.role as string) || 'user',
       content: message.content as string,
     };
+
+    let session;
+    try {
+      session = await state.sessionStore.get(sessionId, true);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('not found') || msg.includes('Invalid session ID')) {
+        res.status(404).json({ error: msg });
+      } else {
+        console.error('[Web] POST /api/sessions/:id/chat error:', msg);
+        res.status(500).json({ error: msg });
+      }
+      return;
+    }
 
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
@@ -1009,7 +1023,6 @@ export function createWebApp(state: DaemonState): Express {
 
     (async () => {
       try {
-        const session = await state.sessionStore.get(sessionId, true);
         await state.sessionStore.appendMessage(sessionId, chatMessage);
 
         const allMessages = [...session.messages, chatMessage];
@@ -1033,10 +1046,11 @@ export function createWebApp(state: DaemonState): Express {
               await state.sessionStore.appendMessage(sessionId, {
                 role: 'assistant',
                 content: '',
-                tool_calls: [{ id: callId, type: 'function', function: { name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' } }],
+                tool_calls: [{ id: callId, name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' }],
               });
               await state.sessionStore.appendMessage(sessionId, {
                 role: 'tool',
+                name: chunk.name,
                 content: typeof chunk.call.result === 'string' ? chunk.call.result : JSON.stringify(chunk.call.result || {}),
                 tool_call_id: callId,
               });

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -1021,6 +1021,26 @@ export function createWebApp(state: DaemonState): Express {
           if (chunk.type === 'text' && chunk.text) {
             fullText += chunk.text;
             safeWrite(`data: ${JSON.stringify({ type: 'text', content: chunk.text })}\n\n`);
+          } else if (chunk.type === 'tool') {
+            const toolData: Record<string, unknown> = { type: 'tool', name: chunk.name, state: chunk.state, done: chunk.done };
+            if (chunk.call) {
+              toolData.call = { params: chunk.call.params, result: chunk.call.result };
+            }
+            safeWrite(`data: ${JSON.stringify(toolData)}\n\n`);
+
+            if (chunk.done && chunk.call) {
+              const callId = `call_${chunk.name}_${Date.now()}`;
+              await state.sessionStore.appendMessage(sessionId, {
+                role: 'assistant',
+                content: '',
+                tool_calls: [{ id: callId, type: 'function', function: { name: chunk.name, arguments: chunk.call.params ? JSON.stringify(chunk.call.params) : '{}' } }],
+              });
+              await state.sessionStore.appendMessage(sessionId, {
+                role: 'tool',
+                content: typeof chunk.call.result === 'string' ? chunk.call.result : JSON.stringify(chunk.call.result || {}),
+                tool_call_id: callId,
+              });
+            }
           } else if (chunk.type === 'error') {
             safeWrite(`data: ${JSON.stringify({ type: 'error', error: chunk.error })}\n\n`);
           } else if (chunk.type === 'done') {

--- a/packages/daemon/tests/integration/sessions.test.ts
+++ b/packages/daemon/tests/integration/sessions.test.ts
@@ -370,9 +370,11 @@ describe('Session chat SSE endpoint', () => {
 
     expect(session.messages[1].role).toBe('assistant');
     expect(session.messages[1].tool_calls).toBeDefined();
-    expect(session.messages[1].tool_calls[0].function.name).toBe('readFile');
+    expect(session.messages[1].tool_calls[0].name).toBe('readFile');
+    expect(session.messages[1].tool_calls[0].arguments).toBe('{"path":"/tmp/test.txt"}');
 
     expect(session.messages[2].role).toBe('tool');
+    expect(session.messages[2].name).toBe('readFile');
     expect(session.messages[2].tool_call_id).toBeTruthy();
     expect(session.messages[2].content).toBe('file contents here');
 

--- a/packages/daemon/tests/integration/sessions.test.ts
+++ b/packages/daemon/tests/integration/sessions.test.ts
@@ -19,7 +19,16 @@ import { SessionStore } from '../../src/core/session-store.js';
 
 // ─── Mock DaemonState ───────────────────────────────────────────────────
 
-let mockChatChunks: string[] = ['Hello', ' world'];
+type MockChunk =
+  | { type: 'text'; text: string }
+  | { type: 'tool'; name: string; state: string; call?: { params: unknown; result: unknown }; done: boolean }
+  | { type: 'done'; finishReason: string };
+
+let mockChatResponse: MockChunk[] = [
+  { type: 'text', text: 'Hello' },
+  { type: 'text', text: ' world' },
+  { type: 'done', finishReason: 'stop' },
+];
 
 const mockSecretStore: SecretStore = {
   async get() { return null; },
@@ -50,10 +59,9 @@ function createMockState(): DaemonState {
     },
 
     async* chat(_model: string, _messages: Array<{ role: string; content: string }>) {
-      for (const text of mockChatChunks) {
-        yield { type: 'text' as const, text };
+      for (const chunk of mockChatResponse) {
+        yield chunk;
       }
-      yield { type: 'done' as const, finishReason: 'stop' };
     },
   } as any as DaemonState;
 }
@@ -88,7 +96,11 @@ afterAll(async () => {
 });
 
 afterEach(() => {
-  mockChatChunks = ['Hello', ' world'];
+  mockChatResponse = [
+    { type: 'text', text: 'Hello' },
+    { type: 'text', text: ' world' },
+    { type: 'done', finishReason: 'stop' },
+  ];
 });
 
 // ─── HTTP Helpers ───────────────────────────────────────────────────────
@@ -288,7 +300,11 @@ describe('Session chat SSE endpoint', () => {
     const created = await httpRequest('POST', `${baseUrl}/api/sessions`, { model: 'test/model' });
     const id = created.body.id;
 
-    mockChatChunks = ['Session', ' response'];
+    mockChatResponse = [
+      { type: 'text', text: 'Session' },
+      { type: 'text', text: ' response' },
+      { type: 'done', finishReason: 'stop' },
+    ];
 
     const { events, statusCode } = await postSSE(`${baseUrl}/api/sessions/${id}/chat`, {
       message: { role: 'user', content: 'Hello session' },
@@ -320,6 +336,48 @@ describe('Session chat SSE endpoint', () => {
     const { statusCode, body } = await httpRequest('POST', `${baseUrl}/api/sessions/${id}/chat`, {});
     expect(statusCode).toBe(400);
     expect(body.error).toContain('message');
+  });
+
+  it('POST /api/sessions/:id/chat persists tool calls and results', async () => {
+    const created = await httpRequest('POST', `${baseUrl}/api/sessions`, { model: 'test/model' });
+    const id = created.body.id;
+
+    mockChatResponse = [
+      { type: 'tool', name: 'readFile', state: 'running', done: false },
+      { type: 'tool', name: 'readFile', state: 'completed', call: { params: { path: '/tmp/test.txt' }, result: 'file contents here' }, done: true },
+      { type: 'text', text: 'I read the file for you.' },
+      { type: 'done', finishReason: 'stop' },
+    ];
+
+    const { events, statusCode } = await postSSE(`${baseUrl}/api/sessions/${id}/chat`, {
+      message: { role: 'user', content: 'Read /tmp/test.txt' },
+    });
+
+    expect(statusCode).toBe(200);
+
+    // Should have tool events in the SSE stream
+    const toolEvents = events.filter((e) => e.type === 'tool');
+    expect(toolEvents.length).toBeGreaterThanOrEqual(1);
+
+    // Verify persisted messages include tool call data
+    const { body: session } = await httpRequest('GET', `${baseUrl}/api/sessions/${id}`);
+
+    // Expected: user msg, assistant tool_calls msg, tool result msg, assistant text msg
+    expect(session.messages).toHaveLength(4);
+
+    expect(session.messages[0].role).toBe('user');
+    expect(session.messages[0].content).toBe('Read /tmp/test.txt');
+
+    expect(session.messages[1].role).toBe('assistant');
+    expect(session.messages[1].tool_calls).toBeDefined();
+    expect(session.messages[1].tool_calls[0].function.name).toBe('readFile');
+
+    expect(session.messages[2].role).toBe('tool');
+    expect(session.messages[2].tool_call_id).toBeTruthy();
+    expect(session.messages[2].content).toBe('file contents here');
+
+    expect(session.messages[3].role).toBe('assistant');
+    expect(session.messages[3].content).toBe('I read the file for you.');
   });
 
   it('POST /api/sessions/:id/chat auto-titles on first turn', async () => {

--- a/proto/abbenay/v1/service.proto
+++ b/proto/abbenay/v1/service.proto
@@ -558,7 +558,7 @@ message ListSessionsRequest {
   int32 limit = 1;                      // Max sessions to return
   int32 offset = 2;                     // For pagination
   optional string source_filter = 3;   // Filter by client type
-  optional string model_filter = 4;    // Filter by model prefix
+  optional string model_filter = 4;    // Filter by exact model name
 }
 
 message ListSessionsResponse {


### PR DESCRIPTION
## Summary

- All three session chat transports (gRPC, web API, CLI) now persist assistant `tool_calls` messages and tool result messages to the session store, fixing a gap where tool interaction context was lost on session resume.
- Session loading in the CLI now restores `tool_calls`, `tool_call_id`, and `name` fields so the LLM has complete conversation history.
- Integration test added verifying tool call persistence through the web API SSE endpoint.

## Commits

- `fix(session): persist tool call data in session history` — persist both assistant tool_calls and tool result messages across all three transports
- `fix(session): address Copilot review on tool persistence PR` — UUID validation to prevent path traversal, restrictive file permissions (0o600/0o700), validate session before SSE headers, remove dead code, fix proto Role enum mapping, normalize tool_calls to flat shape, update model_filter proto docs

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npx tsc --noEmit` passes
- [x] `npm test -w packages/daemon` — all 266 tests pass (13 suites)
- [x] New integration test verifies tool call + result messages are persisted and retrievable
- [x] New unit tests for path traversal validation (invalid ID, unknown UUID)
- [x] Rebased on upstream/main (includes PR #14 merge with write lock, pagination validation, etc.)