### PR TITLE
chore: add GH Actions caching and optimize container build layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.containerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,29 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-1-dev
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-1-dev xvfb
+
+      - name: Cache build tools
+        uses: actions/cache@v4
+        with:
+          path: .build-tools
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install dependencies
         run: npm ci
 
       - name: Lint
         run: npm run lint
-
-      - name: Install Xvfb
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
 
       - name: Disable GPU acceleration
         run: |
@@ -61,8 +71,21 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-1-dev
 
+      - name: Cache build tools
+        uses: actions/cache@v4
+        with:
+          path: .build-tools
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+
       - name: Bootstrap
         run: ./bootstrap.sh
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install dependencies
         run: npm ci
@@ -91,6 +114,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Cache build tools
+        uses: actions/cache@v4
+        with:
+          path: .build-tools
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build-tools
-          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build-tools
-          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh
@@ -119,7 +119,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build-tools
-          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build-tools
-          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build-tools
-          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,21 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq libsecret-1-dev
 
+      - name: Cache build tools
+        uses: actions/cache@v4
+        with:
+          path: .build-tools
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
+
       - name: Bootstrap
         run: ./bootstrap.sh
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install dependencies
         run: npm ci
@@ -81,6 +94,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Cache build tools
+        uses: actions/cache@v4
+        with:
+          path: .build-tools
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version') }}
 
       - name: Bootstrap
         run: ./bootstrap.sh

--- a/Containerfile
+++ b/Containerfile
@@ -21,21 +21,36 @@ RUN dnf install -y --nodocs python3 python3-pip xz && \
     dnf clean all
 
 WORKDIR /build
-COPY . .
 
 # Download an official nodejs.org binary for SEA injection.  The UBI9
 # Node.js package doesn't contain the NODE_SEA_FUSE sentinel required
 # to produce a Single Executable Application.
+# Cached via BuildKit mount so re-downloads are skipped across builds.
 ARG TARGETARCH
-RUN node_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "${TARGETARCH:-$(node -p process.arch)}") && \
+COPY .node-version .node-version
+RUN --mount=type=cache,target=/tmp/node-cache,sharing=locked \
+    node_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "${TARGETARCH:-$(node -p process.arch)}") && \
     node_version=$(cat .node-version | tr -d '[:space:]') && \
+    tarball="/tmp/node-cache/node-v${node_version}-linux-${node_arch}.tar.xz" && \
     mkdir -p /build/.sea-node && \
-    curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
-      | tar xJ --strip-components=1 -C /build/.sea-node && \
+    if [ ! -f "$tarball" ]; then \
+      curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" -o "$tarball"; \
+    fi && \
+    tar xJf "$tarball" --strip-components=1 -C /build/.sea-node && \
     grep -q 'NODE_SEA_FUSE' /build/.sea-node/bin/node
 
-RUN npm ci --ignore-scripts && \
+# Copy lockfiles and workspace package.json files first so the npm ci
+# layer is only invalidated when dependencies actually change.
+COPY package.json package-lock.json ./
+COPY packages/daemon/package.json packages/daemon/
+COPY packages/vscode/package.json packages/vscode/
+COPY packages/proto-ts/package.json packages/proto-ts/
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci --ignore-scripts && \
     npx node-gyp rebuild --directory node_modules/keytar 2>/dev/null || true
+
+# Now copy the full source tree and build.
+COPY . .
 
 RUN node_arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "${TARGETARCH:-$(node -p process.arch)}") && \
     export NODE_SEA_BASE="/build/.sea-node/bin/node" && \

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 # Abbenay — Multi-stage container build
 #
-# Build:   podman build -f Containerfile -t abbenay:latest .
+# Build:   podman build -f Containerfile -t abbenay:latest .  (podman 4+ / BuildKit required)
 # Run:     podman run -d -p 8787:8787 \
 #            -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
 #            -e OPENROUTER_API_KEY=sk-... \
@@ -33,8 +33,10 @@ RUN --mount=type=cache,target=/tmp/node-cache,sharing=locked \
     node_version=$(cat .node-version | tr -d '[:space:]') && \
     tarball="/tmp/node-cache/node-v${node_version}-linux-${node_arch}.tar.xz" && \
     mkdir -p /build/.sea-node && \
-    if [ ! -f "$tarball" ]; then \
-      curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" -o "$tarball"; \
+    if [ ! -f "$tarball" ] || ! tar -tJf "$tarball" >/dev/null 2>&1; then \
+      rm -f "$tarball"; \
+      curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" -o "${tarball}.tmp" && \
+      mv "${tarball}.tmp" "$tarball"; \
     fi && \
     tar xJf "$tarball" --strip-components=1 -C /build/.sea-node && \
     grep -q 'NODE_SEA_FUSE' /build/.sea-node/bin/node


### PR DESCRIPTION
## Summary

- **Containerfile layer reordering**: Copy lockfiles and workspace `package.json` files before `COPY . .` so the `npm ci` layer is only invalidated when dependencies actually change — not on every source edit. With the existing Buildx GHA cache (`cache-from: type=gha`), this should skip the full `npm ci` install on most PR builds.
- **BuildKit cache mounts**: Add `--mount=type=cache` for the npm tarball cache (`~/.npm`) and the Node.js SEA binary download (`/tmp/node-cache`), so even when layers are invalidated (e.g., lockfile change or cross-arch build), downloads are skipped if the content is already cached.
- **CI/Release workflow caching**: Add `actions/cache@v4` for `.build-tools/` (Node, uv, prek — keyed on `.node-version`) and `~/.npm` (keyed on `package-lock.json`) across all jobs in `ci.yml` and `release.yml`.
- **Consolidated apt-get**: Merged the two `apt-get update && install` steps in `ci.yml` `lint-and-test` into one (libsecret-1-dev + xvfb).
- **`.dockerignore` symlink**: Docker/Buildx reads `.dockerignore`, not `.containerignore`. Added a symlink so the build context is filtered consistently.

## Expected impact

| Change | Estimated savings | When |
|---|---|---|
| Containerfile layer reorder | 2-4 min per container build | Most PR builds (only source changed) |
| BuildKit npm cache mount | 30-60s on lockfile changes | When npm ci layer is invalidated |
| Node tarball cache mount | 10-15s per arch | Every container build |
| `.build-tools` cache in CI | 15-30s per job | Every CI run after first |
| npm cache in CI | 30-60s per job (x4 jobs) | Every CI run after first |
| Consolidated apt-get | ~10s | Every lint-and-test run |

## Test plan

- [ ] CI workflow runs successfully on this PR (validates workflow syntax + caching)
- [ ] Container build succeeds (validates Containerfile layer reordering + BuildKit mounts)
- [ ] Second CI run shows cache hits in build-tools and npm cache steps
- [ ] Container build with no dependency changes skips npm ci layer


Made with [Cursor](https://cursor.com)