### PR TITLE
fix: update undici to 7.24.4 and add dependabot.yml

### DIFF
--- a/.audit-allowlist
+++ b/.audit-allowlist
@@ -5,14 +5,3 @@
 # serialize-javascript via mocha via @vscode/test-cli (dev-only, no fix)
 # Added 2026-03-11
 https://github.com/advisories/GHSA-5c6j-r48x-rmvq
-
-# undici 7.0.0-7.23.0 — transitive via Node built-in fetch (no fix in range)
-# WebSocket 64-bit length overflow, HTTP smuggling, permessage-deflate DoS,
-# server_max_window_bits crash, CRLF injection, DeduplicationHandler DoS
-# Added 2026-03-18
-https://github.com/advisories/GHSA-f269-vfmq-vjvj
-https://github.com/advisories/GHSA-2mjp-6q6p-2qxm
-https://github.com/advisories/GHSA-vrm6-8vpv-qv8q
-https://github.com/advisories/GHSA-v9p9-hfj2-hcw8
-https://github.com/advisories/GHSA-4992-7rv2-5pvq
-https://github.com/advisories/GHSA-phc3-fgpg-7m6h

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -10674,11 +10674,10 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }


### PR DESCRIPTION
## Summary

- Update `undici` from 7.22.0 to 7.24.4 in `package-lock.json`, resolving 6 Dependabot security alerts:
  - GHSA-f269-vfmq-vjvj (WebSocket 64-bit length overflow)
  - GHSA-2mjp-6q6p-2qxm (HTTP smuggling)
  - GHSA-vrm6-8vpv-qv8q (permessage-deflate DoS)
  - GHSA-v9p9-hfj2-hcw8 (server_max_window_bits crash)
  - GHSA-4992-7rv2-5pvq (CRLF injection)
  - GHSA-phc3-fgpg-7m6h (DeduplicationHandler DoS)
- Remove the now-resolved undici entries from `.audit-allowlist`.
- Add `.github/dependabot.yml` for weekly npm and GitHub Actions dependency updates, with dev-dependency grouping to reduce PR noise.

This also fixes the failing Dependabot security update run (#4).

## Test plan

- [ ] All 319 vitest tests pass
- [ ] `npm audit` shows no undici advisories
- [ ] Dependabot alerts auto-dismiss after merge

Made with [Cursor](https://cursor.com)