### PR TITLE
docs: update all documentation for current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ The name fits this project on three levels: it literally means *mind* (an AI/LLM
 
 ## Quick Start
 
+> **Binary names:** If you installed via npm, use `aby` (or `abbenay`).
+> If you downloaded a release binary, it is named
+> `abbenay-daemon-<platform>-<arch>` — rename or symlink it to `aby` for
+> convenience. All examples below use `aby`.
+
 ### Start everything
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ Abbenay produces two packages from a single source tree:
 ## Features
 
 - **19 LLM engines** via the [Vercel AI SDK](https://sdk.vercel.ai/) with dynamic provider loading
-- **Unified daemon**: TypeScript/Node.js service serves all clients via gRPC
+- **OpenAI-compatible API**: Drop-in `/v1/chat/completions` for Cursor, Continue, aider, etc.
+- **CLI chat**: Interactive terminal chat with tool approval and session persistence
+- **Session management**: Persistent conversations with periodic LLM-generated summaries
+- **Unified daemon**: TypeScript/Node.js service serves all clients via gRPC, REST, and SSE
 - **Web dashboard**: Configure providers, API keys, and models via browser UI
 - **VS Code integration**: Models appear in VS Code's Language Model picker
 - **Reusable core library**: Use `@abbenay/core` in your own apps without the daemon
+- **Tool calling**: Full tool execution loop with MCP support and approval policies
+- **MCP aggregation**: Connect to external MCP servers, expose daemon as MCP server
 - **Dynamic model discovery**: Fetches available models from provider APIs
-- **Tool calling**: Full tool execution loop with approval tiers
 - **Single Executable Application (SEA)**: Self-contained binary, no Node.js install required
 
 ## Why "Abbenay"?
@@ -67,34 +71,63 @@ The name fits this project on three levels: it literally means *mind* (an AI/LLM
 
 ## Quick Start
 
-### Using the daemon
+### Start everything
 
 ```bash
-cd packages/daemon
-npm install
-npm run daemon    # Start daemon (foreground)
-npm run web       # Start web dashboard at http://localhost:8787
+aby start                     # Start daemon + web dashboard + OpenAI API + MCP
 ```
 
-With the compiled binary (or SEA):
+Or start services individually:
 
 ```bash
-abbenay daemon        # Start daemon
-abbenay web           # Start web dashboard
-abbenay status        # Check status
-abbenay list-engines  # Show all supported engines
-abbenay list-models   # Show configured models (from your config)
-abbenay chat -m openai/gpt-4o   # Interactive chat
-aby daemon            # Short alias — aby is equivalent to abbenay
+aby daemon                    # gRPC daemon only
+aby web                       # Web dashboard at http://localhost:8787
+aby serve                     # OpenAI-compatible API at http://localhost:8787
+aby status                    # Check if daemon is running
+aby stop                      # Stop the daemon
 ```
 
-To discover what models an engine offers:
+### Chat
 
 ```bash
-abbenay list-models --discover ollama           # keyless — works immediately
-abbenay list-models --discover openai           # reads OPENAI_API_KEY from env
-abbenay list-models --discover anthropic        # reads ANTHROPIC_API_KEY from env
+aby chat -m openai/gpt-4o                # Interactive chat
+aby chat -m ollama/llama3.2 -s "Be concise"  # With system prompt
+aby chat -m openai/gpt-4o --session new  # Start a persistent session
+aby chat --session <id>                  # Resume a session
 ```
+
+### Sessions
+
+```bash
+aby sessions list                        # List saved sessions
+aby sessions show <id>                   # Show session messages
+aby sessions delete <id>                 # Delete a session
+```
+
+### Model discovery
+
+```bash
+aby list-engines                         # Show all supported engines
+aby list-models                          # Show configured models
+aby list-models --discover ollama        # Discover models from a provider
+aby list-models --discover openai        # Reads OPENAI_API_KEY from env
+```
+
+### OpenAI-compatible API
+
+Any tool that speaks the OpenAI protocol can use Abbenay as a backend:
+
+```bash
+aby serve -p 8787
+
+# Then point your client at it:
+curl http://localhost:8787/v1/models
+curl http://localhost:8787/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "openai/gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+Works with Cursor, Continue, aider, and any `openai` SDK script.
 
 ### Using the core library
 
@@ -103,7 +136,6 @@ import { CoreState, MemorySecretStore } from '@abbenay/core';
 
 const core = new CoreState({ secretStore: new MemorySecretStore() });
 
-// Add a provider on the fly — no config files needed
 await core.addProvider('my-openai', {
   engine: 'openai',
   apiKey: process.env.OPENAI_API_KEY!,
@@ -119,7 +151,7 @@ for await (const chunk of core.chat('my-openai/gpt-4o', [
 
 See [docs/CORE.md](docs/CORE.md) for the full library API reference.
 
-### Building everything
+### Building from source
 
 **Prerequisites:** `curl` and `bash` (that's it).
 
@@ -138,7 +170,7 @@ To build and install the VSIX into VS Code:
 node build.js --code-install
 ```
 
-See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for all platforms, CI details, and build options.
+See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for a complete walkthrough, or [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for all platforms, CI details, and build options.
 
 ## Supported Engines
 
@@ -237,12 +269,15 @@ abbenay/
 
 ## Documentation
 
+- [Getting Started](docs/GETTING_STARTED.md)
 - [Core Library (API Reference)](docs/CORE.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Configuration](docs/CONFIGURATION.md)
 - [Development Guide](docs/DEVELOPMENT.md)
 - [Testing](docs/TESTING.md)
+- [Roadmap](docs/ROADMAP.md)
 - [Product Overview](docs/PRODUCT_OVERVIEW.md)
+- [Landscape Comparison](docs/LANDSCAPE.md)
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -349,6 +349,9 @@ Defined in `proto/abbenay/v1/service.proto`. The daemon loads protos dynamically
 | RPC | Description |
 |-----|-------------|
 | `Chat` | Streaming chat with a model |
+| `SessionChat` | Streaming chat within a session |
+| `CreateSession` / `GetSession` / `ListSessions` / `DeleteSession` | Session CRUD |
+| `SummarizeSession` | On-demand or cached session summary |
 | `ListModels` | List available models from providers |
 | `ListProviders` | List configured providers |
 | `GetSecret` / `SetSecret` / `DeleteSecret` / `ListSecrets` | Secret management |
@@ -359,16 +362,18 @@ Defined in `proto/abbenay/v1/service.proto`. The daemon loads protos dynamically
 | `GetProviderStatus` | Provider status |
 | `GetConnectedWorkspaces` | Workspace paths from VS Code |
 | `StartWebServer` / `StopWebServer` | Embedded web dashboard lifecycle |
+| `ListEngines` | List available engine types |
+| `ListPolicies` | List built-in and custom policies |
 | `Shutdown` | Daemon shutdown |
 
 ### Stub RPCs (Deferred)
 
 | RPC | Description |
 |-----|-------------|
-| `WatchSessions` / `ReplaySession` / `SummarizeSession` | Session features |
-| `ForkSession` / `ExportSession` / `ImportSession` | Session branching |
-| `ListTools` / `ExecuteTool` | Tool execution (future MCP) |
-| `RegisterMcpServer` / `UnregisterMcpServer` | MCP server registration |
+| `WatchSessions` / `ReplaySession` | Session replay / real-time events |
+| `ForkSession` / `ExportSession` / `ImportSession` | Session branching and sharing |
+| `ListTools` / `ExecuteTool` | Tool execution via gRPC |
+| `RegisterMcpServer` / `UnregisterMcpServer` | MCP server registration via gRPC |
 
 ### VS Code Backchannel
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,13 +12,19 @@ Download the latest release for your platform. The binary is a
 [Node.js Single Executable Application (SEA)](https://nodejs.org/api/single-executables.html) —
 no Node.js installation required.
 
+Release artifacts are named `abbenay-daemon-<platform>-<arch>`. Rename
+or symlink to `aby` for convenience:
+
 ```bash
-# Linux / macOS — move to PATH
-chmod +x abbenay
-sudo mv abbenay /usr/local/bin/
+# Linux / macOS — rename and move to PATH
+chmod +x abbenay-daemon-linux-x64
+sudo mv abbenay-daemon-linux-x64 /usr/local/bin/aby
 ```
 
-The `aby` alias is equivalent to `abbenay` everywhere in these docs.
+If you install via npm (`npm install -g @abbenay/daemon`), both `aby`
+and `abbenay` are available on PATH automatically.
+
+All examples in this guide use `aby`.
 
 ### Option B: Build from source
 
@@ -46,13 +52,21 @@ npx tsx src/daemon/index.ts daemon   # run daemon directly
 
 ## 2. Configure a provider
 
-Abbenay needs at least one LLM provider. Create a config file:
+Abbenay needs at least one LLM provider. Create a config file at the
+platform-appropriate location:
+
+| Platform | Config directory |
+|----------|----------------|
+| Linux | `$XDG_CONFIG_HOME/abbenay/` (default `~/.config/abbenay/`) |
+| macOS | `~/Library/Application Support/abbenay/` |
+| Windows | `%APPDATA%\abbenay\` |
 
 ```bash
+# Linux example
 mkdir -p ~/.config/abbenay
 ```
 
-**`~/.config/abbenay/config.yaml`:**
+**`config.yaml`:**
 
 ```yaml
 providers:
@@ -140,7 +154,7 @@ aby chat -m my-openai/gpt-4o --no-tools                        # disable tools
 aby chat -m my-openai/gpt-4o --json                            # JSON output (for piping)
 ```
 
-Multi-line input: type freely, press Enter to send. Ctrl+D to exit.
+Type your message and press Enter to send. Ctrl+D to exit.
 
 ---
 
@@ -165,9 +179,15 @@ aby sessions show <session-id>
 aby sessions delete <session-id>
 ```
 
-Sessions are stored as JSON in `$XDG_DATA_HOME/abbenay/sessions/`
-(typically `~/.local/share/abbenay/sessions/`). Every 10 user messages,
-a background LLM call generates a short summary.
+Sessions are stored as JSON in a platform-specific data directory:
+
+| Platform | Session directory |
+|----------|------------------|
+| Linux | `$XDG_DATA_HOME/abbenay/sessions/` (default `~/.local/share/abbenay/sessions/`) |
+| macOS | `~/Library/Application Support/abbenay/sessions/` |
+| Windows | `%LOCALAPPDATA%\abbenay\sessions\` |
+
+Every 10 user messages, a background LLM call generates a short summary.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,296 @@
+# Getting Started with Abbenay
+
+This guide walks you through installing, configuring, and using Abbenay.
+
+---
+
+## 1. Install
+
+### Option A: Pre-built binary (recommended)
+
+Download the latest release for your platform. The binary is a
+[Node.js Single Executable Application (SEA)](https://nodejs.org/api/single-executables.html) —
+no Node.js installation required.
+
+```bash
+# Linux / macOS — move to PATH
+chmod +x abbenay
+sudo mv abbenay /usr/local/bin/
+```
+
+The `aby` alias is equivalent to `abbenay` everywhere in these docs.
+
+### Option B: Build from source
+
+```bash
+git clone https://github.com/redhat-developer/abbenay.git
+cd abbenay
+
+./bootstrap.sh                 # downloads Node.js + uv into .build-tools/
+source .build-tools/env.sh     # puts them on PATH
+npm install
+node build.js                  # builds SEA binary + VSIX + dist archives
+```
+
+### Option C: Run from source (development)
+
+```bash
+git clone https://github.com/redhat-developer/abbenay.git
+cd abbenay
+npm install
+cd packages/daemon
+npx tsx src/daemon/index.ts daemon   # run daemon directly
+```
+
+---
+
+## 2. Configure a provider
+
+Abbenay needs at least one LLM provider. Create a config file:
+
+```bash
+mkdir -p ~/.config/abbenay
+```
+
+**`~/.config/abbenay/config.yaml`:**
+
+```yaml
+providers:
+  my-openai:
+    engine: openai
+    api_key_env_var_name: "OPENAI_API_KEY"
+    models:
+      gpt-4o: {}
+      gpt-4o-mini: {}
+```
+
+Set the API key in your environment:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Or use the system keychain instead of env vars:
+
+```yaml
+providers:
+  my-openai:
+    engine: openai
+    api_key_keychain_name: "OPENAI_API_KEY"
+    models:
+      gpt-4o: {}
+```
+
+Then store the key via the web dashboard or CLI.
+
+### Local models (no API key needed)
+
+```yaml
+providers:
+  local-ollama:
+    engine: ollama
+    models:
+      llama3.2: {}
+      qwen2.5-coder: {}
+```
+
+Ollama must be running at `http://localhost:11434` (the default).
+
+See [CONFIGURATION.md](CONFIGURATION.md) for all options.
+
+---
+
+## 3. Start Abbenay
+
+### All-in-one
+
+```bash
+aby start
+```
+
+This launches the daemon, web dashboard, OpenAI-compatible API, and MCP
+server on port 8787.
+
+### Individual services
+
+```bash
+aby daemon                    # gRPC daemon only (background-ready)
+aby web -p 8787               # Web dashboard
+aby serve -p 8787             # OpenAI-compatible API
+aby status                    # Check if running
+aby stop                      # Stop everything
+```
+
+---
+
+## 4. Chat from the CLI
+
+```bash
+aby chat -m my-openai/gpt-4o
+```
+
+The model ID is `<provider-name>/<model-name>` from your config.
+
+Options:
+
+```bash
+aby chat -m my-openai/gpt-4o -s "You are a helpful assistant"   # system prompt
+aby chat -m my-openai/gpt-4o -p coder                          # apply a policy
+aby chat -m my-openai/gpt-4o --no-tools                        # disable tools
+aby chat -m my-openai/gpt-4o --json                            # JSON output (for piping)
+```
+
+Multi-line input: type freely, press Enter to send. Ctrl+D to exit.
+
+---
+
+## 5. Use sessions for persistent conversations
+
+Sessions save your conversation so you can resume later.
+
+```bash
+# Start a new session
+aby chat -m my-openai/gpt-4o --session new
+
+# Resume an existing session
+aby chat --session <session-id>
+
+# List all sessions
+aby sessions list
+
+# Show a session's messages
+aby sessions show <session-id>
+
+# Delete a session
+aby sessions delete <session-id>
+```
+
+Sessions are stored as JSON in `$XDG_DATA_HOME/abbenay/sessions/`
+(typically `~/.local/share/abbenay/sessions/`). Every 10 user messages,
+a background LLM call generates a short summary.
+
+---
+
+## 6. Use the OpenAI-compatible API
+
+Start the server:
+
+```bash
+aby serve -p 8787
+```
+
+Then point any OpenAI-compatible client at it:
+
+```bash
+# List models
+curl http://localhost:8787/v1/models
+
+# Chat (streaming)
+curl http://localhost:8787/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "my-openai/gpt-4o",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
+  }'
+```
+
+### With the OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8787/v1", api_key="unused")
+response = client.chat.completions.create(
+    model="my-openai/gpt-4o",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+### With Cursor / Continue / aider
+
+Set the API base URL to `http://localhost:8787/v1` in your tool's
+settings. The API key field can be any non-empty string.
+
+---
+
+## 7. Use the web dashboard
+
+```bash
+aby web
+```
+
+Open http://localhost:8787 in your browser to:
+
+- Add and configure providers
+- Store API keys in the system keychain
+- Enable/disable models
+- Test chat with streaming responses
+
+---
+
+## 8. Connect MCP servers
+
+Abbenay can connect to external [MCP](https://modelcontextprotocol.io/)
+servers and aggregate their tools.
+
+Add to your config:
+
+```yaml
+mcp_servers:
+  filesystem:
+    transport: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]
+    enabled: true
+  github:
+    transport: http
+    url: http://localhost:3001/mcp
+    enabled: true
+```
+
+Tools from connected MCP servers are automatically available in chat.
+Tool approval policies control which tools can execute without
+confirmation.
+
+---
+
+## 9. VS Code integration
+
+Install the Abbenay VS Code extension (VSIX):
+
+```bash
+node build.js --code-install
+```
+
+The extension:
+- Connects to the daemon automatically on activation
+- Registers all configured models with VS Code's Language Model API
+- Other extensions can use Abbenay models via `vscode.lm.selectChatModels({ vendor: 'abbenay' })`
+
+---
+
+## 10. Discover models
+
+```bash
+# Show configured models
+aby list-models
+
+# Discover what an engine offers (fetches from provider API)
+aby list-models --discover ollama
+aby list-models --discover openai
+aby list-models --discover anthropic
+
+# Show available engines
+aby list-engines
+```
+
+---
+
+## Next steps
+
+- [Configuration Reference](CONFIGURATION.md) — all config options
+- [Core Library API](CORE.md) — use `@abbenay/core` in your own apps
+- [Architecture](ARCHITECTURE.md) — how the system fits together
+- [Roadmap](ROADMAP.md) — what's coming next

--- a/docs/LANDSCAPE.md
+++ b/docs/LANDSCAPE.md
@@ -166,9 +166,11 @@ changes required.
 ² Abbenay exposes an OpenAI-compatible API at `/v1/models` and
 `/v1/chat/completions` (streaming and non-streaming). Any tool that
 speaks the OpenAI protocol (Cursor, Continue, aider, `openai` SDK
-scripts) can use Abbenay as a drop-in backend via `aby serve`. Client
-access is also available via the `@abbenay/core` library (in-process),
-gRPC (daemon), REST API (`/api/*`), or the CLI.
+scripts) can use Abbenay as a drop-in backend via the `serve` command
+(e.g., `aby serve` if installed via npm, or `./abbenay-daemon serve`
+for the standalone binary). Client access is also available via the
+`@abbenay/core` library (in-process), gRPC (daemon), REST API
+(`/api/*`), or the CLI.
 
 ---
 

--- a/docs/LANDSCAPE.md
+++ b/docs/LANDSCAPE.md
@@ -89,10 +89,11 @@ built-in cost tracking or billing, earlier in development.
 
 | Capability | LiteLLM | Portkey | LLM Gateway | Abbenay |
 |------------|---------|---------|-------------|---------|
-| **Built-in engines** | 100+ | 250+ | ~15 | 18 + any OpenAI-compatible¹ |
-| **OpenAI-compatible API** | Yes | Yes | Yes | No (gRPC + library)² |
+| **Built-in engines** | 100+ | 250+ | ~15 | 19 + any OpenAI-compatible¹ |
+| **OpenAI-compatible API** | Yes | Yes | Yes | Yes (`/v1/chat/completions`)² |
 | **Embeddable library** | Python SDK | No | No | Yes (`@abbenay/core`) |
 | **Standalone daemon** | Proxy server | Proxy server | Proxy server | Optional daemon |
+| **Session persistence** | No | No | No | Yes (file-based + summaries) |
 | **CLI chat** | No | No | No | Yes |
 | **VS Code integration** | No | No | No | Language Model API |
 | **MCP tool aggregation** | MCP Gateway | MCP Gateway | No | MCP client pool |
@@ -155,16 +156,19 @@ These tools are not mutually exclusive. Example combinations:
 
 ## Footnotes
 
-¹ Abbenay ships 18 pre-configured engines (OpenAI, Anthropic, Gemini,
+¹ Abbenay ships 19 pre-configured engines (OpenAI, Anthropic, Gemini,
 Mistral, xAI, DeepSeek, Groq, Cohere, Amazon Bedrock, Fireworks,
 Together AI, Perplexity, Azure, OpenRouter, Ollama, LM Studio, Cerebras,
-Meta). Any provider that exposes an OpenAI-compatible REST API can be
-used by pointing a configured engine's `base_url` at it — no code
+Meta, Mock). Any provider that exposes an OpenAI-compatible REST API can
+be used by pointing a configured engine's `base_url` at it — no code
 changes required.
 
-² Abbenay *consumes* OpenAI-compatible provider APIs but does not
-*expose* one. Client access is via the `@abbenay/core` library
-(in-process), gRPC (daemon), or the CLI.
+² Abbenay exposes an OpenAI-compatible API at `/v1/models` and
+`/v1/chat/completions` (streaming and non-streaming). Any tool that
+speaks the OpenAI protocol (Cursor, Continue, aider, `openai` SDK
+scripts) can use Abbenay as a drop-in backend via `aby serve`. Client
+access is also available via the `@abbenay/core` library (in-process),
+gRPC (daemon), REST API (`/api/*`), or the CLI.
 
 ---
 

--- a/docs/PRODUCT_OVERVIEW.md
+++ b/docs/PRODUCT_OVERVIEW.md
@@ -115,6 +115,10 @@ The project implements a **TypeScript daemon** with **gRPC API**, a **web dashbo
 
 ## Components
 
+> **Note:** Commands below use `aby`, available when installed via npm.
+> For the standalone SEA binary, use `./abbenay-daemon` (or rename/symlink
+> it to `aby`).
+
 ### 1. TypeScript Daemon (`aby daemon`)
 
 The core service that runs as a background process:
@@ -261,8 +265,11 @@ providers:
 
 ## Session Continuity
 
-Sessions are persisted as JSON files in `$XDG_DATA_HOME/abbenay/sessions/`
-with a companion `index.json` for fast listing (DR-021). Features:
+Sessions are persisted as JSON files in a platform-specific data directory
+(`~/.local/share/abbenay/sessions/` on Linux, `~/Library/Application
+Support/abbenay/sessions/` on macOS, `%LOCALAPPDATA%\abbenay\sessions\`
+on Windows) with a companion `index.json` for fast listing (DR-021).
+Features:
 
 - **CRUD**: Create, get, list, delete sessions via gRPC, REST API, and CLI
 - **Session chat**: Continue conversations across sessions (`aby chat --session <id>`)

--- a/docs/PRODUCT_OVERVIEW.md
+++ b/docs/PRODUCT_OVERVIEW.md
@@ -1,8 +1,8 @@
 # Abbenay - Product Overview
 
 **Status:** MVP Complete  
-**Version:** 0.1.0  
-**Last Updated:** February 2026
+**Version:** 0.0.0-dev  
+**Last Updated:** March 2026
 
 ---
 
@@ -10,7 +10,7 @@
 
 Abbenay is a unified AI daemon that provides consistent access to multiple LLM providers through a single interface. It enables the "Bring Your Own Model" (BYOM) vision by supporting both cloud providers (OpenAI, Anthropic, Google) and local models (Ollama).
 
-The project implements a **TypeScript daemon** with **gRPC API**, a **web dashboard** for configuration, and a **VS Code extension** that registers models with VS Code's Language Model API.
+The project implements a **TypeScript daemon** with **gRPC API**, a **web dashboard** for configuration, an **OpenAI-compatible API** (`/v1/chat/completions`), and a **VS Code extension** that registers models with VS Code's Language Model API.
 
 ---
 
@@ -115,7 +115,7 @@ The project implements a **TypeScript daemon** with **gRPC API**, a **web dashbo
 
 ## Components
 
-### 1. TypeScript Daemon (`abbenay daemon`)
+### 1. TypeScript Daemon (`aby daemon`)
 
 The core service that runs as a background process:
 - Listens on Unix socket for gRPC requests
@@ -123,7 +123,7 @@ The core service that runs as a background process:
 - Handles chat streaming and session persistence
 - Stores secrets in system keychain
 
-### 2. Web Dashboard (`abbenay web`)
+### 2. Web Dashboard (`aby web`)
 
 Browser-based configuration UI:
 - Configure API keys (keychain or environment variable)
@@ -131,7 +131,25 @@ Browser-based configuration UI:
 - View connection status
 - Choose user or workspace config level
 
-### 3. VS Code Extension
+### 3. OpenAI-Compatible API (`aby serve`)
+
+Drop-in replacement for any OpenAI-compatible client:
+- `GET /v1/models` — list configured models in OpenAI format
+- `POST /v1/chat/completions` — streaming and non-streaming chat
+- Works with Cursor, Continue, aider, and any `openai` SDK script
+
+### 4. CLI Chat (`aby chat`)
+
+Interactive terminal chat with streaming output:
+- Model selection, system prompts, named policies
+- Tool execution with inline approval prompts
+- Session persistence (`--session <id>` or `--session new`)
+
+### 5. All-in-One (`aby start`)
+
+Single command to start all services (daemon, web dashboard, OpenAI API, MCP server).
+
+### 6. VS Code Extension
 
 Integrates Abbenay with VS Code:
 - Connects to daemon on activation
@@ -205,7 +223,7 @@ providers:
 | 2 | Local Model Support | ✅ Complete | Ollama provider with auto-discovery |
 | 3 | Simplified Integration | ✅ Complete | Standard VS Code LM API |
 | 4 | Provider Switching | ✅ Complete | Enable/disable via web dashboard |
-| 5 | Session Continuity | Deferred | Stub RPCs exist; full implementation in a future release |
+| 5 | Session Continuity | ✅ Complete | File-based persistence, CLI/web/gRPC transports, periodic summaries |
 
 ---
 
@@ -243,7 +261,18 @@ providers:
 
 ## Session Continuity
 
-Session continuity is **deferred** to a future release. Stub RPCs exist in the gRPC proto but return `UNIMPLEMENTED`. The vision is to enable starting a chat in VS Code and continuing from CLI or another tool, with JSON-based session persistence.
+Sessions are persisted as JSON files in `$XDG_DATA_HOME/abbenay/sessions/`
+with a companion `index.json` for fast listing (DR-021). Features:
+
+- **CRUD**: Create, get, list, delete sessions via gRPC, REST API, and CLI
+- **Session chat**: Continue conversations across sessions (`aby chat --session <id>`)
+- **Tool persistence**: Tool calls and results are stored in session history
+- **Periodic summaries**: Every 10 user messages, a background LLM call generates a 2-3 sentence summary (DR-022)
+- **On-demand summaries**: `SummarizeSession` gRPC RPC and `GET /api/sessions/:id/summary`
+- **CLI commands**: `aby sessions list`, `aby sessions show <id>`, `aby sessions delete <id>`
+
+**Not yet implemented**: `ForkSession`, `ExportSession`, `ImportSession`, web dashboard
+session sidebar, context window compression.
 
 ---
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -54,13 +54,9 @@ code --install-extension abbenay-provider-0.1.0.vsix
 The Abbenay daemon must be running:
 
 ```bash
-# From the repository root
-cd packages/daemon
-npm install
-npm run build
-
-# Start the daemon
-node dist/index.js daemon
+aby daemon        # Start the daemon
+# Or start everything (daemon + web + API + MCP):
+aby start
 ```
 
 ## Configuration
@@ -70,11 +66,8 @@ Configuration is managed through the **web dashboard**, not VS Code settings.
 ### Start the Web Dashboard
 
 ```bash
-# If daemon is already running:
-node dist/index.js web
-
-# Or start both daemon and web server:
-node dist/index.js web
+aby web           # Start web dashboard
+aby start         # Or start everything at once
 ```
 
 Open http://localhost:8787 to:
@@ -96,14 +89,16 @@ Example config:
 ```yaml
 providers:
   openai:
+    engine: openai
     api_key_keychain_name: "OPENAI_API_KEY"
-    enabled_models:
-      - gpt-4o
-      - gpt-4o-mini
+    models:
+      gpt-4o: {}
+      gpt-4o-mini: {}
   anthropic:
+    engine: anthropic
     api_key_env_var_name: "ANTHROPIC_API_KEY"
-    enabled_models:
-      - claude-3-5-sonnet-20241022
+    models:
+      claude-sonnet-4-20250514: {}
 ```
 
 ## Commands
@@ -122,7 +117,7 @@ providers:
 | Anthropic | ✓ | ✓ | ✓ |
 | Google Gemini | ✓ | ✓ | ✓ |
 | Mistral | ✓ | ✗ | ✓ |
-| Ollama | ✗ | ✗ | ✓ |
+| Ollama | ✓ | ✗ | ✓ |
 | Azure OpenAI | ✓ | ✓ | ✓ |
 | OpenRouter | ✓ | ✓ | ✓ |
 | DeepSeek | ✓ | ✗ | ✓ |
@@ -206,9 +201,8 @@ npm run package
 
 3. Restart daemon:
    ```bash
-   pkill -f "node.*abbenay"
-   rm -f /run/user/$(id -u)/abbenay/daemon.sock
-   cd packages/daemon && node dist/index.js daemon
+   aby stop
+   aby daemon
    ```
 
 4. Check Output panel: View → Output → "Abbenay Provider"

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -51,17 +51,21 @@ code --install-extension abbenay-provider-0.1.0.vsix
 
 ### Prerequisites
 
-The Abbenay daemon must be running:
+The Abbenay daemon must be running. If installed via npm:
 
 ```bash
 aby daemon        # Start the daemon
-# Or start everything (daemon + web + API + MCP):
-aby start
+aby start         # Or start everything (daemon + web + API + MCP)
 ```
+
+If using the standalone SEA binary, use `./abbenay-daemon daemon` (or
+rename/symlink to `aby`).
 
 ## Configuration
 
-Configuration is managed through the **web dashboard**, not VS Code settings.
+Provider and model configuration is managed through the **web dashboard**,
+not VS Code settings. The extension contributes only `abbenay.logLevel`
+as a VS Code setting.
 
 ### Start the Web Dashboard
 


### PR DESCRIPTION
## Summary

- Add `docs/GETTING_STARTED.md` — complete 10-step walkthrough from install to CLI chat, sessions, OpenAI API, MCP, and VS Code integration
- Update `README.md` with expanded Quick Start (aby start, sessions, serve, OpenAI API), updated feature list, and new doc links
- Fix `docs/LANDSCAPE.md` — correct engine count (19), OpenAI-compat API now "Yes", add session persistence row
- Fix `docs/PRODUCT_OVERVIEW.md` — mark Session Continuity as Complete, add new component sections
- Fix `docs/ARCHITECTURE.md` — move implemented RPCs out of stub section
- Fix `packages/vscode/README.md` — correct config format, Ollama tool support, use aby commands

## Test plan

- [x] No code changes — documentation only
- [x] All links and references verified against current codebase