### PR TITLE
fix: vertex-anthropic compat — empty text blocks, tool_use SSE, and model visibility

### DIFF
--- a/packages/daemon/src/core/engines.test.ts
+++ b/packages/daemon/src/core/engines.test.ts
@@ -146,13 +146,6 @@ describe('convertAnthropicJsonToSse', () => {
     expect(convertAnthropicJsonToSse(randomObj)).toEqual({ ok: false, reason: 'parse-error' });
   });
 
-  it('should return parse-error for JSON that is not an Anthropic Messages response', () => {
-    const errorPayload = JSON.stringify({ error: { type: 'server_error', message: 'Internal error' } });
-    expect(convertAnthropicJsonToSse(errorPayload)).toEqual({ ok: false, reason: 'parse-error' });
-    const randomObj = JSON.stringify({ status: 'ok', data: [1, 2, 3] });
-    expect(convertAnthropicJsonToSse(randomObj)).toEqual({ ok: false, reason: 'parse-error' });
-  });
-
   it('should return non-text-content reason for null content blocks', () => {
     const json = JSON.stringify({ id: 'msg', content: [null, { type: 'text', text: 'hi' }] });
     const result = convertAnthropicJsonToSse(json);
@@ -176,8 +169,9 @@ describe('convertAnthropicJsonToSse', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.body).toContain('Hello ');
-    expect(result.body).toContain('');
     expect(result.body).toContain('world');
+    const blockDeltaCount = (result.body.match(/event: content_block_delta/g) || []).length;
+    expect(blockDeltaCount).toBe(2);
   });
 
   it('should preserve message metadata in SSE events', () => {

--- a/packages/daemon/src/core/engines.test.ts
+++ b/packages/daemon/src/core/engines.test.ts
@@ -115,7 +115,7 @@ describe('convertAnthropicJsonToSse', () => {
     expect(result.body.endsWith('\n')).toBe(true);
   });
 
-  it('should return non-text-content reason for tool_use blocks', () => {
+  it('should convert tool_use blocks to SSE events', () => {
     const json = JSON.stringify({
       id: 'msg_456',
       content: [
@@ -124,12 +124,26 @@ describe('convertAnthropicJsonToSse', () => {
       ],
     });
     const result = convertAnthropicJsonToSse(json);
-    expect(result).toEqual({ ok: false, reason: 'non-text-content' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.body).toContain('Let me call a tool');
+    expect(result.body).toContain('"type":"tool_use"');
+    expect(result.body).toContain('"name":"search"');
+    expect(result.body).toContain('"id":"call_1"');
+    expect(result.body).toContain('input_json_delta');
+    expect(result.body).toContain('event: message_stop');
   });
 
   it('should return parse-error reason for invalid JSON', () => {
     const result = convertAnthropicJsonToSse('{broken');
     expect(result).toEqual({ ok: false, reason: 'parse-error' });
+  });
+
+  it('should return parse-error for JSON that is not an Anthropic Messages response', () => {
+    const errorPayload = JSON.stringify({ error: { type: 'server_error', message: 'Internal error' } });
+    expect(convertAnthropicJsonToSse(errorPayload)).toEqual({ ok: false, reason: 'parse-error' });
+    const randomObj = JSON.stringify({ status: 'ok', data: [1, 2, 3] });
+    expect(convertAnthropicJsonToSse(randomObj)).toEqual({ ok: false, reason: 'parse-error' });
   });
 
   it('should return parse-error for JSON that is not an Anthropic Messages response', () => {
@@ -153,7 +167,7 @@ describe('convertAnthropicJsonToSse', () => {
     expect(result.body).toContain('event: message_start');
   });
 
-  it('should concatenate multiple text blocks', () => {
+  it('should stream multiple text blocks as separate SSE events', () => {
     const json = JSON.stringify({
       id: 'msg',
       content: [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'world' }],
@@ -161,7 +175,9 @@ describe('convertAnthropicJsonToSse', () => {
     const result = convertAnthropicJsonToSse(json);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.body).toContain('Hello world');
+    expect(result.body).toContain('Hello ');
+    expect(result.body).toContain('');
+    expect(result.body).toContain('world');
   });
 
   it('should preserve message metadata in SSE events', () => {

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -147,6 +147,8 @@ type VertexAnthropicProviderFactory = (config: Record<string, unknown>) => (mode
 
 /**
  * Strip fields the Anthropic Vertex API rejects but the AI SDK may inject.
+ * Also removes empty text content blocks which Vertex Anthropic rejects with
+ * "text content blocks must be non-empty".
  * Returns the sanitized JSON string and the list of removed field names,
  * or null if no changes were needed.
  */
@@ -160,6 +162,50 @@ export function sanitizeVertexRequestBody(bodyStr: string): { body: string; remo
   const removed: string[] = [];
   if ('stream_options' in body) { delete body.stream_options; removed.push('stream_options'); }
   if ('stream' in body) { delete body.stream; removed.push('stream'); }
+
+  // Filter empty/whitespace text content blocks from messages — Vertex Anthropic rejects them.
+  // This handles both string content (e.g. content: ' ') and array content
+  // (e.g. [{type:'text', text:' '}]). Messages that have no content remaining
+  // after filtering are dropped entirely.
+  if (Array.isArray(body.messages)) {
+    let messagesChanged = false;
+    const filteredMessages: Array<Record<string, unknown>> = [];
+    for (const msg of body.messages as Array<Record<string, unknown>>) {
+      // String content: if empty/whitespace, drop the message
+      if (typeof msg.content === 'string') {
+        if (msg.content.trim() === '') {
+          messagesChanged = true;
+          continue;
+        }
+        filteredMessages.push(msg);
+        continue;
+      }
+      // Array content: filter whitespace-only text blocks
+      if (!Array.isArray(msg.content)) {
+        filteredMessages.push(msg);
+        continue;
+      }
+      const filtered = (msg.content as Array<Record<string, unknown>>).filter(
+        block => !(block.type === 'text' && typeof block.text === 'string' && block.text.trim() === ''),
+      );
+      if (filtered.length === 0 && (msg.content as unknown[]).length > 0) {
+        // All content was empty text blocks — drop the whole message
+        messagesChanged = true;
+        continue;
+      }
+      if (filtered.length !== (msg.content as unknown[]).length) {
+        messagesChanged = true;
+        filteredMessages.push({ ...msg, content: filtered });
+      } else {
+        filteredMessages.push(msg);
+      }
+    }
+    if (messagesChanged) {
+      body.messages = filteredMessages;
+      removed.push('empty_text_blocks');
+    }
+  }
+
   if (removed.length === 0) {
     return null;
   }
@@ -189,31 +235,44 @@ export function convertAnthropicJsonToSse(jsonStr: string): SseConversionResult 
   if (!Array.isArray(msg.content)) {
     return { ok: false, reason: 'parse-error' };
   }
-  const content = msg.content;
-  let fullText = '';
-  for (const block of content) {
+  const content = msg.content as Array<Record<string, unknown>>;
+
+  const events: string[] = [
+    `event: message_start\ndata: ${JSON.stringify({ type: 'message_start', message: { id: msg.id || '', type: 'message', role: 'assistant', content: [], model: msg.model || '', stop_reason: null, stop_sequence: null, usage: msg.usage || { input_tokens: 0, output_tokens: 0 } } })}\n`,
+  ];
+
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i];
     if (!block || typeof block !== 'object') {
       return { ok: false, reason: 'non-text-content' };
     }
-    const b = block as Record<string, unknown>;
-    if (b.type === 'text') {
-      fullText += typeof b.text === 'string' ? b.text : '';
+    if (block.type === 'text') {
+      const text = typeof block.text === 'string' ? block.text : '';
+      events.push(
+        `event: content_block_start\ndata: ${JSON.stringify({ type: 'content_block_start', index: i, content_block: { type: 'text', text: '' } })}\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', index: i, delta: { type: 'text_delta', text } })}\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: 'content_block_stop', index: i })}\n`,
+      );
+    } else if (block.type === 'tool_use') {
+      const inputStr = block.input != null ? JSON.stringify(block.input) : '{}';
+      events.push(
+        `event: content_block_start\ndata: ${JSON.stringify({ type: 'content_block_start', index: i, content_block: { type: 'tool_use', id: block.id || '', name: block.name || '', input: {} } })}\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', index: i, delta: { type: 'input_json_delta', partial_json: inputStr } })}\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: 'content_block_stop', index: i })}\n`,
+      );
     } else {
       return { ok: false, reason: 'non-text-content' };
     }
   }
+
   const stopReason = typeof msg.stop_reason === 'string' ? msg.stop_reason : 'end_turn';
   const stopSequence = typeof msg.stop_sequence === 'string' || msg.stop_sequence === null
     ? msg.stop_sequence
     : null;
-  const events = [
-    `event: message_start\ndata: ${JSON.stringify({ type: 'message_start', message: { id: msg.id || '', type: 'message', role: 'assistant', content: [], model: msg.model || '', stop_reason: null, stop_sequence: null, usage: msg.usage || { input_tokens: 0, output_tokens: 0 } } })}\n`,
-    `event: content_block_start\ndata: ${JSON.stringify({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } })}\n`,
-    `event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: fullText } })}\n`,
-    `event: content_block_stop\ndata: ${JSON.stringify({ type: 'content_block_stop', index: 0 })}\n`,
+  events.push(
     `event: message_delta\ndata: ${JSON.stringify({ type: 'message_delta', delta: { stop_reason: stopReason, stop_sequence: stopSequence }, usage: msg.usage || { output_tokens: 0 } })}\n`,
     `event: message_stop\ndata: ${JSON.stringify({ type: 'message_stop' })}\n`,
-  ];
+  );
   return { ok: true as const, body: `${events.join('\n')}\n` };
 }
 
@@ -957,12 +1016,14 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
       case 'user':
         return { role: 'user' as const, content: m.content };
 
-      case 'assistant':
+      case 'assistant': {
+        // Always use array form so empty content is handled uniformly.
+        // sanitizeVertexRequestBody will drop messages with empty content arrays.
+        const parts: AssistantModelMessage['content'] = [];
+        if (m.content && m.content.trim()) {
+          parts.push({ type: 'text', text: m.content });
+        }
         if (m.tool_calls && m.tool_calls.length > 0) {
-          const parts: AssistantModelMessage['content'] = [];
-          if (m.content) {
-            parts.push({ type: 'text', text: m.content });
-          }
           for (const tc of m.tool_calls) {
             const item = tc && typeof tc === 'object' ? tc as Record<string, unknown> : {};
             const args = item.arguments;
@@ -973,9 +1034,9 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
               input: typeof args === 'string' ? JSON.parse(args) as Record<string, unknown> : (args && typeof args === 'object' ? args as Record<string, unknown> : {}),
             });
           }
-          return { role: 'assistant' as const, content: parts };
         }
-        return { role: 'assistant' as const, content: m.content };
+        return { role: 'assistant' as const, content: parts };
+      }
 
       case 'tool':
         return {

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -188,8 +188,7 @@ export function sanitizeVertexRequestBody(bodyStr: string): { body: string; remo
       const filtered = (msg.content as Array<Record<string, unknown>>).filter(
         block => !(block.type === 'text' && typeof block.text === 'string' && block.text.trim() === ''),
       );
-      if (filtered.length === 0 && (msg.content as unknown[]).length > 0) {
-        // All content was empty text blocks — drop the whole message
+      if (filtered.length === 0) {
         messagesChanged = true;
         continue;
       }
@@ -221,9 +220,10 @@ export type SseConversionResult =
  * the Vercel AI SDK's @ai-sdk/google-vertex/anthropic parser expects.
  *
  * Returns `{ ok: false, reason }` when conversion cannot be performed:
- * - `'parse-error'`: the input is not valid JSON
- * - `'non-text-content'`: the response contains non-text content blocks
- *   (e.g. tool_use) that cannot be faithfully represented
+ * - `'parse-error'`: the input is not valid JSON or not an Anthropic Messages response
+ * - `'non-text-content'`: the response contains unsupported content blocks
+ *   (e.g. null entries) that cannot be faithfully represented.
+ *   `text` and `tool_use` blocks are handled.
  */
 export function convertAnthropicJsonToSse(jsonStr: string): SseConversionResult {
   let msg: Record<string, unknown>;
@@ -330,8 +330,8 @@ async function vertexAnthropicProvider(
         }
         if (result.reason === 'non-text-content') {
           debug(
-            '[Adapter] vertex-anthropic: proxy returned application/json with non-text content blocks (e.g. tool_use). ' +
-            'JSON→SSE conversion only supports text blocks. Tool calling requires the proxy to return text/event-stream.',
+            '[Adapter] vertex-anthropic: proxy returned application/json with unsupported content blocks. ' +
+            'JSON→SSE conversion supports text and tool_use blocks only.',
           );
         } else {
           debug('[Adapter] vertex-anthropic: proxy returned application/json but body is not valid Anthropic Messages API JSON.');
@@ -1017,8 +1017,6 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
         return { role: 'user' as const, content: m.content };
 
       case 'assistant': {
-        // Always use array form so empty content is handled uniformly.
-        // sanitizeVertexRequestBody will drop messages with empty content arrays.
         const parts: AssistantModelMessage['content'] = [];
         if (m.content && m.content.trim()) {
           parts.push({ type: 'text', text: m.content });
@@ -1034,6 +1032,9 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
               input: typeof args === 'string' ? JSON.parse(args) as Record<string, unknown> : (args && typeof args === 'object' ? args as Record<string, unknown> : {}),
             });
           }
+        }
+        if (parts.length === 0) {
+          return { role: 'assistant' as const, content: m.content || '' };
         }
         return { role: 'assistant' as const, content: parts };
       }

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -462,6 +462,14 @@ export class CoreState {
         const compositeId = `${providerId}/${modelName}`;
         const discovered = discoveryMap.get(engineModelId);
 
+        // Fall back to engine's static metadata when discovery returns nothing.
+        // Without this, engines that have no discovery API (e.g. vertex-anthropic)
+        // would report supportsTools=false, causing VS Code/Copilot to hide the model.
+        const capabilities = discovered?.capabilities ?? {
+          supportsTools: engineInfo.supportsTools,
+          supportsVision: false,
+        };
+
         allModels.push({
           id: compositeId,
           name: modelName,
@@ -469,7 +477,7 @@ export class CoreState {
           provider: providerId,
           engine: providerCfg.engine,
           contextWindow: discovered?.contextWindow || 0,
-          capabilities: discovered?.capabilities,
+          capabilities,
           params: Object.keys(modelCfg).length > 0 ? modelCfg : undefined,
         });
       }

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -462,12 +462,8 @@ export class CoreState {
         const compositeId = `${providerId}/${modelName}`;
         const discovered = discoveryMap.get(engineModelId);
 
-        // Fall back to engine's static metadata when discovery returns nothing.
-        // Without this, engines that have no discovery API (e.g. vertex-anthropic)
-        // would report supportsTools=false, causing VS Code/Copilot to hide the model.
         const capabilities = discovered?.capabilities ?? {
           supportsTools: engineInfo.supportsTools,
-          supportsVision: false,
         };
 
         allModels.push({

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -540,8 +540,6 @@ export function createWebApp(state: DaemonState): Express {
     // Convert web messages to the format state.chat() expects
     const chatMessages = messages.map((m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown[] }) => ({
       role: m.role || 'user',
-      // Preserve null/undefined as-is so convertMessages can skip empty content
-      // blocks rather than producing empty strings that Vertex Anthropic rejects
       content: m.content ?? '',
       name: m.name || undefined,
       tool_call_id: m.tool_call_id || undefined,

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -540,7 +540,9 @@ export function createWebApp(state: DaemonState): Express {
     // Convert web messages to the format state.chat() expects
     const chatMessages = messages.map((m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown[] }) => ({
       role: m.role || 'user',
-      content: m.content || '',
+      // Preserve null/undefined as-is so convertMessages can skip empty content
+      // blocks rather than producing empty strings that Vertex Anthropic rejects
+      content: m.content ?? '',
       name: m.name || undefined,
       tool_call_id: m.tool_call_id || undefined,
       tool_calls: m.tool_calls || undefined,


### PR DESCRIPTION
## Summary

- Fix Vertex Anthropic compatibility issues discovered after the engine was merged:
  - Sanitize empty/whitespace text content blocks from requests (Vertex rejects with 400)
  - Handle `tool_use` blocks in JSON-to-SSE conversion (previously failed with `non-text-content`)
  - Fall back to engine's static `supportsTools` metadata when model discovery returns nothing (VS Code was hiding models)
  - Use nullish coalescing (`??`) for message content in `web/server.ts`
- Update tests to match new tool_use SSE behavior and add coverage for non-Anthropic JSON payloads

## Commits

- `fix: vertex-anthropic empty text blocks, tool_use SSE, and model visibility` -- compat fixes for edge cases found during real Vertex Anthropic usage
- `test(core): update convertAnthropicJsonToSse tests for tool_use SSE support` -- align test expectations, add parse-error coverage
- `fix: address Copilot review feedback on vertex-anthropic compat` -- remove inaccurate comments, drop hardcoded supportsVision:false, fix empty-array edge cases in sanitizer and convertMessages, remove duplicate test, fix tautological assertion, update JSDoc/debug messages

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test` passes locally (420 tests, all green)
- [x] Tests updated for changed behavior
- [x] All Copilot review comments addressed and threads resolved