### PR TITLE
fix(daemon): strip markdown fences from json_strict responses

### DIFF
--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -834,8 +834,31 @@ function mergeParams(
 }
 
 /**
+ * Strip markdown code fences and leading prose from an LLM response
+ * so that the inner JSON can be parsed. Returns the original string
+ * unchanged if no fences are detected.
+ *
+ * @internal Exported for testing.
+ */
+export function stripJsonFences(raw: string): string {
+  let cleaned = raw.trim();
+
+  if (cleaned.startsWith('```')) {
+    const lines = cleaned.split('\n');
+    lines.shift();
+    if (lines.length && lines[lines.length - 1].trim() === '```') {
+      lines.pop();
+    }
+    cleaned = lines.join('\n').trim();
+  }
+
+  return cleaned;
+}
+
+/**
  * Stream chat with JSON validation and retry.
- * Buffers the full response, attempts JSON.parse(), and retries once on failure.
+ * Buffers the full response, strips markdown fences, then attempts
+ * JSON.parse().  Only retries if the cleaned content is still invalid.
  */
 async function* streamChatWithJsonRetry(
   engine: string,
@@ -859,14 +882,29 @@ async function* streamChatWithJsonRetry(
     }
   }
 
+  const cleaned = stripJsonFences(fullText);
+
   try {
-    JSON.parse(fullText.trim());
-    for (const chunk of buffered) {
-      yield chunk;
+    JSON.parse(cleaned);
+
+    if (cleaned !== fullText) {
+      // Fences were stripped — re-emit as a single cleaned text chunk
+      // plus any non-text chunks (tool_call, done, etc.)
+      console.log(`[State] json_strict: stripped markdown fences from response (${fullText.length} → ${cleaned.length} chars)`);
+      for (const chunk of buffered) {
+        if (chunk.type !== 'text') {
+          yield chunk;
+        }
+      }
+      yield { type: 'text', text: cleaned };
+    } else {
+      for (const chunk of buffered) {
+        yield chunk;
+      }
     }
     return;
   } catch {
-    console.warn(`[State] json_strict: response is not valid JSON (${fullText.length} chars). Retrying once.`);
+    console.warn(`[State] json_strict: response is not valid JSON (${cleaned.length} chars). Retrying once.`);
   }
 
   const retryMessages = [

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -834,9 +834,10 @@ function mergeParams(
 }
 
 /**
- * Strip markdown code fences and leading prose from an LLM response
- * so that the inner JSON can be parsed. Returns the original string
- * unchanged if no fences are detected.
+ * Strip markdown code fences from an LLM response so that the inner
+ * JSON can be parsed.  Trims whitespace and removes a leading
+ * ` ```json ` / ` ``` ` fence pair.  Returns the original string
+ * (trimmed) when no fences are detected.
  *
  * @internal Exported for testing.
  */
@@ -888,15 +889,18 @@ async function* streamChatWithJsonRetry(
     JSON.parse(cleaned);
 
     if (cleaned !== fullText) {
-      // Fences were stripped — re-emit as a single cleaned text chunk
-      // plus any non-text chunks (tool_call, done, etc.)
-      console.log(`[State] json_strict: stripped markdown fences from response (${fullText.length} → ${cleaned.length} chars)`);
+      debug(`[State] json_strict: stripped markdown fences from response (${fullText.length} → ${cleaned.length} chars)`);
+      let emittedText = false;
       for (const chunk of buffered) {
-        if (chunk.type !== 'text') {
+        if (chunk.type === 'text') {
+          if (!emittedText) {
+            yield { type: 'text', text: cleaned };
+            emittedText = true;
+          }
+        } else {
           yield chunk;
         }
       }
-      yield { type: 'text', text: cleaned };
     } else {
       for (const chunk of buffered) {
         yield chunk;

--- a/packages/daemon/src/daemon/state.ts
+++ b/packages/daemon/src/daemon/state.ts
@@ -17,8 +17,9 @@ import { AbbenayMcpServer } from './mcp-server.js';
 import { SessionStore } from '../core/session-store.js';
 import { getSessionsDir } from '../core/paths.js';
 
-// Re-export core types needed by daemon consumers (gRPC service, web server)
+// Re-export core types and utilities needed by daemon consumers (gRPC service, web server)
 export type { ChatToolOptions, ProviderInfo, ModelInfo } from '../core/state.js';
+export { stripJsonFences } from '../core/state.js';
 export type { ChatChunk, ChatParams, ToolDefinition, ToolExecutor, EngineInfo, DiscoveredModel } from '../core/engines.js';
 export type { ConfigFile, ProviderConfig, ModelConfig } from '../core/config.js';
 export type { SecretStore } from '../core/secrets.js';

--- a/packages/daemon/src/daemon/state.ts
+++ b/packages/daemon/src/daemon/state.ts
@@ -17,9 +17,8 @@ import { AbbenayMcpServer } from './mcp-server.js';
 import { SessionStore } from '../core/session-store.js';
 import { getSessionsDir } from '../core/paths.js';
 
-// Re-export core types and utilities needed by daemon consumers (gRPC service, web server)
+// Re-export core types needed by daemon consumers (gRPC service, web server)
 export type { ChatToolOptions, ProviderInfo, ModelInfo } from '../core/state.js';
-export { stripJsonFences } from '../core/state.js';
 export type { ChatChunk, ChatParams, ToolDefinition, ToolExecutor, EngineInfo, DiscoveredModel } from '../core/engines.js';
 export type { ConfigFile, ProviderConfig, ModelConfig } from '../core/config.js';
 export type { SecretStore } from '../core/secrets.js';

--- a/packages/daemon/src/state.test.ts
+++ b/packages/daemon/src/state.test.ts
@@ -86,7 +86,8 @@ vi.mock('./daemon/secrets/keychain.js', () => ({
 
 // ── Import DaemonState (after mocks) ─────────────────────────────────────────
 
-import { DaemonState, ClientType, stripJsonFences } from './daemon/state.js';
+import { DaemonState, ClientType } from './daemon/state.js';
+import { stripJsonFences } from './core/state.js';
 import { protoToPolicyConfig, authorizeInlinePolicy, authorizeMcpRegister } from './daemon/server/abbenay-service.js';
 import * as grpc from '@grpc/grpc-js';
 

--- a/packages/daemon/src/state.test.ts
+++ b/packages/daemon/src/state.test.ts
@@ -86,7 +86,7 @@ vi.mock('./daemon/secrets/keychain.js', () => ({
 
 // ── Import DaemonState (after mocks) ─────────────────────────────────────────
 
-import { DaemonState, ClientType } from './daemon/state.js';
+import { DaemonState, ClientType, stripJsonFences } from './daemon/state.js';
 import { protoToPolicyConfig, authorizeInlinePolicy, authorizeMcpRegister } from './daemon/server/abbenay-service.js';
 import * as grpc from '@grpc/grpc-js';
 
@@ -604,6 +604,138 @@ describe('DaemonState.chat inline policy', () => {
   });
 });
 
+// ── json_strict fence stripping (streamChatWithJsonRetry) ────────────────────
+
+describe('DaemonState.chat json_strict fence stripping', () => {
+  const jsonPayload = '{"patches": [1, 2, 3]}';
+
+  function makeJsonStrictConfig(): ConfigFile {
+    return {
+      providers: {
+        'my-mock': {
+          engine: 'mock',
+          models: { 'json-model': {} },
+        },
+      },
+    };
+  }
+
+  const jsonStrictPolicy = {
+    output: { format: 'json_only' as const },
+    reliability: { retry_on_invalid_json: true },
+  };
+
+  beforeEach(() => {
+    const cfg = makeJsonStrictConfig();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockMergeConfigs.mockReturnValue(cfg);
+  });
+
+  it('should accept fenced JSON without retrying', async () => {
+    async function* fencedStream(): AsyncGenerator<{ type: string; text?: string; finishReason?: string }> {
+      yield { type: 'text', text: `\`\`\`json\n${jsonPayload}\n\`\`\`` };
+      yield { type: 'done', finishReason: 'stop' };
+    }
+    mockStreamChat.mockReturnValue(fencedStream());
+
+    const chunks = [];
+    for await (const chunk of state.chat(
+      'my-mock/json-model',
+      [{ role: 'user', content: 'give me json' }],
+      undefined,
+      undefined,
+      undefined,
+      jsonStrictPolicy,
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(mockStreamChat).toHaveBeenCalledTimes(1);
+    const textChunks = chunks.filter(c => c.type === 'text');
+    const fullText = textChunks.map(c => c.text).join('');
+    expect(() => JSON.parse(fullText)).not.toThrow();
+    expect(JSON.parse(fullText)).toEqual(JSON.parse(jsonPayload));
+  });
+
+  it('should pass clean JSON through without modification', async () => {
+    async function* cleanStream(): AsyncGenerator<{ type: string; text?: string; finishReason?: string }> {
+      yield { type: 'text', text: jsonPayload };
+      yield { type: 'done', finishReason: 'stop' };
+    }
+    mockStreamChat.mockReturnValue(cleanStream());
+
+    const chunks = [];
+    for await (const chunk of state.chat(
+      'my-mock/json-model',
+      [{ role: 'user', content: 'give me json' }],
+      undefined,
+      undefined,
+      undefined,
+      jsonStrictPolicy,
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(mockStreamChat).toHaveBeenCalledTimes(1);
+    const textChunks = chunks.filter(c => c.type === 'text');
+    const fullText = textChunks.map(c => c.text).join('');
+    expect(fullText).toBe(jsonPayload);
+  });
+
+  it('should still retry when response is genuinely invalid JSON', async () => {
+    let callCount = 0;
+    async function* invalidStream(): AsyncGenerator<{ type: string; text?: string; finishReason?: string }> {
+      callCount++;
+      if (callCount === 1) {
+        yield { type: 'text', text: 'Sure! Here is the data {broken' };
+      } else {
+        yield { type: 'text', text: jsonPayload };
+      }
+      yield { type: 'done', finishReason: 'stop' };
+    }
+    mockStreamChat.mockImplementation(() => invalidStream());
+
+    const chunks = [];
+    for await (const chunk of state.chat(
+      'my-mock/json-model',
+      [{ role: 'user', content: 'give me json' }],
+      undefined,
+      undefined,
+      undefined,
+      jsonStrictPolicy,
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(mockStreamChat).toHaveBeenCalledTimes(2);
+  });
+
+  it('should accept bare-fenced (no language tag) JSON without retrying', async () => {
+    async function* bareFencedStream(): AsyncGenerator<{ type: string; text?: string; finishReason?: string }> {
+      yield { type: 'text', text: `\`\`\`\n${jsonPayload}\n\`\`\`` };
+      yield { type: 'done', finishReason: 'stop' };
+    }
+    mockStreamChat.mockReturnValue(bareFencedStream());
+
+    const chunks = [];
+    for await (const chunk of state.chat(
+      'my-mock/json-model',
+      [{ role: 'user', content: 'give me json' }],
+      undefined,
+      undefined,
+      undefined,
+      jsonStrictPolicy,
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(mockStreamChat).toHaveBeenCalledTimes(1);
+    const textChunks = chunks.filter(c => c.type === 'text');
+    const fullText = textChunks.map(c => c.text).join('');
+    expect(JSON.parse(fullText)).toEqual(JSON.parse(jsonPayload));
+  });
+});
+
 // ── runHealthChecks ──────────────────────────────────────────────────────────
 
 describe('DaemonState.runHealthChecks', () => {
@@ -886,5 +1018,58 @@ describe('authorizeMcpRegister', () => {
       if (prev === undefined) delete process.env.TEST_TOKEN;
       else process.env.TEST_TOKEN = prev;
     }
+  });
+});
+
+// ── stripJsonFences ──────────────────────────────────────────────────────────
+
+describe('stripJsonFences', () => {
+  it('should pass through valid JSON unchanged', () => {
+    const json = '{"patches": [1, 2, 3]}';
+    expect(stripJsonFences(json)).toBe(json);
+  });
+
+  it('should strip ```json ... ``` fences', () => {
+    const fenced = '```json\n{"patches": [1, 2, 3]}\n```';
+    expect(stripJsonFences(fenced)).toBe('{"patches": [1, 2, 3]}');
+  });
+
+  it('should strip bare ``` ... ``` fences (no language tag)', () => {
+    const fenced = '```\n{"key": "value"}\n```';
+    expect(stripJsonFences(fenced)).toBe('{"key": "value"}');
+  });
+
+  it('should handle leading/trailing whitespace around fences', () => {
+    const fenced = '  \n```json\n[1, 2, 3]\n```\n  ';
+    expect(stripJsonFences(fenced)).toBe('[1, 2, 3]');
+  });
+
+  it('should handle multiline JSON inside fences', () => {
+    const inner = '{\n  "a": 1,\n  "b": [2, 3]\n}';
+    const fenced = `\`\`\`json\n${inner}\n\`\`\``;
+    expect(stripJsonFences(fenced)).toBe(inner);
+  });
+
+  it('should handle fences with only an opening (no closing) gracefully', () => {
+    const partial = '```json\n{"key": "value"}';
+    const result = stripJsonFences(partial);
+    expect(result).toBe('{"key": "value"}');
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('should trim whitespace from non-fenced input', () => {
+    const padded = '  \n{"key": "value"}\n  ';
+    expect(stripJsonFences(padded)).toBe('{"key": "value"}');
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(stripJsonFences('')).toBe('');
+    expect(stripJsonFences('   ')).toBe('');
+  });
+
+  it('should not strip fences that appear mid-content', () => {
+    const prose = 'Here is the JSON:\n```json\n{"a":1}\n```\nDone.';
+    // Leading text means this doesn't start with ```, so no stripping
+    expect(stripJsonFences(prose)).toBe(prose.trim());
   });
 });


### PR DESCRIPTION
## Summary

- Adds `stripJsonFences()` to remove markdown code fences (` ```json...``` ` and bare ` ```...``` `) from LLM responses before JSON validation in the `json_strict` path.
- Fenced-but-valid JSON is now accepted on the first attempt, eliminating unnecessary retries that were doubling LLM costs and latency for `json_only` consumers (observed in APME testing: 18 calls instead of 9).
- When fences are stripped, the cleaned JSON is re-emitted to the consumer; genuinely malformed responses still trigger a retry as before.

## Test plan

- [x] 9 unit tests for `stripJsonFences`: plain passthrough, `json` fences, bare fences, whitespace, multiline, unclosed fences, empty input, mid-content fences
- [x] 4 integration tests for `streamChatWithJsonRetry`: fenced JSON accepted without retry, clean JSON unchanged, invalid JSON still retried, bare-fenced JSON accepted
- [x] Full build (`npm run ci:build`) passes
- [x] All 319 tests pass
- [x] Lint and audit pass (`prek pre-commit`)


Made with [Cursor](https://cursor.com)