### PR TITLE
feat(daemon): add container support with gRPC TCP listener

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,32 @@
+# Build output
+dist/
+packages/daemon/dist/
+packages/vscode/bin/
+
+# Downloaded build tools (re-installed in builder stage)
+.build-tools/
+node_modules/
+
+# Python
+.venv/
+.build-venv/
+__pycache__/
+*.egg-info/
+
+# VS Code extension artifacts
+*.vsix
+.vscode-test/
+
+# Git and editor
+.git/
+.gitignore
+.DS_Store
+
+# Design docs and RFEs
+DESIGN-*.md
+RFE-*.md
+
+# CI / IDE
+.github/
+.cursor/
+.codex/

--- a/Containerfile
+++ b/Containerfile
@@ -34,7 +34,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG APP_USER=abbenay
 ARG APP_UID=1001
 
-RUN microdnf install -y shadow-utils && \
+RUN microdnf install -y shadow-utils curl-minimal && \
     useradd -u ${APP_UID} -m ${APP_USER} && \
     microdnf clean all
 
@@ -60,4 +60,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -sf http://localhost:8787/api/health || exit 1
 
 ENTRYPOINT ["./abbenay"]
-CMD ["start", "--port", "8787", "--grpc-port", "50051"]
+CMD ["start", "--port", "8787", "--grpc-port", "50051", "--grpc-host", "0.0.0.0"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,63 @@
+# Abbenay — Multi-stage container build
+#
+# Build:   podman build -f Containerfile -t abbenay:latest .
+# Run:     podman run -d -p 8787:8787 \
+#            -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+#            -e OPENROUTER_API_KEY=sk-... \
+#            abbenay:latest
+#
+# See docs/CONTAINER.md for full documentation.
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build the SEA binary and sidecars
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS builder
+
+USER 0
+
+# Install protobuf compiler and Python for proto generation
+RUN dnf install -y --nodocs protobuf-compiler python3 python3-pip && \
+    dnf clean all
+
+WORKDIR /build
+COPY . .
+
+RUN npm ci --ignore-scripts && \
+    npx node-gyp rebuild --directory node_modules/keytar 2>/dev/null || true && \
+    node build.js
+
+# ---------------------------------------------------------------------------
+# Stage 2: Minimal runtime image
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG APP_USER=abbenay
+ARG APP_UID=1001
+
+RUN microdnf install -y shadow-utils && \
+    useradd -u ${APP_UID} -m ${APP_USER} && \
+    microdnf clean all
+
+WORKDIR /opt/abbenay
+
+# Copy SEA binary and required sidecars (proto + static assets).
+# keytar.node is intentionally excluded — it requires D-Bus / libsecret
+# which are unavailable in containers.  Use api_key_env_var_name in config
+# instead of api_key_keychain_name.
+COPY --from=builder /build/packages/daemon/dist/sea/abbenay-daemon-linux-x64 ./abbenay
+COPY --from=builder /build/packages/daemon/dist/sea/proto/ ./proto/
+COPY --from=builder /build/packages/daemon/dist/sea/static/ ./static/
+
+RUN chmod 755 ./abbenay && \
+    mkdir -p /home/${APP_USER}/.config/abbenay && \
+    chown -R ${APP_USER}:${APP_USER} /home/${APP_USER}
+
+USER ${APP_USER}
+
+EXPOSE 8787 50051
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -sf http://localhost:8787/api/health || exit 1
+
+ENTRYPOINT ["./abbenay"]
+CMD ["start", "--port", "8787", "--grpc-port", "50051"]

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ abbenay/
 - [Core Library (API Reference)](docs/CORE.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Configuration](docs/CONFIGURATION.md)
+- [Container Deployment](docs/CONTAINER.md)
 - [Development Guide](docs/DEVELOPMENT.md)
 - [Testing](docs/TESTING.md)
 - [Roadmap](docs/ROADMAP.md)

--- a/RFE-json-format-fence-stripping.md
+++ b/RFE-json-format-fence-stripping.md
@@ -1,0 +1,99 @@
+# RFE: json_only Format Should Accept Fenced JSON
+
+**Filed by**: APME integration testing  
+**Priority**: Medium — causes double LLM calls on every request  
+**Component**: `packages/daemon` (policy enforcement / output format)
+
+---
+
+## Summary
+
+The `json_only` output format policy rejects valid JSON responses that are
+wrapped in markdown code fences. Most LLMs (including Claude) habitually
+wrap JSON responses in `` ```json ... ``` `` fences even when explicitly
+instructed not to. This causes every request to fail validation and retry,
+doubling LLM costs and latency.
+
+---
+
+## Current Behavior
+
+When a consumer sends a policy with `output.format: "json_only"`:
+
+1. LLM returns: `` ```json\n{"patches": [...]}\n``` ``
+2. Abbenay's `json_strict` validator rejects it ("not valid JSON")
+3. If `retry_on_invalid_json: true`, Abbenay retries the same prompt
+4. Second attempt may or may not include fences (non-deterministic)
+5. If it passes, the response is forwarded to the consumer
+
+From the daemon logs during APME testing (9 sequential batch calls):
+
+```
+[State] json_strict: response is not valid JSON (14820 chars). Retrying once.
+[State] json_strict: response is not valid JSON (14234 chars). Retrying once.
+[State] json_strict: response is not valid JSON (10248 chars). Retrying once.
+... (all 9 chunks required retries)
+```
+
+**Result**: 18 LLM calls instead of 9, ~$2.16 instead of ~$1.08, ~10
+minutes instead of ~5 minutes.
+
+---
+
+## Proposed Behavior
+
+Before running JSON validation, strip common LLM response wrappers:
+
+1. Leading/trailing whitespace
+2. Markdown code fences: `` ```json ... ``` `` or `` ``` ... ``` ``
+3. Optional: leading prose before the first `{` or `[`
+
+Then validate the cleaned content as JSON.
+
+### Suggested implementation
+
+```typescript
+function cleanJsonResponse(raw: string): string {
+  let cleaned = raw.trim();
+
+  // Strip markdown fences
+  if (cleaned.startsWith('```')) {
+    const lines = cleaned.split('\n');
+    // Remove first line (```json or ```)
+    lines.shift();
+    // Remove last line if it's ```)
+    if (lines.length && lines[lines.length - 1].trim() === '```') {
+      lines.pop();
+    }
+    cleaned = lines.join('\n').trim();
+  }
+
+  return cleaned;
+}
+```
+
+This should be applied in the `json_strict` validator before
+`JSON.parse()`, so the retry is only triggered for genuinely malformed
+responses.
+
+---
+
+## Impact
+
+- Cuts LLM call count in half for `json_only` consumers
+- Halves latency and cost for JSON-heavy workflows
+- No change needed on the consumer side
+- Backward compatible — responses that are already valid JSON pass through
+  unchanged
+
+---
+
+## Alternatives Considered
+
+**Consumer-side workaround**: APME can drop `json_only` from the policy and
+parse JSON itself (including fence stripping). This works but defeats the
+purpose of server-side format enforcement and pushes validation burden to
+every consumer.
+
+**New format mode**: Add `json_lenient` alongside `json_only` that accepts
+fenced JSON. This preserves strict mode for consumers that want it.

--- a/RFE-python-client-packaging.md
+++ b/RFE-python-client-packaging.md
@@ -1,0 +1,193 @@
+# RFE: Python Client Packaging Issues
+
+**Filed by**: APME integration testing  
+**Priority**: High — blocks clean consumer integration  
+**Component**: `packages/python` (`abbenay-client` / `abbenay_grpc`)
+
+---
+
+## Summary
+
+The `abbenay_grpc` Python client has several packaging issues that force
+consumers to apply non-standard workarounds to import and use it correctly.
+These were discovered during APME's AI escalation integration.
+
+---
+
+## Issue 1: Generated proto stubs use absolute imports from wrong root
+
+**Problem**
+
+`proto/generate.sh` runs `protoc --python_out` with the output directory set
+to `packages/python/src/abbenay_grpc/`. This produces generated stubs like:
+
+```python
+# service_pb2_grpc.py (generated)
+from abbenay.v1 import service_pb2 as abbenay_dot_v1_dot_service__pb2
+```
+
+This is an **absolute import from `abbenay.v1`**, which only resolves if
+`abbenay_grpc/` itself is on `sys.path`. But when the package is installed
+via pip, `site-packages/` is on `sys.path`, so Python looks for
+`abbenay.v1` at `site-packages/abbenay/v1/` — which doesn't exist. The
+actual location is `site-packages/abbenay_grpc/abbenay/v1/`.
+
+**Current workaround in APME**
+
+```python
+spec = importlib.util.find_spec("abbenay_grpc")
+if spec and spec.submodule_search_locations:
+    pkg_dir = spec.submodule_search_locations[0]
+    if pkg_dir not in sys.path:
+        sys.path.insert(0, pkg_dir)
+importlib.reload(abbenay_grpc.client)
+```
+
+This pollutes `sys.path` and can cause import conflicts.
+
+**Recommended fix**
+
+Change the protoc invocation to generate imports relative to `site-packages/`
+by adjusting the proto path or output directory so stubs import from
+`abbenay_grpc.abbenay.v1` instead of `abbenay.v1`. Two approaches:
+
+**Option A**: Use `--proto_path` set one level higher and adjust the output:
+
+```bash
+python -m grpc_tools.protoc \
+    -I "$ROOT_DIR/packages/python/src" \
+    --python_out="$ROOT_DIR/packages/python/src" \
+    --pyi_out="$ROOT_DIR/packages/python/src" \
+    --grpc_python_out="$ROOT_DIR/packages/python/src" \
+    "$PROTO_DIR/abbenay/v1/service.proto"
+```
+
+This would require restructuring the proto source to mirror the Python
+package layout, or post-processing the generated imports.
+
+**Option B**: Post-process generated files to rewrite imports:
+
+```bash
+sed -i 's/from abbenay\./from abbenay_grpc.abbenay./g' \
+    "$PYTHON_OUT/abbenay/v1/service_pb2_grpc.py"
+```
+
+**Option C**: Use `grpc_tools.protoc` with a custom plugin or
+`grpcio-tools`' `--grpc_python_out` option that supports
+`grpc_package_prefix` (if available in newer versions).
+
+---
+
+## Issue 2: gRPC `aio` channel bound to event loop lifecycle
+
+**Problem**
+
+`AbbenayClient` uses `grpc.aio` channels internally. These channels are
+bound to the asyncio event loop that was active when `connect()` was called.
+If a consumer calls `asyncio.run()` (which creates and closes a loop) for
+a preflight check, then later calls `asyncio.run()` again for the main
+workload, the channel is dead:
+
+```
+RuntimeError: Event loop is closed
+```
+
+This is a fundamental property of `grpc.aio`, but the client API doesn't
+surface it. Consumers must manually recreate the client + reconnect when
+crossing event loop boundaries.
+
+**Current workaround in APME**
+
+```python
+class AbbenayProvider:
+    async def reconnect(self) -> None:
+        self._client = AbbenayClient(socket_path=...)
+        await self._client.connect()
+```
+
+**Recommended fix**
+
+Add a `reconnect()` or `reset()` method to `AbbenayClient` that discards
+the old channel and creates a fresh one. Alternatively, support lazy
+connection (connect on first RPC call) so the channel is always created in
+the caller's event loop. Example:
+
+```python
+class AbbenayClient:
+    async def reconnect(self) -> None:
+        """Discard existing channel and reconnect."""
+        if self._channel:
+            await self._channel.close()
+        self._channel = grpc.aio.insecure_channel(self._target)
+        self._stub = grpc_service.AbbenayServiceStub(self._channel)
+```
+
+Or make `connect()` idempotent — if the channel is dead, recreate it.
+
+---
+
+## Issue 3: `client.py` try/except swallows ImportError silently
+
+**Problem**
+
+```python
+try:
+    from .abbenay.v1 import service_pb2 as proto
+    from .abbenay.v1 import service_pb2_grpc as grpc_service
+except ImportError:
+    proto = None
+    grpc_service = None
+```
+
+When stubs fail to import (due to Issue 1), `proto` is silently set to
+`None`. The error only surfaces later as `AbbenayError: gRPC stubs not
+generated` during `connect()`, which is misleading — the stubs *are*
+generated, the import path is just wrong.
+
+**Recommended fix**
+
+Either:
+- Raise immediately on ImportError with a clear message about the actual
+  cause (import path mismatch, not missing stubs).
+- Or log a warning at import time so the root cause is visible:
+
+```python
+except ImportError as e:
+    import warnings
+    warnings.warn(
+        f"Failed to import gRPC stubs: {e}. "
+        f"This usually means the protobuf imports use the wrong package prefix. "
+        f"See: https://github.com/abbenay/abbenay/issues/XXX"
+    )
+    proto = None
+    grpc_service = None
+```
+
+---
+
+## Issue 4: Package name vs import name mismatch
+
+**Problem**
+
+The package is published as `abbenay-client` (pip name) but the import
+is `abbenay_grpc`. This is a minor ergonomic issue but can confuse
+consumers:
+
+```
+pip install abbenay-client    # installs the package
+import abbenay_grpc           # but this is the import name
+```
+
+**Recommendation**
+
+Either align them (e.g., both `abbenay-grpc`) or document the mapping
+prominently in the README.
+
+---
+
+## Impact on APME
+
+These issues required ~100 lines of workaround code in APME's
+`abbenay_provider.py` (dynamic `sys.path` manipulation, `importlib.reload`,
+manual client recreation). Fixing Issue 1 alone would eliminate most of
+this complexity.

--- a/config.container.example.yaml
+++ b/config.container.example.yaml
@@ -1,0 +1,63 @@
+# Abbenay — Container Configuration Example
+#
+# This config is designed for container deployments where the system
+# keychain is unavailable.  All API keys are read from environment
+# variables (api_key_env_var_name) instead of keytar (api_key_keychain_name).
+#
+# Mount this file into the container at:
+#   /home/abbenay/.config/abbenay/config.yaml
+#
+# Pass the referenced env vars when starting the container:
+#   podman run -d \
+#     -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+#     -e OPENROUTER_API_KEY=sk-or-... \
+#     -p 8787:8787 \
+#     abbenay:latest
+#
+# See docs/CONTAINER.md for full documentation.
+
+providers:
+  # ── OpenRouter (access to many providers via a single key) ───────────
+  openrouter:
+    engine: openrouter
+    api_key_env_var_name: "OPENROUTER_API_KEY"
+    models:
+      anthropic/claude-sonnet-4: {}
+      anthropic/claude-haiku-3.5: {}
+      google/gemini-2.5-pro-preview: {}
+
+  # ── Direct provider access ──────────────────────────────────────────
+  # Uncomment and configure as needed.
+
+  # anthropic:
+  #   engine: anthropic
+  #   api_key_env_var_name: "ANTHROPIC_API_KEY"
+  #   models:
+  #     claude-sonnet-4-20250514: {}
+
+  # openai:
+  #   engine: openai
+  #   api_key_env_var_name: "OPENAI_API_KEY"
+  #   models:
+  #     gpt-4o: {}
+  #     gpt-4o-mini: {}
+
+  # ── Local models (no API key required) ──────────────────────────────
+  # To reach Ollama from inside the container, use the host network
+  # address or run with --network=host.
+
+  # ollama:
+  #   engine: ollama
+  #   base_url: "http://host.containers.internal:11434"
+  #   models:
+  #     llama3.2: {}
+
+# ── Consumer authentication (optional) ────────────────────────────────
+# Uncomment to require tokens for programmatic clients.
+
+# consumers:
+#   apme:
+#     token_env: "APME_TOKEN"
+#     capabilities:
+#       inline_policy: true
+#       mcp_register: true

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -1,0 +1,294 @@
+# Running Abbenay in a Container
+
+This guide covers building and running Abbenay as a container image using
+the provided `Containerfile`.
+
+---
+
+## Overview
+
+The container packages the Abbenay SEA binary into a minimal UBI 9 image.
+The `start` command runs all services:
+
+| Service | Endpoint |
+|---------|----------|
+| Web dashboard | `http://localhost:8787` |
+| REST API | `http://localhost:8787/api/*` |
+| OpenAI-compatible API | `http://localhost:8787/v1/chat/completions` |
+| MCP server | `http://localhost:8787/mcp` (when `--mcp` is passed) |
+| gRPC (TCP) | `localhost:50051` (for Python/programmatic clients) |
+
+### What's different from bare-metal
+
+- **No keytar / keychain.** The container has no D-Bus session or
+  gnome-keyring, so `api_key_keychain_name` will not work. Use
+  `api_key_env_var_name` in your config and pass keys as environment
+  variables.
+- **Config is mounted, not baked in.** Bind-mount your `config.yaml`
+  into the container at runtime.
+
+---
+
+## Building the image
+
+```bash
+podman build -f Containerfile -t abbenay:latest .
+```
+
+The multi-stage build compiles the SEA binary in a Node.js builder stage
+and copies only the binary and its sidecars (`proto/`, `static/`) into a
+UBI 9 minimal runtime image. The final image contains no Node.js, npm,
+or build tooling.
+
+---
+
+## Configuration
+
+Create a `config.yaml` that uses `api_key_env_var_name` instead of
+`api_key_keychain_name`. A ready-to-use example is provided at
+[`config.container.example.yaml`](../config.container.example.yaml)
+in the repo root.
+
+Minimal example:
+
+```yaml
+providers:
+  openrouter:
+    engine: openrouter
+    api_key_env_var_name: "OPENROUTER_API_KEY"
+    models:
+      anthropic/claude-sonnet-4: {}
+      anthropic/claude-haiku-3.5: {}
+```
+
+Mount this file into the container at:
+
+```
+/home/abbenay/.config/abbenay/config.yaml
+```
+
+---
+
+## Running
+
+```bash
+podman run -d --name abbenay \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  -p 8787:8787 \
+  -p 50051:50051 \
+  abbenay:latest
+```
+
+With consumer authentication (for programmatic clients like APME):
+
+```bash
+podman run -d --name abbenay \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  -e APME_TOKEN=secret123 \
+  -p 8787:8787 \
+  -p 50051:50051 \
+  abbenay:latest
+```
+
+### Verify it's running
+
+```bash
+curl http://localhost:8787/api/health
+```
+
+### View logs
+
+```bash
+podman logs -f abbenay
+```
+
+---
+
+## Overriding the command
+
+The default `CMD` is `start --port 8787`, which runs all services. You
+can override it to run a subset:
+
+```bash
+# Web dashboard and REST API only
+podman run -d -p 8787:8787 \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  abbenay:latest web --port 8787
+
+# OpenAI-compatible API only
+podman run -d -p 8787:8787 \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  abbenay:latest serve --port 8787
+
+# gRPC daemon only (no HTTP port needed)
+podman run -d \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  abbenay:latest daemon
+```
+
+---
+
+## Multiple providers
+
+Pass one environment variable per provider key:
+
+```bash
+podman run -d --name abbenay \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e OPENAI_API_KEY=sk-... \
+  -p 8787:8787 \
+  abbenay:latest
+```
+
+Your `config.yaml` references these by name:
+
+```yaml
+providers:
+  openrouter:
+    engine: openrouter
+    api_key_env_var_name: "OPENROUTER_API_KEY"
+    models: { ... }
+  anthropic:
+    engine: anthropic
+    api_key_env_var_name: "ANTHROPIC_API_KEY"
+    models: { ... }
+  openai:
+    engine: openai
+    api_key_env_var_name: "OPENAI_API_KEY"
+    models: { ... }
+```
+
+---
+
+## Python gRPC client
+
+When the daemon runs in a container, the Python client connects via TCP
+instead of the Unix socket:
+
+```python
+from abbenay_grpc import AbbenayClient
+
+# Connect to containerized daemon via TCP
+async with AbbenayClient(host="localhost", port=50051) as client:
+    async for chunk in client.chat("openrouter/anthropic/claude-sonnet-4", "Hello!"):
+        if chunk.text:
+            print(chunk.text, end="")
+```
+
+The `is_daemon_running()` and `get_daemon_pid()` convenience methods
+check the local filesystem and do not apply to remote connections. Use
+`health_check()` instead:
+
+```python
+client = AbbenayClient(host="container-host", port=50051)
+await client.connect()
+healthy = await client.health_check()
+```
+
+---
+
+## Kubernetes / OpenShift
+
+### Deployment with mounted Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: abbenay-keys
+type: Opaque
+stringData:
+  OPENROUTER_API_KEY: "sk-or-..."
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: abbenay-config
+data:
+  config.yaml: |
+    providers:
+      openrouter:
+        engine: openrouter
+        api_key_env_var_name: "OPENROUTER_API_KEY"
+        models:
+          anthropic/claude-sonnet-4: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abbenay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: abbenay
+  template:
+    metadata:
+      labels:
+        app: abbenay
+    spec:
+      containers:
+        - name: abbenay
+          image: abbenay:latest
+          ports:
+            - containerPort: 8787
+              name: http
+            - containerPort: 50051
+              name: grpc
+          envFrom:
+            - secretRef:
+                name: abbenay-keys
+          volumeMounts:
+            - name: config
+              mountPath: /home/abbenay/.config/abbenay/config.yaml
+              subPath: config.yaml
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 8787
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 8787
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: abbenay-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: abbenay
+spec:
+  selector:
+    app: abbenay
+  ports:
+    - name: http
+      port: 8787
+      targetPort: 8787
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+```
+
+### Notes
+
+- The image runs as non-root user `abbenay` (UID 1001), compatible with
+  OpenShift's restricted SCC.
+- The built-in `HEALTHCHECK` uses `curl` against `/api/health`. In
+  Kubernetes, use the `livenessProbe` and `readinessProbe` shown above
+  instead.
+- Sessions are ephemeral by default. To persist sessions across restarts,
+  mount a volume at `/home/abbenay/.local/share/abbenay/sessions/`.

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -108,8 +108,9 @@ podman logs -f abbenay
 
 ## Overriding the command
 
-The default `CMD` is `start --port 8787`, which runs all services. You
-can override it to run a subset:
+The default `CMD` is `start --port 8787 --grpc-port 50051 --grpc-host 0.0.0.0`,
+which runs all services with gRPC accessible from outside the container.
+You can override it to run a subset:
 
 ```bash
 # Web dashboard and REST API only
@@ -125,10 +126,10 @@ podman run -d -p 8787:8787 \
   abbenay:latest serve --port 8787
 
 # gRPC daemon only (no HTTP port needed)
-podman run -d \
+podman run -d -p 50051:50051 \
   -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
   -e OPENROUTER_API_KEY=sk-or-... \
-  abbenay:latest daemon
+  abbenay:latest daemon --grpc-port 50051 --grpc-host 0.0.0.0
 ```
 
 ---
@@ -292,3 +293,24 @@ spec:
   instead.
 - Sessions are ephemeral by default. To persist sessions across restarts,
   mount a volume at `/home/abbenay/.local/share/abbenay/sessions/`.
+
+---
+
+## Security: `--grpc-host`
+
+The `--grpc-host` flag controls which network interface the TCP gRPC
+listener binds to:
+
+| Value | Effect |
+|-------|--------|
+| `127.0.0.1` (default) | Loopback only -- safe for local development |
+| `0.0.0.0` | All interfaces -- required inside containers so that published ports are reachable |
+
+The container's default `CMD` uses `--grpc-host 0.0.0.0` because
+container networking requires the listener to accept connections from
+outside the container's network namespace. The daemon logs a warning
+when `0.0.0.0` is used without consumer authentication.
+
+**Recommendation:** When exposing gRPC outside a trusted network,
+configure a `consumers` section in `config.yaml` to require
+token-based authentication on every RPC.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -38,7 +38,24 @@ npm install
 node build.js                  # builds SEA binary + VSIX + dist archives
 ```
 
-### Option C: Run from source (development)
+### Option C: Container image
+
+```bash
+git clone https://github.com/redhat-developer/abbenay.git
+cd abbenay
+podman build -f Containerfile -t abbenay:latest .
+
+podman run -d --name abbenay \
+  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
+  -e OPENROUTER_API_KEY=sk-or-... \
+  -p 8787:8787 \
+  abbenay:latest
+```
+
+See [CONTAINER.md](CONTAINER.md) for full container deployment docs
+including Kubernetes manifests.
+
+### Option D: Run from source (development)
 
 ```bash
 git clone https://github.com/redhat-developer/abbenay.git

--- a/packages/daemon/src/daemon/daemon.ts
+++ b/packages/daemon/src/daemon/daemon.ts
@@ -79,11 +79,17 @@ function loadProto() {
   return grpc.loadPackageDefinition(packageDefinition);
 }
 
+export interface DaemonOptions {
+  keepAlive?: boolean;
+  /** When set, also bind gRPC to this TCP port (0.0.0.0). */
+  grpcPort?: number;
+}
+
 /**
  * Start the daemon (gRPC server only, no web).
  * Returns the DaemonState for callers that need it (e.g. `abbenay web` in-process mode).
  */
-export async function startDaemon(opts?: { keepAlive?: boolean }): Promise<DaemonState> {
+export async function startDaemon(opts?: DaemonOptions): Promise<DaemonState> {
   // Check if already running
   if (isDaemonRunningSync()) {
     throw new Error('Abbenay daemon is already running');
@@ -131,6 +137,25 @@ export async function startDaemon(opts?: { keepAlive?: boolean }): Promise<Daemo
   });
   
   console.log(`Abbenay daemon listening on ${socketPath}`);
+
+  // Optionally bind gRPC to a TCP port for remote / container access
+  if (opts?.grpcPort) {
+    await new Promise<void>((resolve, reject) => {
+      server!.bindAsync(
+        `0.0.0.0:${opts.grpcPort}`,
+        grpc.ServerCredentials.createInsecure(),
+        (error, boundPort) => {
+          if (error) {
+            reject(error);
+          } else {
+            console.log(`Abbenay gRPC listening on 0.0.0.0:${boundPort}`);
+            resolve();
+          }
+        }
+      );
+    });
+  }
+
   console.log(`Version: ${state.version}`);
   
   // Initialize MCP connections from config (non-blocking)

--- a/packages/daemon/src/daemon/daemon.ts
+++ b/packages/daemon/src/daemon/daemon.ts
@@ -81,8 +81,10 @@ function loadProto() {
 
 export interface DaemonOptions {
   keepAlive?: boolean;
-  /** When set, also bind gRPC to this TCP port (0.0.0.0). */
+  /** When set, also bind gRPC to this TCP port. */
   grpcPort?: number;
+  /** Host/IP to bind the TCP gRPC listener to (default: 127.0.0.1). */
+  grpcHost?: string;
 }
 
 /**
@@ -119,41 +121,63 @@ export async function startDaemon(opts?: DaemonOptions): Promise<DaemonState> {
   const abbenayService = createAbbenayService(state);
   server.addService(abbenayProto.Abbenay.service, abbenayService);
   
-  // Bind to Unix socket
   const socketPath = getDefaultSocketPath();
-  
-  await new Promise<void>((resolve, reject) => {
-    server!.bindAsync(
-      `unix://${socketPath}`,
-      grpc.ServerCredentials.createInsecure(),
-      (error, _port) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      }
-    );
-  });
-  
-  console.log(`Abbenay daemon listening on ${socketPath}`);
 
-  // Optionally bind gRPC to a TCP port for remote / container access
-  if (opts?.grpcPort) {
+  try {
+    // Bind to Unix socket
     await new Promise<void>((resolve, reject) => {
       server!.bindAsync(
-        `0.0.0.0:${opts.grpcPort}`,
+        `unix://${socketPath}`,
         grpc.ServerCredentials.createInsecure(),
-        (error, boundPort) => {
+        (error, _port) => {
           if (error) {
             reject(error);
           } else {
-            console.log(`Abbenay gRPC listening on 0.0.0.0:${boundPort}`);
             resolve();
           }
         }
       );
     });
+    
+    console.log(`Abbenay daemon listening on ${socketPath}`);
+
+    // Optionally bind gRPC to a TCP port for remote / container access
+    if (opts?.grpcPort) {
+      const grpcHost = opts.grpcHost ?? '127.0.0.1';
+
+      if (grpcHost === '0.0.0.0') {
+        console.warn(
+          '[Daemon] WARNING: gRPC is bound to 0.0.0.0 — the API is accessible from ' +
+          'any network interface. Ensure a consumers section is configured in config.yaml ' +
+          'to require authentication, or use --grpc-host 127.0.0.1 to restrict access.',
+        );
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        server!.bindAsync(
+          `${grpcHost}:${opts.grpcPort}`,
+          grpc.ServerCredentials.createInsecure(),
+          (error, boundPort) => {
+            if (error) {
+              reject(error);
+            } else {
+              console.log(`Abbenay gRPC listening on ${grpcHost}:${boundPort}`);
+              resolve();
+            }
+          }
+        );
+      });
+    }
+  } catch (err) {
+    // Clean up PID file, socket, and server on bind failure
+    await new Promise<void>((resolve) => {
+      server!.tryShutdown(() => resolve());
+    });
+    server = null;
+    cleanupSocket();
+    removePidFile();
+    state = null;
+    throw err;
   }
 
   console.log(`Version: ${state.version}`);

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -48,9 +48,12 @@ program
 program
   .command('daemon')
   .description('Start the daemon (foreground)')
-  .action(async () => {
+  .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
+  .action(async (options) => {
     try {
-      await startDaemon();
+      await startDaemon({
+        grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
+      });
     } catch (error) {
       console.error('Failed to start daemon:', error);
       process.exit(1);
@@ -92,6 +95,7 @@ program
 interface ServerOptions {
   port: number;
   mcp?: boolean;
+  grpcPort?: number;
   /** Lines printed after the server URL, before "Press Ctrl+C" */
   bannerLines?: (url: string, mcpStarted: boolean) => string[];
 }
@@ -110,7 +114,7 @@ function validatePort(raw: string): number {
 }
 
 async function runServer(opts: ServerOptions): Promise<void> {
-  const { port, mcp, bannerLines } = opts;
+  const { port, mcp, grpcPort, bannerLines } = opts;
 
   if (isDaemonRunningSync()) {
     console.log('Daemon is running, requesting web server start via gRPC...');
@@ -150,7 +154,7 @@ async function runServer(opts: ServerOptions): Promise<void> {
     });
   } else {
     console.log('No daemon running, starting in-process...');
-    const daemonState = await startDaemon({ keepAlive: false });
+    const daemonState = await startDaemon({ keepAlive: false, grpcPort });
     const { url, app } = await startEmbeddedWebServer(daemonState, port);
 
     if (mcp && app) {
@@ -172,13 +176,16 @@ program
   .command('start')
   .description('Start all services (daemon, web dashboard, OpenAI API, MCP server)')
   .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
   .action(async (options) => {
     const port = validatePort(options.port);
     try {
       await runServer({
         port,
         mcp: true,
+        grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
         bannerLines: (url, mcpStarted) => {
+          const grpc = options.grpcPort ? validatePort(options.grpcPort) : undefined;
           const lines = [
             '',
             `  Abbenay is running on ${url}`,
@@ -189,6 +196,7 @@ program
             `    Models     ${url}/v1/models`,
           ];
           if (mcpStarted) lines.push(`    MCP        ${url}/mcp`);
+          if (grpc) lines.push(`    gRPC       0.0.0.0:${grpc}`);
           lines.push('');
           return lines;
         },
@@ -204,6 +212,7 @@ program
   .command('web')
   .description('Start web dashboard')
   .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
   .option('--mcp', 'Start MCP server on /mcp endpoint')
   .action(async (options) => {
     const port = validatePort(options.port);
@@ -211,6 +220,7 @@ program
       await runServer({
         port,
         mcp: options.mcp,
+        grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
         bannerLines: (url, mcpStarted) => {
           const lines = [`Abbenay Web Dashboard: ${url}`];
           if (mcpStarted) lines.push(`MCP Server: ${url}/mcp`);
@@ -228,6 +238,7 @@ program
   .command('serve')
   .description('Start OpenAI-compatible API server (serves /v1/models, /v1/chat/completions)')
   .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
   .option('--mcp', 'Start MCP server on /mcp endpoint')
   .action(async (options) => {
     const port = validatePort(options.port);
@@ -235,6 +246,7 @@ program
       await runServer({
         port,
         mcp: options.mcp,
+        grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
         bannerLines: (url, mcpStarted) => {
           const lines = [
             `Abbenay API server: ${url}`,

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -49,10 +49,12 @@ program
   .command('daemon')
   .description('Start the daemon (foreground)')
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
+  .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .action(async (options) => {
     try {
       await startDaemon({
         grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
+        grpcHost: options.grpcHost,
       });
     } catch (error) {
       console.error('Failed to start daemon:', error);
@@ -96,6 +98,7 @@ interface ServerOptions {
   port: number;
   mcp?: boolean;
   grpcPort?: number;
+  grpcHost?: string;
   /** Lines printed after the server URL, before "Press Ctrl+C" */
   bannerLines?: (url: string, mcpStarted: boolean) => string[];
 }
@@ -114,7 +117,7 @@ function validatePort(raw: string): number {
 }
 
 async function runServer(opts: ServerOptions): Promise<void> {
-  const { port, mcp, grpcPort, bannerLines } = opts;
+  const { port, mcp, grpcPort, grpcHost, bannerLines } = opts;
 
   if (isDaemonRunningSync()) {
     console.log('Daemon is running, requesting web server start via gRPC...');
@@ -154,7 +157,7 @@ async function runServer(opts: ServerOptions): Promise<void> {
     });
   } else {
     console.log('No daemon running, starting in-process...');
-    const daemonState = await startDaemon({ keepAlive: false, grpcPort });
+    const daemonState = await startDaemon({ keepAlive: false, grpcPort, grpcHost });
     const { url, app } = await startEmbeddedWebServer(daemonState, port);
 
     if (mcp && app) {
@@ -177,15 +180,18 @@ program
   .description('Start all services (daemon, web dashboard, OpenAI API, MCP server)')
   .option('-p, --port <port>', 'Port to listen on', '8787')
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
+  .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .action(async (options) => {
     const port = validatePort(options.port);
     try {
+      const grpcPort = options.grpcPort ? validatePort(options.grpcPort) : undefined;
+      const grpcHost = options.grpcHost;
       await runServer({
         port,
         mcp: true,
-        grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
+        grpcPort,
+        grpcHost,
         bannerLines: (url, mcpStarted) => {
-          const grpc = options.grpcPort ? validatePort(options.grpcPort) : undefined;
           const lines = [
             '',
             `  Abbenay is running on ${url}`,
@@ -196,7 +202,7 @@ program
             `    Models     ${url}/v1/models`,
           ];
           if (mcpStarted) lines.push(`    MCP        ${url}/mcp`);
-          if (grpc) lines.push(`    gRPC       0.0.0.0:${grpc}`);
+          if (grpcPort) lines.push(`    gRPC       ${grpcHost ?? '127.0.0.1'}:${grpcPort}`);
           lines.push('');
           return lines;
         },
@@ -213,6 +219,7 @@ program
   .description('Start web dashboard')
   .option('-p, --port <port>', 'Port to listen on', '8787')
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
+  .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .option('--mcp', 'Start MCP server on /mcp endpoint')
   .action(async (options) => {
     const port = validatePort(options.port);
@@ -221,6 +228,7 @@ program
         port,
         mcp: options.mcp,
         grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
+        grpcHost: options.grpcHost,
         bannerLines: (url, mcpStarted) => {
           const lines = [`Abbenay Web Dashboard: ${url}`];
           if (mcpStarted) lines.push(`MCP Server: ${url}/mcp`);
@@ -239,6 +247,7 @@ program
   .description('Start OpenAI-compatible API server (serves /v1/models, /v1/chat/completions)')
   .option('-p, --port <port>', 'Port to listen on', '8787')
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
+  .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .option('--mcp', 'Start MCP server on /mcp endpoint')
   .action(async (options) => {
     const port = validatePort(options.port);
@@ -247,6 +256,7 @@ program
         port,
         mcp: options.mcp,
         grpcPort: options.grpcPort ? validatePort(options.grpcPort) : undefined,
+        grpcHost: options.grpcHost,
         bannerLines: (url, mcpStarted) => {
           const lines = [
             `Abbenay API server: ${url}`,

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -50,6 +50,24 @@ async def main():
     # ... or explicitly: await client.reconnect()
 ```
 
+## Connecting to a Container
+
+When the daemon runs in a container, connect via TCP instead of the
+default Unix socket:
+
+```python
+async with AbbenayClient(host="localhost", port=50051) as client:
+    async for chunk in client.chat("openrouter/anthropic/claude-sonnet-4", "Hello!"):
+        if chunk.text:
+            print(chunk.text, end="")
+```
+
+The container must be started with `--grpc-port 50051` (the default
+`Containerfile` CMD does this) and the port published (`-p 50051:50051`).
+
+See [docs/CONTAINER.md](../../docs/CONTAINER.md) for full container
+deployment instructions.
+
 ## Features
 
 - **Chat**: Streaming chat with any configured model


### PR DESCRIPTION
## Summary

- Adds a `Containerfile` (UBI 9 minimal, multi-stage build) that packages the SEA binary into a minimal runtime image with no Node.js, npm, or build tooling. Runs as non-root user (UID 1001), includes healthcheck.
- Adds `--grpc-port <port>` flag to `daemon`, `start`, `web`, and `serve` commands, enabling the gRPC server to bind to a TCP port in addition to the Unix socket. This allows Python clients to connect to a containerized daemon via `AbbenayClient(host="...", port=50051)`.
- Adds comprehensive container deployment docs (`docs/CONTAINER.md`) covering build, configuration, running, Python gRPC client connection, and Kubernetes/OpenShift manifests with liveness/readiness probes.
- Adds `config.container.example.yaml` with env-var-based API key configuration (no keytar/keychain in containers).

## Test plan

- [x] Full build passes
- [x] All 319 tests pass
- [x] Lint and audit pass
- [ ] Manual: `podman build -f Containerfile -t abbenay:latest .`
- [ ] Manual: `podman run -d -p 8787:8787 -p 50051:50051 -v config.yaml:... -e KEY=... abbenay:latest`
- [ ] Manual: Python client connects via `AbbenayClient(host="localhost", port=50051)`


Made with [Cursor](https://cursor.com)