### PR TITLE
feat(session): add periodic LLM-generated session summaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,7 @@ Reusable library with zero transport dependencies. Can be used standalone by age
 | `core/policies.ts` | Policy system — built-in + custom policies, resolution, flattening |
 | `core/tool-registry.ts` | Tool collection, namespacing, policy filtering, executor builder |
 | `core/session-store.ts` | File-based session persistence (CRUD, index, messages) |
+| `core/session-summarizer.ts` | Periodic LLM-generated session summaries (DR-022) |
 | `core/index.ts` | Public API surface |
 
 ### @abbenay/daemon (`src/daemon/`)
@@ -392,12 +393,18 @@ The `SessionStore` class (core layer) handles CRUD operations and maintains an
 `index.json` for fast listing without reading every session file.
 
 **Available transports:**
-- gRPC: `CreateSession`, `GetSession`, `ListSessions`, `DeleteSession`, `SessionChat`
-- Web API: `POST/GET/DELETE /api/sessions`, `POST /api/sessions/:id/chat` (SSE)
+- gRPC: `CreateSession`, `GetSession`, `ListSessions`, `DeleteSession`, `SessionChat`, `SummarizeSession`
+- Web API: `POST/GET/DELETE /api/sessions`, `POST /api/sessions/:id/chat` (SSE), `GET /api/sessions/:id/summary`
 - CLI: `aby sessions list/show/delete`, `aby chat --session <id|new>`
 
+**Periodic summaries:** Every 10 user messages, a background LLM call generates
+a 2-3 sentence summary stored on the session (see DR-022). Summaries are also
+available on demand via `SummarizeSession` (gRPC) or `GET /api/sessions/:id/summary`.
+
 **Not yet implemented:** `ForkSession`, `ExportSession`, `ImportSession`,
-`ReplaySession`, `SummarizeSession`, web dashboard session sidebar.
+`ReplaySession`, web dashboard session sidebar, context window compression
+using summaries (`context.context_threshold` / `compression_strategy`),
+internal MCP tool for cross-session retrieval.
 
 ## Data Flow
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -184,7 +184,7 @@ companion `index.json` for fast listing. See DR-021.
 |---|---|
 | `ForkSession` gRPC + web API | medium |
 | `ExportSession` / `ImportSession` | medium |
-| `ReplaySession` / `SummarizeSession` | low |
+| `ReplaySession` / ~~`SummarizeSession`~~ | low (SummarizeSession done) |
 | Web dashboard session sidebar UI | medium |
 | VS Code session picker | low |
 | SQLite storage backend (large session counts) | low |
@@ -198,7 +198,7 @@ companion `index.json` for fast listing. See DR-021.
 - **M2**: Web dashboard session sidebar
 - **M3**: CLI session commands — **done**
 - **M4**: `ForkSession`, `ExportSession`, `ImportSession`
-- **M5**: `ReplaySession`, `SummarizeSession`
+- **M5**: `ReplaySession`, ~~`SummarizeSession`~~ (done)
 
 ---
 
@@ -249,7 +249,7 @@ Several gRPC RPCs in `abbenay-service.ts` are unimplemented stubs.
 | `ListSessions` | done | section 5 |
 | `DeleteSession` | done | section 5 |
 | `ReplaySession` | stub | section 5 |
-| `SummarizeSession` | stub | section 5 |
+| `SummarizeSession` | **done** | section 5 |
 | `ForkSession` | stub | section 5 |
 | `ExportSession` | stub | section 5 |
 | `ImportSession` | stub | section 5 |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,7 +17,8 @@ packages/daemon/
 │   │   ├── config.test.ts            <- Unit test (co-located)
 │   │   ├── tool-registry.test.ts     <- Unit test (glob matching, registry)
 │   │   ├── tool-approval.test.ts     <- Unit test (3-tier approval logic)
-│   │   └── session-store.test.ts     <- Unit test (session CRUD, index)
+│   │   ├── session-store.test.ts     <- Unit test (session CRUD, index)
+│   │   └── session-summarizer.test.ts <- Unit test (periodic summary logic)
 │   ├── daemon/
 │   │   ├── chat-prompt.test.ts       <- Unit test (parseApprovalInput)
 │   │   └── web/
@@ -70,7 +71,8 @@ Pure unit tests with no I/O, no network, no processes.
 | `src/state.test.ts` | DaemonState: provider listing, model listing, chat flow |
 | `src/daemon/chat-prompt.test.ts` | `parseApprovalInput` case-sensitive routing |
 | `src/daemon/web/openai-compat.test.ts` | OpenAI format mapping: models, finish reasons, stream chunks, complete responses |
-| `src/core/session-store.test.ts` | SessionStore: CRUD, appendMessage, updateTitle, index consistency |
+| `src/core/session-store.test.ts` | SessionStore: CRUD, appendMessage, updateTitle, updateSummary, index consistency |
+| `src/core/session-summarizer.test.ts` | generateSessionSummary, maybeSummarize interval logic, error handling |
 
 ### Layer 2: Integration Tests
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -260,3 +260,26 @@ routes is purely additive and doesn't affect existing `/api/` behavior. Abbenay
 composite model IDs (e.g., `openai/gpt-4o`) serve as the `model` field in
 OpenAI requests. A new `aby serve` CLI command highlights the OpenAI-compat
 angle while reusing the same `startEmbeddedWebServer()` lifecycle.
+
+## DR-022: Periodic session summarization every 10 user turns
+
+**Date:** 2026-03-12  
+**Decision:** Generate an LLM session summary every 10 user messages via a
+fire-and-forget background call, stored on the session as `summary` and
+`summaryMessageCount`.  
+**Rationale:** Sessions have no explicit close event (CLI gets EOF, web SSE
+drops, gRPC streams end — none reliably signal "done"). Periodic summarization
+ensures summaries stay reasonably current without requiring user action. The
+10-message interval balances freshness against token cost. The `maybeSummarize`
+helper is shared across all three transports and catches errors silently to
+avoid disrupting the user's chat flow. On-demand summarization is also available
+via the `SummarizeSession` gRPC RPC and `GET /api/sessions/:id/summary`.  
+**Future work:**
+- **Context window management:** The current summary is informational only.
+  It is not yet used to compress conversation history when approaching the
+  model's context window limit (see `context.context_threshold` /
+  `context.compression_strategy` in the roadmap policy table).
+- **Session retrieval tool:** No internal MCP/tool is registered that would
+  let the LLM query or search past sessions. Adding a `session_lookup` tool
+  would allow cross-session knowledge reuse (e.g., "what did we decide last
+  time about X?").

--- a/packages/daemon/src/core/session-store.ts
+++ b/packages/daemon/src/core/session-store.ts
@@ -24,6 +24,9 @@ export interface Session {
   metadata: Record<string, string>;
   parentSessionId?: string;
   forkPoint?: number;
+  summary?: string;
+  /** User-message count at which the summary was last generated. */
+  summaryMessageCount?: number;
 }
 
 export interface SessionSummary {
@@ -33,6 +36,7 @@ export interface SessionSummary {
   messageCount: number;
   createdAt: string;
   updatedAt: string;
+  summary?: string;
 }
 
 export interface SessionListOptions {
@@ -183,6 +187,16 @@ export class SessionStore {
       await this.writeSession(session);
       await this.updateIndex(id, { title, updatedAt: session.updatedAt });
     });
+  }
+
+  async updateSummary(id: string, summary: string, messageCount: number): Promise<void> {
+    const session = await this.get(id, true);
+    session.summary = summary;
+    session.summaryMessageCount = messageCount;
+    session.updatedAt = new Date().toISOString();
+
+    await this.writeSession(session);
+    await this.updateIndex(id, { summary, updatedAt: session.updatedAt });
   }
 
   // ── Private helpers ───────────────────────────────────────────────────

--- a/packages/daemon/src/core/session-summarizer.test.ts
+++ b/packages/daemon/src/core/session-summarizer.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Session summarizer unit tests
+ *
+ * Tests generateSessionSummary and maybeSummarize with a mock CoreState
+ * and real SessionStore backed by a temp directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SessionStore } from './session-store.js';
+import { generateSessionSummary, maybeSummarize } from './session-summarizer.js';
+import type { CoreState } from './state.js';
+
+let tmpDir: string;
+let store: SessionStore;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-summarizer-test-'));
+  store = new SessionStore(tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createMockState(responseText: string): CoreState {
+  return {
+    async* chat(_model: string, _messages: Array<{ role: string; content: string }>) {
+      yield { type: 'text' as const, text: responseText };
+      yield { type: 'done' as const, finishReason: 'stop' };
+    },
+  } as unknown as CoreState;
+}
+
+function createErrorState(): CoreState {
+  return {
+    async *chat() {
+      yield { type: 'error' as const, error: 'forced' };
+      throw new Error('LLM unavailable');
+    },
+  } as unknown as CoreState;
+}
+
+describe('generateSessionSummary', () => {
+  it('returns LLM-generated text from session messages', async () => {
+    const session = await store.create('test/model', 'Test');
+    await store.appendMessage(session.id, { role: 'user', content: 'Hello' });
+    await store.appendMessage(session.id, { role: 'assistant', content: 'Hi there!' });
+
+    const updated = await store.get(session.id, true);
+    const state = createMockState('A greeting exchange.');
+
+    const summary = await generateSessionSummary(state, updated);
+    expect(summary).toBe('A greeting exchange.');
+  });
+
+  it('uses override model when provided', async () => {
+    const session = await store.create('test/model', 'Test');
+    await store.appendMessage(session.id, { role: 'user', content: 'Hello' });
+
+    const updated = await store.get(session.id, true);
+    let capturedModel = '';
+    const state = {
+      async* chat(model: string) {
+        capturedModel = model;
+        yield { type: 'text' as const, text: 'summary' };
+        yield { type: 'done' as const, finishReason: 'stop' };
+      },
+    } as unknown as CoreState;
+
+    await generateSessionSummary(state, updated, 'override/model');
+    expect(capturedModel).toBe('override/model');
+  });
+
+  it('includes existing summary in prompt for incremental refinement', async () => {
+    const session = await store.create('test/model', 'Test');
+    await store.appendMessage(session.id, { role: 'user', content: 'Tell me about cats' });
+    await store.appendMessage(session.id, { role: 'assistant', content: 'Cats are great.' });
+    await store.updateSummary(session.id, 'Discussion about cats.', 1);
+
+    const updated = await store.get(session.id, true);
+    let capturedMessages: Array<{ role: string; content: string }> = [];
+    const state = {
+      async* chat(_model: string, messages: Array<{ role: string; content: string }>) {
+        capturedMessages = messages;
+        yield { type: 'text' as const, text: 'Refined summary.' };
+        yield { type: 'done' as const, finishReason: 'stop' };
+      },
+    } as unknown as CoreState;
+
+    await generateSessionSummary(state, updated);
+    const hasExistingSummary = capturedMessages.some(
+      (m) => m.content.includes('Previous summary') && m.content.includes('Discussion about cats.'),
+    );
+    expect(hasExistingSummary).toBe(true);
+  });
+});
+
+describe('maybeSummarize', () => {
+  it('triggers at SUMMARY_INTERVAL (10) user messages', async () => {
+    const session = await store.create('test/model', 'Test');
+
+    for (let i = 0; i < 10; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    const state = createMockState('Summary after 10 turns.');
+    await maybeSummarize(state, session.id, store);
+
+    const updated = await store.get(session.id, true);
+    expect(updated.summary).toBe('Summary after 10 turns.');
+    expect(updated.summaryMessageCount).toBe(10);
+  });
+
+  it('does not trigger below SUMMARY_INTERVAL', async () => {
+    const session = await store.create('test/model', 'Test');
+
+    for (let i = 0; i < 5; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    const state = createMockState('Should not appear.');
+    await maybeSummarize(state, session.id, store);
+
+    const updated = await store.get(session.id, true);
+    expect(updated.summary).toBeUndefined();
+  });
+
+  it('does not trigger at non-interval counts (e.g. 13)', async () => {
+    const session = await store.create('test/model', 'Test');
+
+    for (let i = 0; i < 13; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    const state = createMockState('Should not appear.');
+    await maybeSummarize(state, session.id, store);
+
+    const updated = await store.get(session.id, true);
+    expect(updated.summary).toBeUndefined();
+  });
+
+  it('skips if summary is already current (summaryMessageCount matches)', async () => {
+    const session = await store.create('test/model', 'Test');
+
+    for (let i = 0; i < 10; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    await store.updateSummary(session.id, 'Already summarized.', 10);
+
+    let chatCalled = false;
+    const state = {
+      async* chat() {
+        chatCalled = true;
+        yield { type: 'text' as const, text: 'New summary.' };
+        yield { type: 'done' as const, finishReason: 'stop' };
+      },
+    } as unknown as CoreState;
+
+    await maybeSummarize(state, session.id, store);
+
+    expect(chatCalled).toBe(false);
+    const updated = await store.get(session.id, true);
+    expect(updated.summary).toBe('Already summarized.');
+  });
+
+  it('catches errors and does not throw', async () => {
+    const session = await store.create('test/model', 'Test');
+
+    for (let i = 0; i < 10; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const state = createErrorState();
+
+    await expect(maybeSummarize(state, session.id, store)).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Summarizer]'),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('triggers again at 20 user messages', async () => {
+    const session = await store.create('test/model', 'Test');
+
+    for (let i = 0; i < 10; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    const state1 = createMockState('First summary.');
+    await maybeSummarize(state1, session.id, store);
+    expect((await store.get(session.id, true)).summary).toBe('First summary.');
+
+    for (let i = 10; i < 20; i++) {
+      await store.appendMessage(session.id, { role: 'user', content: `msg ${i + 1}` });
+      await store.appendMessage(session.id, { role: 'assistant', content: `reply ${i + 1}` });
+    }
+
+    const state2 = createMockState('Updated summary.');
+    await maybeSummarize(state2, session.id, store);
+
+    const updated = await store.get(session.id, true);
+    expect(updated.summary).toBe('Updated summary.');
+    expect(updated.summaryMessageCount).toBe(20);
+  });
+});

--- a/packages/daemon/src/core/session-summarizer.ts
+++ b/packages/daemon/src/core/session-summarizer.ts
@@ -1,0 +1,90 @@
+/**
+ * Session summarizer — periodic LLM-generated session summaries.
+ *
+ * Fires a background LLM call every SUMMARY_INTERVAL user messages to produce
+ * a short summary of the conversation. The summary is persisted on the session
+ * and available through the index for fast listing.
+ *
+ * Core layer (no transport dependencies).
+ */
+
+import type { CoreState } from './state.js';
+import type { Session, SessionStore } from './session-store.js';
+
+const SUMMARY_INTERVAL = 10;
+
+const SUMMARY_SYSTEM_PROMPT =
+  'You are a concise summarizer. Given the conversation below, produce a 2-3 sentence summary ' +
+  'capturing the key topics, decisions, and outcomes. Do not include greetings or filler. ' +
+  'Reply with only the summary text.';
+
+/**
+ * Generate an LLM summary of a session's conversation history.
+ *
+ * Uses the session's own model by default, or an explicit override.
+ * Tools are disabled — this is a plain text-in / text-out call.
+ */
+export async function generateSessionSummary(
+  state: CoreState,
+  session: Session,
+  model?: string,
+): Promise<string> {
+  const targetModel = model || session.model;
+
+  const messages: Array<{ role: string; content: string }> = [
+    { role: 'system', content: SUMMARY_SYSTEM_PROMPT },
+  ];
+
+  if (session.summary) {
+    messages.push({
+      role: 'user',
+      content: `Previous summary (may be outdated):\n${session.summary}\n\nHere is the full conversation so far:`,
+    });
+  }
+
+  const conversationText = session.messages
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m) => `${m.role}: ${m.content}`)
+    .join('\n');
+
+  messages.push({ role: 'user', content: conversationText || '(empty conversation)' });
+
+  let summary = '';
+  for await (const chunk of state.chat(targetModel, messages, undefined, { toolMode: 'none' })) {
+    if (chunk.type === 'text' && chunk.text) {
+      summary += chunk.text;
+    }
+  }
+
+  return summary.trim();
+}
+
+/**
+ * Check whether a session needs a summary refresh and generate one if so.
+ *
+ * Intended to be called fire-and-forget (`void maybeSummarize(...)`) after
+ * a chat turn completes. Errors are caught and logged, never propagated.
+ */
+export async function maybeSummarize(
+  state: CoreState,
+  sessionId: string,
+  store: SessionStore,
+  model?: string,
+): Promise<void> {
+  try {
+    const session = await store.get(sessionId, true);
+    const userMessageCount = session.messages.filter((m) => m.role === 'user').length;
+
+    if (userMessageCount < SUMMARY_INTERVAL) return;
+    if (userMessageCount % SUMMARY_INTERVAL !== 0) return;
+    if (session.summaryMessageCount === userMessageCount) return;
+
+    const summary = await generateSessionSummary(state, session, model);
+    if (summary) {
+      await store.updateSummary(sessionId, summary, userMessageCount);
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Summarizer] Failed to summarize session ${sessionId}: ${msg}`);
+  }
+}

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -14,6 +14,7 @@ import { startDaemon } from './daemon.js';
 import { isDaemonRunningSync } from './transport.js';
 import { DaemonState } from './state.js';
 import { SessionStore } from '../core/session-store.js';
+import { maybeSummarize } from '../core/session-summarizer.js';
 import type { ChatToolOptions } from '../core/state.js';
 
 interface ChatOptions {
@@ -224,6 +225,7 @@ async function runInteractiveMode(
           }
           isFirstTurn = false;
         }
+        void maybeSummarize(state, sessionId, store);
       }
     }
   }

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -301,8 +301,9 @@ sessions
         s.model,
         String(s.messageCount),
         new Date(s.updatedAt).toLocaleString(),
+        (s.summary || '').substring(0, 50),
       ]);
-      printTable(['ID', 'Title', 'Model', 'Msgs', 'Updated'], rows);
+      printTable(['ID', 'Title', 'Model', 'Msgs', 'Updated', 'Summary'], rows);
       console.log(`\n${result.totalCount} session(s) total`);
     }
   });
@@ -321,12 +322,16 @@ sessions
       if (options.json) {
         console.log(JSON.stringify(session, null, 2));
       } else {
-        console.log(`Session: ${session.id}`);
-        console.log(`Title:   ${session.title}`);
-        console.log(`Model:   ${session.model}`);
-        console.log(`Created: ${session.createdAt}`);
-        console.log(`Updated: ${session.updatedAt}`);
-        console.log(`Messages: ${session.messages.length}\n`);
+        console.log(`Session:  ${session.id}`);
+        console.log(`Title:    ${session.title}`);
+        console.log(`Model:    ${session.model}`);
+        console.log(`Created:  ${session.createdAt}`);
+        console.log(`Updated:  ${session.updatedAt}`);
+        console.log(`Messages: ${session.messages.length}`);
+        if (session.summary) {
+          console.log(`Summary:  ${session.summary}`);
+        }
+        console.log();
         for (const msg of session.messages) {
           const label = msg.role === 'user' ? 'you' : msg.role;
           console.log(`[${label}] ${msg.content}\n`);

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -12,6 +12,7 @@ import {
   getWebServerPort,
 } from '../web/server.js';
 import { listAllPolicies, type PolicyConfig as PolicyCfg } from '../../core/policies.js';
+import { maybeSummarize, generateSessionSummary } from '../../core/session-summarizer.js';
 
 interface ProtoClientInfo {
   client_type?: string | number;
@@ -983,6 +984,8 @@ export function createAbbenayService(state: DaemonState) {
               await state.sessionStore.updateTitle(sessionId, title);
             }
           }
+
+          void maybeSummarize(state, sessionId, state.sessionStore);
         } catch (error: unknown) {
           const msg = error instanceof Error ? error.message : String(error);
           console.error('[gRPC] SessionChat error:', msg);
@@ -998,8 +1001,35 @@ export function createAbbenayService(state: DaemonState) {
     ReplaySession(call: grpc.ServerUnaryCall<object, object>, callback: grpc.sendUnaryData<object>): void {
       callback({ code: grpc.status.UNIMPLEMENTED, message: 'Sessions not yet implemented' });
     },
-    SummarizeSession(call: grpc.ServerUnaryCall<object, object>, callback: grpc.sendUnaryData<object>): void {
-      callback({ code: grpc.status.UNIMPLEMENTED, message: 'Sessions not yet implemented' });
+    SummarizeSession(call: grpc.ServerUnaryCall<{ session_id?: string; sessionId?: string; summarize_model?: string; summarizeModel?: string }, object>, callback: grpc.sendUnaryData<object>): void {
+      const sessionId = call.request.session_id || call.request.sessionId || '';
+      if (!sessionId) {
+        callback({ code: grpc.status.INVALID_ARGUMENT, message: 'session_id is required' });
+        return;
+      }
+
+      (async () => {
+        try {
+          const session = await state.sessionStore.get(sessionId, true);
+          const userCount = session.messages.filter((m) => m.role === 'user').length;
+
+          if (session.summary && session.summaryMessageCount === userCount) {
+            callback(null, { summary: session.summary, from_cache: true });
+            return;
+          }
+
+          const overrideModel = call.request.summarize_model || call.request.summarizeModel || undefined;
+          const summary = await generateSessionSummary(state, session, overrideModel);
+          if (summary) {
+            await state.sessionStore.updateSummary(sessionId, summary, userCount);
+          }
+          callback(null, { summary, from_cache: false });
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : String(error);
+          console.error('[gRPC] SummarizeSession error:', msg);
+          callback({ code: grpc.status.INTERNAL, message: msg });
+        }
+      })();
     },
     ForkSession(call: grpc.ServerUnaryCall<object, object>, callback: grpc.sendUnaryData<object>): void {
       callback({ code: grpc.status.UNIMPLEMENTED, message: 'Sessions not yet implemented' });
@@ -1079,6 +1109,7 @@ function sessionToProto(session: import('../../core/session-store.js').Session) 
     updated_at: toTimestamp(session.updatedAt),
     forked_from: session.parentSessionId,
     fork_point: session.forkPoint,
+    cached_summary: session.summary,
   };
 }
 
@@ -1090,6 +1121,7 @@ function summaryToProto(summary: import('../../core/session-store.js').SessionSu
     message_count: summary.messageCount,
     created_at: toTimestamp(summary.createdAt),
     updated_at: toTimestamp(summary.updatedAt),
+    summary: summary.summary,
   };
 }
 

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { getDefaultSocketPath } from '../transport.js';
 import { loadConfig, saveConfig, loadWorkspaceConfig, saveWorkspaceConfig, getUserConfigPath, getWorkspaceConfigPath, isValidVirtualName, type ConfigFile, type ProviderConfig } from '../../core/config.js';
 import { listAllPolicies, loadCustomPolicies, saveCustomPolicies, BUILTIN_POLICY_NAMES, type PolicyConfig } from '../../core/policies.js';
+import { maybeSummarize, generateSessionSummary } from '../../core/session-summarizer.js';
 import type { DaemonState } from '../state.js';
 import type { ChatToolOptions } from '../../core/state.js';
 import { getEngines, getProviderTemplates } from '../../core/engines.js';
@@ -972,6 +973,33 @@ export function createWebApp(state: DaemonState): Express {
     }
   });
 
+  app.get('/api/sessions/:id/summary', async (req, res) => {
+    try {
+      const session = await state.sessionStore.get(req.params.id, true);
+      const userCount = session.messages.filter((m) => m.role === 'user').length;
+
+      if (session.summary && session.summaryMessageCount === userCount) {
+        res.json({ summary: session.summary, from_cache: true });
+        return;
+      }
+
+      const model = req.query.model as string | undefined;
+      const summary = await generateSessionSummary(state, session, model);
+      if (summary) {
+        await state.sessionStore.updateSummary(req.params.id, summary, userCount);
+      }
+      res.json({ summary, from_cache: false });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('not found') || msg.includes('Invalid session ID')) {
+        res.status(404).json({ error: msg });
+      } else {
+        console.error('[Web] GET /api/sessions/:id/summary error:', msg);
+        res.status(500).json({ error: msg });
+      }
+    }
+  });
+
   app.post('/api/sessions/:id/chat', async (req, res) => {
     const sessionId = req.params.id;
     const { message } = req.body;
@@ -1072,6 +1100,8 @@ export function createWebApp(state: DaemonState): Express {
             await state.sessionStore.updateTitle(sessionId, title);
           }
         }
+
+        void maybeSummarize(state, sessionId, state.sessionStore);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[Web] Session chat error:', msg);

--- a/packages/daemon/tests/integration/sessions.test.ts
+++ b/packages/daemon/tests/integration/sessions.test.ts
@@ -30,6 +30,8 @@ let mockChatResponse: MockChunk[] = [
   { type: 'done', finishReason: 'stop' },
 ];
 
+let mockSummaryResponse = 'Mock summary of the conversation.';
+
 const mockSecretStore: SecretStore = {
   async get() { return null; },
   async set() {},
@@ -59,6 +61,12 @@ function createMockState(): DaemonState {
     },
 
     async* chat(_model: string, _messages: Array<{ role: string; content: string }>) {
+      const isSummaryCall = _messages.some((m) => m.role === 'system' && m.content.includes('concise summarizer'));
+      if (isSummaryCall) {
+        yield { type: 'text' as const, text: mockSummaryResponse };
+        yield { type: 'done' as const, finishReason: 'stop' };
+        return;
+      }
       for (const chunk of mockChatResponse) {
         yield chunk;
       }
@@ -101,6 +109,7 @@ afterEach(() => {
     { type: 'text', text: ' world' },
     { type: 'done', finishReason: 'stop' },
   ];
+  mockSummaryResponse = 'Mock summary of the conversation.';
 });
 
 // ─── HTTP Helpers ───────────────────────────────────────────────────────
@@ -392,5 +401,82 @@ describe('Session chat SSE endpoint', () => {
 
     const { body: session } = await httpRequest('GET', `${baseUrl}/api/sessions/${id}`);
     expect(session.title).toBe('What is the meaning of life?');
+  });
+
+  it('POST /api/sessions/:id/chat triggers summary after 10 user turns', async () => {
+    const created = await httpRequest('POST', `${baseUrl}/api/sessions`, { model: 'test/model' });
+    const id = created.body.id;
+
+    mockSummaryResponse = 'Ten-turn summary.';
+
+    for (let i = 0; i < 10; i++) {
+      await postSSE(`${baseUrl}/api/sessions/${id}/chat`, {
+        message: { role: 'user', content: `Turn ${i + 1}` },
+      });
+    }
+
+    // maybeSummarize is fire-and-forget; give it a moment to complete
+    await new Promise((r) => setTimeout(r, 500));
+
+    const { body: session } = await httpRequest('GET', `${baseUrl}/api/sessions/${id}`);
+    expect(session.summary).toBe('Ten-turn summary.');
+  });
+});
+
+describe('Session summary endpoint', () => {
+  it('GET /api/sessions/:id/summary generates and caches summary', async () => {
+    const created = await httpRequest('POST', `${baseUrl}/api/sessions`, { model: 'test/model' });
+    const id = created.body.id;
+
+    await postSSE(`${baseUrl}/api/sessions/${id}/chat`, {
+      message: { role: 'user', content: 'Hello' },
+    });
+
+    mockSummaryResponse = 'On-demand summary.';
+
+    const { statusCode, body } = await httpRequest('GET', `${baseUrl}/api/sessions/${id}/summary`);
+    expect(statusCode).toBe(200);
+    expect(body.summary).toBe('On-demand summary.');
+    expect(body.from_cache).toBe(false);
+
+    // Second call should return cached
+    const { body: cached } = await httpRequest('GET', `${baseUrl}/api/sessions/${id}/summary`);
+    expect(cached.summary).toBe('On-demand summary.');
+    expect(cached.from_cache).toBe(true);
+  });
+
+  it('GET /api/sessions/:id/summary returns 404 for unknown session', async () => {
+    const { statusCode } = await httpRequest('GET', `${baseUrl}/api/sessions/nonexistent/summary`);
+    expect(statusCode).toBe(404);
+  });
+
+  it('summary field appears in GET /api/sessions/:id response', async () => {
+    const created = await httpRequest('POST', `${baseUrl}/api/sessions`, { model: 'test/model' });
+    const id = created.body.id;
+
+    await postSSE(`${baseUrl}/api/sessions/${id}/chat`, {
+      message: { role: 'user', content: 'test' },
+    });
+
+    // Generate summary on demand
+    await httpRequest('GET', `${baseUrl}/api/sessions/${id}/summary`);
+
+    const { body: session } = await httpRequest('GET', `${baseUrl}/api/sessions/${id}`);
+    expect(session.summary).toBeTruthy();
+  });
+
+  it('summary field appears in GET /api/sessions list response', async () => {
+    const created = await httpRequest('POST', `${baseUrl}/api/sessions`, { model: 'test/model' });
+    const id = created.body.id;
+
+    await postSSE(`${baseUrl}/api/sessions/${id}/chat`, {
+      message: { role: 'user', content: 'test' },
+    });
+
+    await httpRequest('GET', `${baseUrl}/api/sessions/${id}/summary`);
+
+    const { body: list } = await httpRequest('GET', `${baseUrl}/api/sessions`);
+    const entry = list.sessions.find((s: any) => s.id === id);
+    expect(entry.summary).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Every 10 user messages, a background LLM call generates a 2-3 sentence session summary stored on the session JSON and index. Summaries are non-blocking (fire-and-forget) and error-safe.
- On-demand summarization available via `SummarizeSession` gRPC RPC and `GET /api/sessions/:id/summary` web endpoint, with caching (returns cached if summary is current).
- Summary field surfaced in session list/show across all transports (gRPC, web API, CLI).

## Commits

- `feat(session): add periodic LLM-generated session summaries` -- adds `session-summarizer.ts` core module, data model fields (`summary`, `summaryMessageCount`), wires `maybeSummarize` into all three transports, implements `SummarizeSession` RPC and web endpoint, DR-022
- `fix(session): address Copilot review on session persistence` -- fixes tool call shape to flat `{id, name, arguments}` matching core/proto, fixes proto Role enum mapping (1..4 not 0..3), differentiates 404 vs 500 on session endpoints, removes dead `pendingToolCalls` code

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test -w packages/daemon` -- all 278 tests pass (14 files)
- [x] `npx tsc --noEmit` passes
- [x] 9 new unit tests for `generateSessionSummary` and `maybeSummarize` (interval logic, skip-if-current, error handling, incremental refinement)
- [x] 5 new integration tests (periodic trigger at 10 turns, on-demand summary endpoint, caching, summary in GET responses)
- [x] Docs updated: DR-022, ROADMAP, ARCHITECTURE, TESTING