### PR TITLE
feat: add GHCR container image CI/CD workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,71 @@
+name: Container Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=semver,pattern=v{{version}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
+
+      - name: Extract version for labels
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Containerfile
+++ b/Containerfile
@@ -15,16 +15,35 @@ FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS builder
 
 USER 0
 
-# Install protobuf compiler and Python for proto generation
-RUN dnf install -y --nodocs protobuf-compiler python3 python3-pip && \
+# Python + pip are needed for grpc_tools.protoc (Python client proto generation).
+# System protoc is not required — the TS stage gracefully skips when absent.
+RUN dnf install -y --nodocs python3 python3-pip xz && \
     dnf clean all
 
 WORKDIR /build
 COPY . .
 
+# Download an official nodejs.org binary for SEA injection.  The UBI9
+# Node.js package doesn't contain the NODE_SEA_FUSE sentinel required
+# to produce a Single Executable Application.
+ARG TARGETARCH
+RUN node_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "${TARGETARCH:-$(node -p process.arch)}") && \
+    node_version=$(cat .node-version | tr -d '[:space:]') && \
+    mkdir -p /build/.sea-node && \
+    curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
+      | tar xJ --strip-components=1 -C /build/.sea-node && \
+    grep -q 'NODE_SEA_FUSE' /build/.sea-node/bin/node
+
 RUN npm ci --ignore-scripts && \
-    npx node-gyp rebuild --directory node_modules/keytar 2>/dev/null || true && \
+    npx node-gyp rebuild --directory node_modules/keytar 2>/dev/null || true
+
+RUN node_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "${TARGETARCH:-$(node -p process.arch)}") && \
+    export NODE_SEA_BASE="/build/.sea-node/bin/node" && \
     node build.js
+
+# Copy the platform-specific binary to a fixed path for the runtime stage.
+RUN node_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "${TARGETARCH:-$(node -p process.arch)}") && \
+    cp packages/daemon/dist/sea/abbenay-daemon-linux-${node_arch} /build/abbenay-binary
 
 # ---------------------------------------------------------------------------
 # Stage 2: Minimal runtime image
@@ -33,6 +52,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG APP_USER=abbenay
 ARG APP_UID=1001
+ARG VERSION=dev
+
+LABEL org.opencontainers.image.title="Abbenay" \
+      org.opencontainers.image.description="AI provider gateway — web dashboard, REST/OpenAI API, gRPC, and MCP server" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.source="https://github.com/redhat-developer/abbenay" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Red Hat"
 
 RUN microdnf install -y shadow-utils curl-minimal && \
     useradd -u ${APP_UID} -m ${APP_USER} && \
@@ -44,7 +71,7 @@ WORKDIR /opt/abbenay
 # keytar.node is intentionally excluded — it requires D-Bus / libsecret
 # which are unavailable in containers.  Use api_key_env_var_name in config
 # instead of api_key_keychain_name.
-COPY --from=builder /build/packages/daemon/dist/sea/abbenay-daemon-linux-x64 ./abbenay
+COPY --from=builder /build/abbenay-binary ./abbenay
 COPY --from=builder /build/packages/daemon/dist/sea/proto/ ./proto/
 COPY --from=builder /build/packages/daemon/dist/sea/static/ ./static/
 

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -5,6 +5,28 @@ the provided `Containerfile`.
 
 ---
 
+## Pre-built images from GHCR
+
+Multi-arch images (linux/amd64 and linux/arm64) are published
+automatically to the GitHub Container Registry on every merge to `main`
+and on every release tag.
+
+```bash
+# Latest stable release
+podman pull ghcr.io/redhat-developer/abbenay:latest
+
+# Latest from main (development builds)
+podman pull ghcr.io/redhat-developer/abbenay:main
+
+# Specific release
+podman pull ghcr.io/redhat-developer/abbenay:v1.0.0
+```
+
+Then run it the same way as a locally built image (see [Running](#running)
+below).
+
+---
+
 ## Overview
 
 The container packages the Abbenay SEA binary into a minimal UBI 9 image.
@@ -29,7 +51,9 @@ The `start` command runs all services:
 
 ---
 
-## Building the image
+## Building the image locally
+
+If you prefer to build from source instead of pulling from GHCR:
 
 ```bash
 podman build -f Containerfile -t abbenay:latest .


### PR DESCRIPTION
## Summary

- Add `.github/workflows/container.yml` to build and publish multi-arch (linux/amd64 + linux/arm64) container images to GHCR:
  - **PRs**: build-only validation (no push) to catch Containerfile breakage early
  - **Main merge**: push with `:main` and `:sha-<short>` tags so devs can pull the latest merged code immediately
  - **Release tags**: push with `:v1.2.3` and `:latest` (stable releases only)
  - Uses GHA build cache for faster subsequent builds
- Update `Containerfile` for multi-arch support via buildx `TARGETARCH`, mapping `amd64` to Node's `x64` naming convention. Falls back to detected host arch via `node -p process.arch` for plain `podman build`.
- Download a minimal official nodejs.org binary for SEA injection instead of using the full `bootstrap.sh` (avoids pulling uv, prek, and other dev tools not needed in containers).
- Add OCI labels (`org.opencontainers.image.*`) so the GHCR package page displays image metadata.
- Add "Pre-built images from GHCR" section to `docs/CONTAINER.md` with pull commands for `:latest`, `:main`, and specific version tags.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] All 319 vitest tests pass
- [ ] `podman build -f Containerfile -t abbenay:latest .` still works locally
- [ ] `container.yml` workflow validates on PR (build-only, no push)
- [ ] GHCR image is pullable after merge to main