### PR TITLE
chore: tier 1 housekeeping — constants, dedup, tests, lint

### DIFF
--- a/packages/daemon/eslint.config.js
+++ b/packages/daemon/eslint.config.js
@@ -7,7 +7,7 @@ export default tseslint.config(
   {
     files: ['**/*.ts'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
@@ -15,6 +15,12 @@ export default tseslint.config(
       'no-inner-declarations': 'off',
       eqeqeq: ['error', 'always', { null: 'ignore' }],
       semi: 'off',
+    },
+  },
+  {
+    files: ['**/*.test.ts', 'tests/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
     },
   },
   { ignores: ['dist/**', 'build.js', '**/*.d.ts'] },

--- a/packages/daemon/src/core/constants.ts
+++ b/packages/daemon/src/core/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared constants for the Abbenay daemon.
+ *
+ * Network, protocol, and operational defaults that don't belong
+ * in a specific module.  Import from here or via the @abbenay/core barrel.
+ */
+
+/** Default HTTP port for the web dashboard and API server. */
+export const DEFAULT_WEB_PORT = 8787;

--- a/packages/daemon/src/core/index.ts
+++ b/packages/daemon/src/core/index.ts
@@ -154,6 +154,7 @@ export {
 
 /** Platform-aware path utilities */
 export {
+  DEFAULT_WEB_PORT,
   getRuntimeDir,
   getConfigDir,
   getWorkspaceConfigDir,

--- a/packages/daemon/src/core/index.ts
+++ b/packages/daemon/src/core/index.ts
@@ -152,9 +152,11 @@ export {
   getUserPoliciesPath,
 } from './policies.js';
 
+/** Shared constants */
+export { DEFAULT_WEB_PORT } from './constants.js';
+
 /** Platform-aware path utilities */
 export {
-  DEFAULT_WEB_PORT,
   getRuntimeDir,
   getConfigDir,
   getWorkspaceConfigDir,

--- a/packages/daemon/src/core/paths.test.ts
+++ b/packages/daemon/src/core/paths.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import * as path from 'node:path';
 
 import {
-  DEFAULT_WEB_PORT,
   getRuntimeDir,
   getConfigDir,
   getDataDir,
@@ -14,6 +13,7 @@ import {
   getWorkspaceConfigPath,
   getUserPoliciesPath,
 } from './paths.js';
+import { DEFAULT_WEB_PORT } from './constants.js';
 
 // ── DEFAULT_WEB_PORT ─────────────────────────────────────────────────────────
 

--- a/packages/daemon/src/core/paths.test.ts
+++ b/packages/daemon/src/core/paths.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'node:path';
+
+import {
+  DEFAULT_WEB_PORT,
+  getRuntimeDir,
+  getConfigDir,
+  getDataDir,
+  getSessionsDir,
+  getWorkspaceConfigDir,
+  getSocketPath,
+  getPidPath,
+  getUserConfigPath,
+  getWorkspaceConfigPath,
+  getUserPoliciesPath,
+} from './paths.js';
+
+// ── DEFAULT_WEB_PORT ─────────────────────────────────────────────────────────
+
+describe('DEFAULT_WEB_PORT', () => {
+  it('should be 8787', () => {
+    expect(DEFAULT_WEB_PORT).toBe(8787);
+  });
+});
+
+// ── getRuntimeDir ────────────────────────────────────────────────────────────
+
+describe('getRuntimeDir', () => {
+  const originalEnv = { ...process.env };
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should use XDG_RUNTIME_DIR when set', () => {
+    process.env.XDG_RUNTIME_DIR = '/run/user/1000';
+    const result = getRuntimeDir();
+    expect(result).toBe('/run/user/1000/abbenay');
+  });
+
+  it('should use tmpdir on darwin when XDG_RUNTIME_DIR is unset', () => {
+    delete process.env.XDG_RUNTIME_DIR;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const result = getRuntimeDir();
+    expect(result).toContain('abbenay');
+    expect(path.basename(result)).toBe('abbenay');
+  });
+
+  it('should try /run/user/<uid> on linux without XDG_RUNTIME_DIR', () => {
+    delete process.env.XDG_RUNTIME_DIR;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const result = getRuntimeDir();
+    expect(result).toMatch(/\babbenay$/);
+  });
+});
+
+// ── getConfigDir ─────────────────────────────────────────────────────────────
+
+describe('getConfigDir', () => {
+  const originalEnv = { ...process.env };
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should use XDG_CONFIG_HOME on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.XDG_CONFIG_HOME = '/custom/config';
+    expect(getConfigDir()).toBe('/custom/config/abbenay');
+  });
+
+  it('should default to ~/.config on linux without XDG_CONFIG_HOME', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.XDG_CONFIG_HOME;
+    const result = getConfigDir();
+    expect(result).toMatch(/\.config\/abbenay$/);
+  });
+});
+
+// ── getDataDir ───────────────────────────────────────────────────────────────
+
+describe('getDataDir', () => {
+  const originalEnv = { ...process.env };
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should use XDG_DATA_HOME on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.XDG_DATA_HOME = '/custom/data';
+    expect(getDataDir()).toBe('/custom/data/abbenay');
+  });
+
+  it('should default to ~/.local/share on linux without XDG_DATA_HOME', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.XDG_DATA_HOME;
+    const result = getDataDir();
+    expect(result).toMatch(/\.local\/share\/abbenay$/);
+  });
+});
+
+// ── derived helpers ──────────────────────────────────────────────────────────
+
+describe('getSessionsDir', () => {
+  it('should be <dataDir>/sessions', () => {
+    const result = getSessionsDir();
+    expect(path.basename(result)).toBe('sessions');
+  });
+});
+
+describe('getWorkspaceConfigDir', () => {
+  it('should return <workspace>/.config/abbenay', () => {
+    expect(getWorkspaceConfigDir('/my/project')).toBe('/my/project/.config/abbenay');
+  });
+});
+
+describe('getSocketPath', () => {
+  it('should end with daemon.sock on non-windows', () => {
+    if (process.platform !== 'win32') {
+      expect(getSocketPath()).toMatch(/daemon\.sock$/);
+    }
+  });
+});
+
+describe('getPidPath', () => {
+  it('should end with abbenay.pid', () => {
+    expect(getPidPath()).toMatch(/abbenay\.pid$/);
+  });
+});
+
+describe('getUserConfigPath', () => {
+  it('should end with config.yaml', () => {
+    expect(getUserConfigPath()).toMatch(/config\.yaml$/);
+  });
+});
+
+describe('getWorkspaceConfigPath', () => {
+  it('should return <workspace>/.config/abbenay/config.yaml', () => {
+    expect(getWorkspaceConfigPath('/proj')).toBe('/proj/.config/abbenay/config.yaml');
+  });
+});
+
+describe('getUserPoliciesPath', () => {
+  it('should end with policies.yaml', () => {
+    expect(getUserPoliciesPath()).toMatch(/policies\.yaml$/);
+  });
+});

--- a/packages/daemon/src/core/paths.ts
+++ b/packages/daemon/src/core/paths.ts
@@ -25,9 +25,6 @@ import * as path from 'node:path';
 
 const APP_NAME = 'abbenay';
 
-/** Default HTTP port for the web dashboard and API server. */
-export const DEFAULT_WEB_PORT = 8787;
-
 // ── Runtime directory ────────────────────────────────────────────────
 
 /**

--- a/packages/daemon/src/core/paths.ts
+++ b/packages/daemon/src/core/paths.ts
@@ -25,6 +25,9 @@ import * as path from 'node:path';
 
 const APP_NAME = 'abbenay';
 
+/** Default HTTP port for the web dashboard and API server. */
+export const DEFAULT_WEB_PORT = 8787;
+
 // ── Runtime directory ────────────────────────────────────────────────
 
 /**

--- a/packages/daemon/src/core/policies.test.ts
+++ b/packages/daemon/src/core/policies.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+let mockConfigDir = '/tmp/nonexistent-config-dir';
+vi.mock('./paths.js', () => ({
+  getConfigDir: () => mockConfigDir,
+}));
+
+import {
+  loadCustomPolicies,
+  saveCustomPolicies,
+  listAllPolicies,
+  resolvePolicy,
+  flattenPolicy,
+  getUserPoliciesPath,
+  BUILTIN_POLICIES,
+  BUILTIN_POLICY_NAMES,
+  type PolicyConfig,
+} from './policies.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-policies-test-'));
+  mockConfigDir = tmpDir;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── getUserPoliciesPath ──────────────────────────────────────────────────────
+
+describe('getUserPoliciesPath', () => {
+  it('should return policies.yaml inside config dir', () => {
+    expect(getUserPoliciesPath()).toBe(path.join(tmpDir, 'policies.yaml'));
+  });
+});
+
+// ── loadCustomPolicies ───────────────────────────────────────────────────────
+
+describe('loadCustomPolicies', () => {
+  it('should return empty object when file does not exist', () => {
+    expect(loadCustomPolicies()).toEqual({});
+  });
+
+  it('should load valid YAML policies', () => {
+    const policies: Record<string, PolicyConfig> = {
+      my_policy: {
+        sampling: { temperature: 0.3 },
+        output: { max_tokens: 1024 },
+      },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'policies.yaml'), yaml.dump(policies));
+    const result = loadCustomPolicies();
+    expect(result.my_policy).toBeDefined();
+    expect(result.my_policy.sampling?.temperature).toBe(0.3);
+    expect(result.my_policy.output?.max_tokens).toBe(1024);
+  });
+
+  it('should return empty object for malformed YAML', () => {
+    fs.writeFileSync(path.join(tmpDir, 'policies.yaml'), ':::invalid yaml[[[');
+    expect(loadCustomPolicies()).toEqual({});
+  });
+
+  it('should return empty object when YAML is an array', () => {
+    fs.writeFileSync(path.join(tmpDir, 'policies.yaml'), yaml.dump(['a', 'b']));
+    expect(loadCustomPolicies()).toEqual({});
+  });
+
+  it('should return empty object when YAML is a scalar', () => {
+    fs.writeFileSync(path.join(tmpDir, 'policies.yaml'), 'just a string\n');
+    expect(loadCustomPolicies()).toEqual({});
+  });
+});
+
+// ── saveCustomPolicies ───────────────────────────────────────────────────────
+
+describe('saveCustomPolicies', () => {
+  it('should create config dir and write policies', () => {
+    const nestedDir = path.join(tmpDir, 'nested', 'dir');
+    mockConfigDir = nestedDir;
+
+    const policies: Record<string, PolicyConfig> = {
+      test_policy: { sampling: { temperature: 0.5, top_p: 0.9 } },
+    };
+    saveCustomPolicies(policies);
+
+    const written = yaml.load(
+      fs.readFileSync(path.join(nestedDir, 'policies.yaml'), 'utf-8'),
+    ) as Record<string, PolicyConfig>;
+    expect(written.test_policy.sampling?.temperature).toBe(0.5);
+  });
+
+  it('should overwrite existing file atomically', () => {
+    const policies1: Record<string, PolicyConfig> = {
+      v1: { sampling: { temperature: 0.1 } },
+    };
+    const policies2: Record<string, PolicyConfig> = {
+      v2: { sampling: { temperature: 0.9 } },
+    };
+    saveCustomPolicies(policies1);
+    saveCustomPolicies(policies2);
+
+    const result = loadCustomPolicies();
+    expect(result.v1).toBeUndefined();
+    expect(result.v2).toBeDefined();
+    expect(result.v2.sampling?.temperature).toBe(0.9);
+  });
+
+  it('should round-trip all policy fields', () => {
+    const policies: Record<string, PolicyConfig> = {
+      full: {
+        sampling: { temperature: 0.2, top_p: 0.5, top_k: 40 },
+        output: {
+          max_tokens: 2048,
+          format: 'json_only',
+          system_prompt_snippet: 'Be precise.',
+          system_prompt_mode: 'append',
+        },
+        context: { context_threshold: 1000, compression_strategy: 'rolling_summary' },
+        tool: { max_tool_iterations: 5, tool_mode: 'ask' },
+        reliability: { retry_on_invalid_json: true, timeout: 30000 },
+      },
+    };
+    saveCustomPolicies(policies);
+    const loaded = loadCustomPolicies();
+    expect(loaded.full).toEqual(policies.full);
+  });
+});
+
+// ── resolvePolicy ────────────────────────────────────────────────────────────
+
+describe('resolvePolicy', () => {
+  it('should resolve built-in policies', () => {
+    const precise = resolvePolicy('precise');
+    expect(precise).toEqual(BUILTIN_POLICIES.precise);
+  });
+
+  it('should return null for unknown policy', () => {
+    expect(resolvePolicy('nonexistent')).toBeNull();
+  });
+
+  it('should prefer custom over built-in when names differ', () => {
+    const custom: Record<string, PolicyConfig> = {
+      my_custom: { sampling: { temperature: 0.42 } },
+    };
+    saveCustomPolicies(custom);
+    const result = resolvePolicy('my_custom');
+    expect(result?.sampling?.temperature).toBe(0.42);
+  });
+});
+
+// ── flattenPolicy ────────────────────────────────────────────────────────────
+
+describe('flattenPolicy', () => {
+  it('should flatten sampling params', () => {
+    const flat = flattenPolicy({ sampling: { temperature: 0.3, top_p: 0.5, top_k: 10 } });
+    expect(flat.params.temperature).toBe(0.3);
+    expect(flat.params.top_p).toBe(0.5);
+    expect(flat.params.top_k).toBe(10);
+  });
+
+  it('should flatten output fields', () => {
+    const flat = flattenPolicy({
+      output: {
+        max_tokens: 4096,
+        format: 'json_only',
+        system_prompt_snippet: 'test',
+        system_prompt_mode: 'append',
+      },
+    });
+    expect(flat.params.max_tokens).toBe(4096);
+    expect(flat.outputFormat).toBe('json_only');
+    expect(flat.systemPromptSnippet).toBe('test');
+    expect(flat.systemPromptMode).toBe('append');
+  });
+
+  it('should default systemPromptMode to prepend', () => {
+    const flat = flattenPolicy({ output: { system_prompt_snippet: 'x' } });
+    expect(flat.systemPromptMode).toBe('prepend');
+  });
+
+  it('should flatten reliability fields', () => {
+    const flat = flattenPolicy({ reliability: { retry_on_invalid_json: true, timeout: 5000 } });
+    expect(flat.retryOnInvalidJson).toBe(true);
+    expect(flat.params.timeout).toBe(5000);
+  });
+
+  it('should flatten tool fields', () => {
+    const flat = flattenPolicy({ tool: { tool_mode: 'ask', max_tool_iterations: 3 } });
+    expect(flat.toolMode).toBe('ask');
+    expect(flat.maxToolIterations).toBe(3);
+  });
+
+  it('should handle empty policy', () => {
+    const flat = flattenPolicy({});
+    expect(flat.params).toEqual({});
+    expect(flat.systemPromptSnippet).toBeUndefined();
+    expect(flat.outputFormat).toBeUndefined();
+  });
+});
+
+// ── listAllPolicies ──────────────────────────────────────────────────────────
+
+describe('listAllPolicies', () => {
+  it('should include all built-in policies', () => {
+    const all = listAllPolicies();
+    for (const name of BUILTIN_POLICY_NAMES) {
+      const entry = all.find((p) => p.name === name);
+      expect(entry).toBeDefined();
+      expect(entry!.builtin).toBe(true);
+    }
+  });
+
+  it('should include custom policies', () => {
+    saveCustomPolicies({ my_extra: { sampling: { temperature: 0.7 } } });
+    const all = listAllPolicies();
+    const custom = all.find((p) => p.name === 'my_extra');
+    expect(custom).toBeDefined();
+    expect(custom!.builtin).toBe(false);
+  });
+
+  it('should not include custom policies that shadow built-in names', () => {
+    saveCustomPolicies({ precise: { sampling: { temperature: 0.99 } } });
+    const all = listAllPolicies();
+    const preciseEntries = all.filter((p) => p.name === 'precise');
+    expect(preciseEntries).toHaveLength(1);
+    expect(preciseEntries[0].builtin).toBe(true);
+  });
+});
+
+// ── built-in policy integrity ────────────────────────────────────────────────
+
+describe('built-in policies', () => {
+  it('BUILTIN_POLICY_NAMES should match BUILTIN_POLICIES keys', () => {
+    expect(BUILTIN_POLICY_NAMES).toEqual(Object.keys(BUILTIN_POLICIES));
+  });
+
+  it('json_strict should enable retry_on_invalid_json', () => {
+    expect(BUILTIN_POLICIES.json_strict.reliability?.retry_on_invalid_json).toBe(true);
+  });
+
+  it('json_strict should set format to json_only', () => {
+    expect(BUILTIN_POLICIES.json_strict.output?.format).toBe('json_only');
+  });
+});

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -20,6 +20,7 @@ import { startDaemon, stopDaemon, getDaemonStatus } from './daemon.js';
 import { isDaemonRunningSync } from './transport.js';
 import { startEmbeddedWebServer } from './web/server.js';
 import { getEngines, fetchModels } from '../core/engines.js';
+import { DEFAULT_WEB_PORT } from '../core/paths.js';
 import { VERSION } from '../version.js';
 
 function printTable(headers: string[], rows: string[][]): void {
@@ -178,7 +179,7 @@ async function runServer(opts: ServerOptions): Promise<void> {
 program
   .command('start')
   .description('Start all services (daemon, web dashboard, OpenAI API, MCP server)')
-  .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('-p, --port <port>', 'Port to listen on', String(DEFAULT_WEB_PORT))
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
   .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .action(async (options) => {
@@ -217,7 +218,7 @@ program
 program
   .command('web')
   .description('Start web dashboard')
-  .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('-p, --port <port>', 'Port to listen on', String(DEFAULT_WEB_PORT))
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
   .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .option('--mcp', 'Start MCP server on /mcp endpoint')
@@ -245,7 +246,7 @@ program
 program
   .command('serve')
   .description('Start OpenAI-compatible API server (serves /v1/models, /v1/chat/completions)')
-  .option('-p, --port <port>', 'Port to listen on', '8787')
+  .option('-p, --port <port>', 'Port to listen on', String(DEFAULT_WEB_PORT))
   .option('--grpc-port <port>', 'Also listen for gRPC on this TCP port (for remote/container access)')
   .option('--grpc-host <host>', 'Host/IP to bind gRPC TCP listener (default: 127.0.0.1, use 0.0.0.0 for containers)')
   .option('--mcp', 'Start MCP server on /mcp endpoint')

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -20,7 +20,7 @@ import { startDaemon, stopDaemon, getDaemonStatus } from './daemon.js';
 import { isDaemonRunningSync } from './transport.js';
 import { startEmbeddedWebServer } from './web/server.js';
 import { getEngines, fetchModels } from '../core/engines.js';
-import { DEFAULT_WEB_PORT } from '../core/paths.js';
+import { DEFAULT_WEB_PORT } from '../core/constants.js';
 import { VERSION } from '../version.js';
 
 function printTable(headers: string[], rows: string[][]): void {

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -14,7 +14,7 @@ import {
 import { listAllPolicies, type PolicyConfig as PolicyCfg } from '../../core/policies.js';
 import { maybeSummarize, generateSessionSummary } from '../../core/session-summarizer.js';
 import { loadConfig, type ConfigFile, type McpServerConfig } from '../../core/config.js';
-import { DEFAULT_WEB_PORT } from '../../core/paths.js';
+import { DEFAULT_WEB_PORT } from '../../core/constants.js';
 
 interface ProtoClientInfo {
   client_type?: string | number;
@@ -1483,7 +1483,7 @@ export function authorizeConsumer(
 
   return {
     allowed: false,
-    reason: `Consumer token not recognized or lacks ${capability} capability.`,
+    reason: `Consumer token not recognized or lacks ${CAPABILITY_LABELS[capability]} capability.`,
   };
 }
 

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -14,6 +14,7 @@ import {
 import { listAllPolicies, type PolicyConfig as PolicyCfg } from '../../core/policies.js';
 import { maybeSummarize, generateSessionSummary } from '../../core/session-summarizer.js';
 import { loadConfig, type ConfigFile, type McpServerConfig } from '../../core/config.js';
+import { DEFAULT_WEB_PORT } from '../../core/paths.js';
 
 interface ProtoClientInfo {
   client_type?: string | number;
@@ -477,7 +478,7 @@ export function createAbbenayService(state: DaemonState) {
         }
 
         // Consumer authorization gate (DR-024)
-        const auth = authorizeInlinePolicy(call, loadConfig());
+        const auth = authorizeConsumer(call, loadConfig(), 'inline_policy');
         if (!auth.allowed) {
           call.write({ error: { code: 'PERMISSION_DENIED', message: auth.reason } });
           call.end();
@@ -841,7 +842,7 @@ export function createAbbenayService(state: DaemonState) {
       call: grpc.ServerUnaryCall<StartWebServerRequestProto, object>,
       callback: grpc.sendUnaryData<object>
     ): void {
-      const port = call.request.port || 8787;
+      const port = call.request.port || DEFAULT_WEB_PORT;
       
       if (isWebServerRunning()) {
         const currentPort = getWebServerPort();
@@ -1024,7 +1025,7 @@ export function createAbbenayService(state: DaemonState) {
         }
 
         // Consumer authorization gate (DR-024)
-        const auth = authorizeInlinePolicy(call, loadConfig());
+        const auth = authorizeConsumer(call, loadConfig(), 'inline_policy');
         if (!auth.allowed) {
           call.write({ error: { code: 'PERMISSION_DENIED', message: auth.reason } });
           call.end();
@@ -1203,7 +1204,7 @@ export function createAbbenayService(state: DaemonState) {
       }
 
       // Consumer auth: require mcp_register capability
-      const authResult = authorizeMcpRegister(call, loadConfig());
+      const authResult = authorizeConsumer(call, loadConfig(), 'mcp_register');
       if (!authResult.allowed) {
         callback({ code: grpc.status.PERMISSION_DENIED, message: authResult.reason! });
         return;
@@ -1430,12 +1431,27 @@ function transportProtoToConfig(transport: McpTransportProto): McpServerConfig {
   throw new Error(`Unknown transport type: "${type}". Must be "stdio", "http", or "sse".`);
 }
 
-// ── Consumer authorization for MCP registration (DR-025) ──────────────
+// ── Consumer authorization (DR-024 / DR-025) ──────────────────────────
 
 /** @internal Exported for testing. */
-export function authorizeMcpRegister(
-  call: grpc.ServerUnaryCall<unknown, unknown>,
+export interface AuthResult {
+  allowed: boolean;
+  consumer?: string;
+  reason?: string;
+}
+
+export type ConsumerCapability = 'inline_policy' | 'mcp_register';
+
+const CAPABILITY_LABELS: Record<ConsumerCapability, string> = {
+  inline_policy: 'Inline policy',
+  mcp_register: 'MCP registration',
+};
+
+/** @internal Exported for testing. */
+export function authorizeConsumer(
+  call: { metadata: grpc.Metadata },
   config: ConfigFile,
+  capability: ConsumerCapability,
 ): AuthResult {
   const consumers = config.consumers;
 
@@ -1449,7 +1465,7 @@ export function authorizeMcpRegister(
   if (!token) {
     return {
       allowed: false,
-      reason: 'MCP registration requires consumer authentication. Set the x-abbenay-token gRPC metadata header.',
+      reason: `${CAPABILITY_LABELS[capability]} requires consumer authentication. Set the x-abbenay-token gRPC metadata header.`,
     };
   }
 
@@ -1460,62 +1476,29 @@ export function authorizeMcpRegister(
 
     if (!expectedToken) continue;
 
-    if (token === expectedToken && consumer.capabilities?.mcp_register) {
+    if (token === expectedToken && consumer.capabilities?.[capability]) {
       return { allowed: true, consumer: name };
     }
   }
 
   return {
     allowed: false,
-    reason: 'Consumer token not recognized or lacks mcp_register capability.',
+    reason: `Consumer token not recognized or lacks ${capability} capability.`,
   };
 }
 
-// ── Consumer authorization for inline policy (DR-024) ──────────────────
-
-/** @internal Exported for testing. */
-export interface AuthResult {
-  allowed: boolean;
-  consumer?: string;
-  reason?: string;
+/** @deprecated Use authorizeConsumer(call, config, 'mcp_register') instead. */
+export function authorizeMcpRegister(
+  call: grpc.ServerUnaryCall<unknown, unknown>,
+  config: ConfigFile,
+): AuthResult {
+  return authorizeConsumer(call, config, 'mcp_register');
 }
 
-/** @internal Exported for testing. */
+/** @deprecated Use authorizeConsumer(call, config, 'inline_policy') instead. */
 export function authorizeInlinePolicy(
   call: grpc.ServerWritableStream<unknown, unknown>,
   config: ConfigFile,
 ): AuthResult {
-  const consumers = config.consumers;
-
-  // Default-open: no consumers section means all callers are allowed
-  if (!consumers || Object.keys(consumers).length === 0) {
-    return { allowed: true };
-  }
-
-  const metadata = call.metadata.get('x-abbenay-token');
-  const token = metadata.length > 0 ? String(metadata[0]) : undefined;
-
-  if (!token) {
-    return {
-      allowed: false,
-      reason: 'Inline policy requires consumer authentication. Set the x-abbenay-token gRPC metadata header.',
-    };
-  }
-
-  for (const [name, consumer] of Object.entries(consumers)) {
-    const expectedToken = consumer.token_env
-      ? process.env[consumer.token_env]
-      : undefined;
-
-    if (!expectedToken) { continue; }
-
-    if (token === expectedToken && consumer.capabilities?.inline_policy) {
-      return { allowed: true, consumer: name };
-    }
-  }
-
-  return {
-    allowed: false,
-    reason: 'Consumer token not recognized or lacks inline_policy capability.',
-  };
+  return authorizeConsumer(call, config, 'inline_policy');
 }

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -22,6 +22,7 @@ import { maybeSummarize, generateSessionSummary } from '../../core/session-summa
 import type { DaemonState } from '../state.js';
 import type { ChatToolOptions } from '../../core/state.js';
 import { getEngines, getProviderTemplates } from '../../core/engines.js';
+import { DEFAULT_WEB_PORT } from '../../core/paths.js';
 import { registerOpenAIRoutes } from './openai-compat.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1131,7 +1132,7 @@ let _lastApp: Express | null = null;
  */
 export async function startEmbeddedWebServer(
   state: DaemonState,
-  port: number = 8787,
+  port: number = DEFAULT_WEB_PORT,
 ): Promise<{ port: number; url: string; app: Express }> {
   if (_httpServer) {
     return { port: _webPort!, url: `http://localhost:${_webPort}`, app: _lastApp! };

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -22,7 +22,7 @@ import { maybeSummarize, generateSessionSummary } from '../../core/session-summa
 import type { DaemonState } from '../state.js';
 import type { ChatToolOptions } from '../../core/state.js';
 import { getEngines, getProviderTemplates } from '../../core/engines.js';
-import { DEFAULT_WEB_PORT } from '../../core/paths.js';
+import { DEFAULT_WEB_PORT } from '../../core/constants.js';
 import { registerOpenAIRoutes } from './openai-compat.js';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/daemon/src/state.test.ts
+++ b/packages/daemon/src/state.test.ts
@@ -88,7 +88,7 @@ vi.mock('./daemon/secrets/keychain.js', () => ({
 
 import { DaemonState, ClientType } from './daemon/state.js';
 import { stripJsonFences } from './core/state.js';
-import { protoToPolicyConfig, authorizeInlinePolicy, authorizeMcpRegister } from './daemon/server/abbenay-service.js';
+import { protoToPolicyConfig, authorizeConsumer } from './daemon/server/abbenay-service.js';
 import * as grpc from '@grpc/grpc-js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -848,24 +848,24 @@ describe('protoToPolicyConfig', () => {
   });
 });
 
-// ── authorizeInlinePolicy ────────────────────────────────────────────────────
+// ── authorizeConsumer ─────────────────────────────────────────────────────────
 
-function mockCall(token?: string): grpc.ServerWritableStream<unknown, unknown> {
+function mockGrpcCall(token?: string): { metadata: grpc.Metadata } {
   const metadata = new grpc.Metadata();
   if (token) {
     metadata.add('x-abbenay-token', token);
   }
-  return { metadata } as unknown as grpc.ServerWritableStream<unknown, unknown>;
+  return { metadata };
 }
 
-describe('authorizeInlinePolicy', () => {
+describe('authorizeConsumer', () => {
   it('should allow when no consumers section (default-open)', () => {
-    const result = authorizeInlinePolicy(mockCall(), { providers: {} });
+    const result = authorizeConsumer(mockGrpcCall(), { providers: {} }, 'inline_policy');
     expect(result.allowed).toBe(true);
   });
 
   it('should allow when consumers section is empty', () => {
-    const result = authorizeInlinePolicy(mockCall(), { providers: {}, consumers: {} });
+    const result = authorizeConsumer(mockGrpcCall(), { providers: {}, consumers: {} }, 'inline_policy');
     expect(result.allowed).toBe(true);
   });
 
@@ -873,12 +873,12 @@ describe('authorizeInlinePolicy', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'secret123';
     try {
-      const result = authorizeInlinePolicy(mockCall(), {
+      const result = authorizeConsumer(mockGrpcCall(), {
         providers: {},
         consumers: {
           apme: { token_env: 'TEST_TOKEN', capabilities: { inline_policy: true } },
         },
-      });
+      }, 'inline_policy');
       expect(result.allowed).toBe(false);
       expect(result.reason).toContain('x-abbenay-token');
     } finally {
@@ -887,16 +887,16 @@ describe('authorizeInlinePolicy', () => {
     }
   });
 
-  it('should reject when token does not match any consumer', () => {
+  it('should reject when token does not match any consumer (inline_policy)', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'secret123';
     try {
-      const result = authorizeInlinePolicy(mockCall('wrong-token'), {
+      const result = authorizeConsumer(mockGrpcCall('wrong-token'), {
         providers: {},
         consumers: {
           apme: { token_env: 'TEST_TOKEN', capabilities: { inline_policy: true } },
         },
-      });
+      }, 'inline_policy');
       expect(result.allowed).toBe(false);
       expect(result.reason).toContain('not recognized');
     } finally {
@@ -909,12 +909,12 @@ describe('authorizeInlinePolicy', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'secret123';
     try {
-      const result = authorizeInlinePolicy(mockCall('secret123'), {
+      const result = authorizeConsumer(mockGrpcCall('secret123'), {
         providers: {},
         consumers: {
           apme: { token_env: 'TEST_TOKEN', capabilities: { inline_policy: true } },
         },
-      });
+      }, 'inline_policy');
       expect(result.allowed).toBe(true);
       expect(result.consumer).toBe('apme');
     } finally {
@@ -923,61 +923,33 @@ describe('authorizeInlinePolicy', () => {
     }
   });
 
-  it('should reject when token matches but consumer lacks inline_policy capability', () => {
+  it('should reject when token matches but consumer lacks requested capability', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'secret123';
     try {
-      const result = authorizeInlinePolicy(mockCall('secret123'), {
+      const result = authorizeConsumer(mockGrpcCall('secret123'), {
         providers: {},
         consumers: {
           limited: { token_env: 'TEST_TOKEN', capabilities: {} },
         },
-      });
+      }, 'inline_policy');
       expect(result.allowed).toBe(false);
     } finally {
       if (prev === undefined) delete process.env.TEST_TOKEN;
       else process.env.TEST_TOKEN = prev;
     }
   });
-});
 
-// ── authorizeMcpRegister (DR-025) ────────────────────────────────────────────
-
-function mockUnaryCall(token?: string): grpc.ServerUnaryCall<unknown, unknown> {
-  const metadata = new grpc.Metadata();
-  if (token) {
-    metadata.add('x-abbenay-token', token);
-  }
-  return { metadata } as unknown as grpc.ServerUnaryCall<unknown, unknown>;
-}
-
-describe('authorizeMcpRegister', () => {
-  it('should allow when no consumers section (default-open)', () => {
-    const result = authorizeMcpRegister(mockUnaryCall(), { providers: {} });
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should reject when consumers exist but no token provided', () => {
-    const result = authorizeMcpRegister(mockUnaryCall(), {
-      providers: {},
-      consumers: {
-        apme: { token_env: 'TEST_TOKEN', capabilities: { mcp_register: true } },
-      },
-    });
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toContain('consumer authentication');
-  });
-
-  it('should allow when token matches consumer with mcp_register capability', () => {
+  it('should allow mcp_register when token matches with that capability', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'mcp-secret';
     try {
-      const result = authorizeMcpRegister(mockUnaryCall('mcp-secret'), {
+      const result = authorizeConsumer(mockGrpcCall('mcp-secret'), {
         providers: {},
         consumers: {
           apme: { token_env: 'TEST_TOKEN', capabilities: { mcp_register: true } },
         },
-      });
+      }, 'mcp_register');
       expect(result.allowed).toBe(true);
       expect(result.consumer).toBe('apme');
     } finally {
@@ -986,16 +958,16 @@ describe('authorizeMcpRegister', () => {
     }
   });
 
-  it('should reject when token matches but consumer lacks mcp_register capability', () => {
+  it('should reject mcp_register when consumer only has inline_policy', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'mcp-secret';
     try {
-      const result = authorizeMcpRegister(mockUnaryCall('mcp-secret'), {
+      const result = authorizeConsumer(mockGrpcCall('mcp-secret'), {
         providers: {},
         consumers: {
           apme: { token_env: 'TEST_TOKEN', capabilities: { inline_policy: true } },
         },
-      });
+      }, 'mcp_register');
       expect(result.allowed).toBe(false);
     } finally {
       if (prev === undefined) delete process.env.TEST_TOKEN;
@@ -1003,16 +975,27 @@ describe('authorizeMcpRegister', () => {
     }
   });
 
-  it('should reject when token does not match any consumer', () => {
+  it('should reject mcp_register when no token provided', () => {
+    const result = authorizeConsumer(mockGrpcCall(), {
+      providers: {},
+      consumers: {
+        apme: { token_env: 'TEST_TOKEN', capabilities: { mcp_register: true } },
+      },
+    }, 'mcp_register');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('consumer authentication');
+  });
+
+  it('should reject mcp_register when token does not match', () => {
     const prev = process.env.TEST_TOKEN;
     process.env.TEST_TOKEN = 'mcp-secret';
     try {
-      const result = authorizeMcpRegister(mockUnaryCall('wrong-token'), {
+      const result = authorizeConsumer(mockGrpcCall('wrong-token'), {
         providers: {},
         consumers: {
           apme: { token_env: 'TEST_TOKEN', capabilities: { mcp_register: true } },
         },
-      });
+      }, 'mcp_register');
       expect(result.allowed).toBe(false);
       expect(result.reason).toContain('not recognized');
     } finally {

--- a/packages/daemon/tests/integration/helpers/mock-daemon.ts
+++ b/packages/daemon/tests/integration/helpers/mock-daemon.ts
@@ -138,10 +138,9 @@ export async function createMockDaemon(chatOptions?: MockChatOptions): Promise<M
             call.write({ done: { finish_reason: finishReason } });
             call.end();
           }
-        } catch (err: any) {
-          // Stream may have been cancelled/closed
+        } catch (_err: unknown) {
           if (!call.cancelled) {
-            try { call.end(); } catch {}
+            try { call.end(); } catch { /* stream already closed */ }
           }
         }
       })();

--- a/packages/daemon/tests/integration/web-sse.test.ts
+++ b/packages/daemon/tests/integration/web-sse.test.ts
@@ -60,8 +60,8 @@ const chatRequests: Array<{ model: string; messages: any[] }> = [];
 /** In-memory secret store for testing */
 const mockSecretStore: SecretStore = {
   async get(key: string) { return key === 'OPENAI_API_KEY' ? 'sk-test' : null; },
-  async set(key: string, value: string) {},
-  async delete(key: string) { return true; },
+  async set(_key: string, _value: string) {},
+  async delete(_key: string) { return true; },
   async has(key: string) { return key === 'OPENAI_API_KEY'; },
 };
 
@@ -445,8 +445,7 @@ describe('Web API - Key Status Endpoint', () => {
 
 describe('Web API - CORS and Headers', () => {
   it('should set CORS headers on responses', async () => {
-    const { statusCode, body } = await httpRequest('GET', `${baseUrl}/api/health`);
-    // CORS is handled by middleware, verify the response is accessible
+    const { statusCode } = await httpRequest('GET', `${baseUrl}/api/health`);
     expect(statusCode).toBe(200);
   });
 

--- a/packages/vscode/eslint.config.mjs
+++ b/packages/vscode/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config(
         'warn',
         { selector: 'import', format: ['camelCase', 'PascalCase'] },
       ],
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },


### PR DESCRIPTION
## Summary

Code quality pass addressing low-risk, high-value housekeeping items:

- **Extract `DEFAULT_WEB_PORT` constant** — replace magic `8787` literals in the daemon package (CLI, gRPC service, web server) with a single `DEFAULT_WEB_PORT` exported from `core/constants.ts`. The VS Code extension retains its own `8787` defaults intentionally — it has no workspace dependency on `@abbenay/core`, and adding one for a single constant would be worse architecturally.
- **Unify consumer auth helpers** — collapse near-identical `authorizeInlinePolicy` and `authorizeMcpRegister` functions (~80 lines of duplication) into one parameterized `authorizeConsumer(call, config, capability)` function; deprecated wrappers kept for backward compat. Error messages use human-readable `CAPABILITY_LABELS` instead of raw keys.
- **Add `policies.test.ts`** (24 tests) — covers `loadCustomPolicies` (missing file, valid YAML, malformed input), `saveCustomPolicies` (dir creation, atomic overwrite, full field round-trip), `resolvePolicy`, `flattenPolicy`, `listAllPolicies` (built-in shadowing), and built-in policy integrity checks
- **Add `paths.test.ts`** (15 tests) — covers `getRuntimeDir` (XDG, darwin, linux fallback), `getConfigDir`, `getDataDir`, and all derived helpers (socket, PID, config, policies paths)
- **Promote `no-explicit-any` to `error`** in both daemon and vscode ESLint configs; test files remain at `warn` via override (proto-loader dynamic types). Fix 6 pre-existing lint errors in integration test helpers (unused vars, empty catch block).

**Test results:** 357 passed (38 new), 0 lint errors.

## Test plan

- [x] All 357 tests pass (`npx vitest run`)
- [x] ESLint clean: 0 errors in production code
- [x] No behavioral changes — only refactoring, new tests, and lint tightening