### PR TITLE
feat: add LLM provider configuration and chat sidebar webviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ __pycache__/
 .venv/
 .build-venv/
 *.egg-info/
-.pytest_cache/
+.pytest_cache/.superpowers/

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -175,6 +175,28 @@ npm run daemon    # tsx runs directly, no build needed
 2. Press **F5** to launch Extension Development Host
 3. Check Output panel -> "Abbenay Provider" for logs
 
+#### Webview architecture
+
+The extension has two webviews built with `@vscode-elements/elements` (Lit-based web components for native VS Code look):
+
+| Webview | Type | Entry point | Handler |
+|---------|------|-------------|---------|
+| Provider Configuration | Editor panel | `src/webview-ui/provider/main.ts` | `src/webviews/provider/providerHandler.ts` |
+| Chat Sidebar | Activity bar view | `src/webview-ui/chat/main.ts` | `src/webviews/chat/chatHandler.ts` |
+
+Webview UI lives in `src/webview-ui/` (bundled by esbuild, excluded from tsc). Extension host handlers live in `src/webviews/`.
+
+#### Building webviews
+
+```bash
+cd packages/vscode
+node esbuild.js                 # dev build (sourcemaps)
+node esbuild.js --production    # production build (minified)
+node esbuild.js --watch         # watch mode
+```
+
+This builds both the extension host (`out/extension.js`) and webview bundles (`out/webview-ui/*/main.js`).
+
 ### Web dashboard
 
 1. Edit `packages/daemon/static/index.html`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,7 +97,62 @@ curl -X POST http://localhost:8787/api/chat \
   -d '{"model":"mock/echo","messages":[{"role":"user","content":"Hello!"}]}'
 ```
 
+## VS Code Extension Tests
+
+The extension uses `@vscode/test-cli` with Mocha to run tests inside a real VS Code instance.
+
+```bash
+cd packages/vscode
+npm test
+```
+
+On headless Linux: `xvfb-run -a npm test`
+
+### Test Structure
+
+```
+packages/vscode/
+├── src/test/
+│   ├── extension.test.ts               <- Smoke tests (activation, commands, config)
+│   ├── helpers/
+│   │   ├── mockDaemonClient.ts         <- Stub DaemonClient with test data
+│   │   └── mockWebview.ts              <- Stub vscode.Webview with message recorder
+│   └── webviews/
+│       ├── getNonce.test.ts            <- Pure function (nonce generation)
+│       ├── getWebviewContent.test.ts   <- HTML template generation
+│       ├── providerHandler.test.ts     <- Provider message handler
+│       └── chatHandler.test.ts         <- Chat message handler
+└── .vscode-test.mjs                    <- Test runner config
+```
+
+### Smoke Tests
+
+| Test | What it covers |
+|------|----------------|
+| `extension.test.ts` | Extension activation, command registration, chat view, config defaults |
+
+### Webview Handler Tests
+
+Handler tests mock the `DaemonClient` and `vscode.Webview` to test message routing, data transformation, and error handling without a running daemon.
+
+| Test | What it covers |
+|------|----------------|
+| `getNonce.test.ts` | Nonce format (32 hex chars), uniqueness |
+| `getWebviewContent.test.ts` | HTML structure, CSP headers, nonce injection, panel-specific assets |
+| `providerHandler.test.ts` | Ready message routing, engine listing, model discovery with credentials, config forwarding, error handling |
+| `chatHandler.test.ts` | Ready message routing, model listing, session create/delete, stream cancellation, error handling |
+
+### Mock Helpers
+
+- **`mockDaemonClient.ts`** — Creates a stub `DaemonClient` with empty default return values. Override individual methods per test.
+- **`mockWebview.ts`** — Creates a stub `vscode.Webview` that records all `postMessage()` calls in a `.messages` array for assertion.
+
 ## Adding Tests
 
+### Daemon tests
 New unit tests should be co-located with their source files (e.g., `src/core/foo.test.ts`).
 New integration tests should go in `packages/daemon/tests/integration/`.
+
+### VS Code extension tests
+New webview handler tests go in `packages/vscode/src/test/webviews/`.
+New test helpers go in `packages/vscode/src/test/helpers/`.

--- a/docs/WEBVIEWS.md
+++ b/docs/WEBVIEWS.md
@@ -1,0 +1,122 @@
+# VS Code Extension Webviews
+
+## Overview
+
+The Abbenay VS Code extension provides two webviews for managing LLM providers and interacting with models directly from the editor.
+
+| Webview | Purpose | Access |
+|---------|---------|--------|
+| **Provider Configuration** | Set up LLM providers — select engine, enter credentials, discover and enable models | Command palette: "Abbenay: Configure Providers" |
+| **Chat Sidebar** | Chat with any configured model — streaming responses, markdown, tool calls, approval gates | Activity bar: Abbenay icon |
+
+## Design Decisions
+
+### Native webviews over iframes
+
+The webviews use VS Code's native webview API rather than embedding an external web dashboard in an iframe. This gives direct access to VS Code theming (CSS variables), the message-passing API, and CSP controls without cross-origin complications.
+
+### Minimal capabilities
+
+Webviews are intentionally thin UI shells. All business logic (provider configuration, model discovery, chat streaming, tool approval) runs in the extension host and communicates with the daemon via gRPC. The webview only handles rendering and user interaction. This reduces the testing surface — webview code is hard to test automatically, so keeping it minimal limits what can break.
+
+### @vscode-elements/elements
+
+Form controls use [`@vscode-elements/elements`](https://vscode-elements.github.io/), a Lit-based web component library that provides native VS Code-styled UI elements. Components like `vscode-button`, `vscode-textfield`, `vscode-single-select`, and `vscode-radio-group` auto-inherit the active VS Code theme — no custom button/input CSS needed.
+
+Accordion sections use custom divs rather than `vscode-collapsible` because the component forces uppercase headings via shadow DOM styles that cannot be overridden.
+
+### Build separation
+
+Webview UI code (`src/webview-ui/`) is bundled by esbuild with `platform: 'browser'` and `format: 'iife'`, separate from the extension host (`platform: 'node'`, `format: 'cjs'`). The webview directory is excluded from `tsc` to avoid Node.js type conflicts in browser code.
+
+## Provider Configuration Panel
+
+A two-step accordion form for managing LLM providers.
+
+### Step 1: Provider Setup
+- **Engine selection** — dropdown of available engines (OpenAI, Anthropic, Ollama, etc.)
+- **Provider name** — unique identifier with validation
+- **Base URL** — shown conditionally when the engine supports a custom endpoint
+- **API key storage** — radio toggle between system keychain and environment variable
+
+### Step 2: Select Models
+- **Model discovery** — queries the engine API using the entered credentials
+- **Dual-list selector** — Available models on the left, Enabled models on the right, with Add/Remove actions
+- **Search filter** — narrows the available models list
+
+### Provider list
+Configured providers appear as cards showing status (healthy/error/unconfigured), engine badge, and model count with edit/delete actions.
+
+## Chat Sidebar
+
+A Copilot-style chat interface in the activity bar sidebar.
+
+### Message rendering
+- User messages appear as right-aligned bubbles
+- Assistant messages are left-aligned with an "Abbenay" label
+- Markdown rendered via `marked` with `highlight.js` syntax highlighting (TypeScript, Python, Bash, JSON, YAML, XML, CSS)
+- Code blocks include a language label and copy button
+
+### Streaming
+- Thinking indicator (animated dots) while waiting for the first chunk
+- Progressive markdown rendering as chunks arrive
+- Smart auto-scroll that pauses when the user scrolls up
+- Cancel button to abort active streams
+
+### Tool calls
+- Collapsible cards showing tool name, arguments (JSON), and result
+- "Running" state with a progress spinner, "Used" state after completion
+- Success/error status indicators
+
+### Tool approval gates
+- Warning-styled cards that block the stream until the user responds
+- Allow / Deny / Abort buttons
+- Resolved state shows the decision taken
+
+### Input area
+- Auto-resizing textarea with Enter to send, Shift+Enter for newline
+- Model selector dropdown (opens upward)
+- New session / Delete session controls
+
+## Architecture
+
+```
+┌──────────────────────────────────┐
+│      Webview (Browser)           │
+│  src/webview-ui/provider/main.ts │
+│  src/webview-ui/chat/main.ts     │
+│  @vscode-elements/elements      │
+│  marked + highlight.js           │
+└──────────┬───────────────────────┘
+           │ postMessage / onMessage
+┌──────────▼───────────────────────┐
+│    Extension Host (Node.js)      │
+│  src/webviews/provider/          │
+│    providerHandler.ts            │
+│    ProviderPanel.ts              │
+│  src/webviews/chat/              │
+│    chatHandler.ts                │
+│    ChatViewProvider.ts           │
+│  src/webviews/shared/            │
+│    types.ts (message protocol)   │
+│    getWebviewContent.ts          │
+└──────────┬───────────────────────┘
+           │ gRPC
+┌──────────▼───────────────────────┐
+│         Daemon                   │
+│    Provider management           │
+│    Model discovery               │
+│    Chat sessions + streaming     │
+│    Tool execution                │
+└──────────────────────────────────┘
+```
+
+## Message Protocol
+
+Webviews and the extension host communicate via typed messages defined in `src/webviews/shared/types.ts`. Each message has a `type` discriminator field.
+
+### Provider messages
+`ready` | `getProviders` | `getEngines` | `configureProvider` | `removeProvider` | `discoverModels` | `getConfig` | `setSecret` | `deleteSecret`
+
+### Chat messages
+`ready` | `listModels` | `createSession` | `deleteSession` | `sendMessage` | `cancelStream` | `approveToolCall`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
+        "@vscode-elements/elements": "^2.5.1",
         "long": "^5.3.2",
         "nice-grpc": "^2.1.14",
         "nice-grpc-common": "^2.0.2",
@@ -2024,6 +2025,30 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.1.0"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
@@ -3336,6 +3361,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -3868,6 +3899,26 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vscode-elements/elements": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-2.5.1.tgz",
+      "integrity": "sha512-HiKgIj9GwlfYkw1LrxG7dM5bMQUr8/GkOqG1HU1+npGHd51nRKCF6ZZ9FtnfoC2wujNN0lc+m0emH/wMpAseYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lit/context": "^1.1.3",
+        "lit": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@vscode/codicons": ">=0.0.40"
+      }
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
+      "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/@vscode/test-cli": {
       "version": "0.0.10",
@@ -7474,6 +7525,37 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/locate-path": {
@@ -12257,6 +12339,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.1",
+        "@vscode-elements/elements": "^2.5.1",
         "highlight.js": "^11.11.1",
         "long": "^5.3.2",
         "marked": "^18.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6740,6 +6740,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.7",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
@@ -7656,6 +7665,18 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -12236,7 +12257,9 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.1",
+        "highlight.js": "^11.11.1",
         "long": "^5.3.2",
+        "marked": "^18.0.4",
         "nice-grpc": "^2.1.14",
         "nice-grpc-common": "^2.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.14.3",
+    "@vscode-elements/elements": "^2.5.1",
     "long": "^5.3.2",
     "nice-grpc": "^2.1.14",
     "nice-grpc-common": "^2.0.2",

--- a/packages/vscode/esbuild.js
+++ b/packages/vscode/esbuild.js
@@ -23,6 +23,7 @@ const esbuildProblemMatcherPlugin = {
 };
 
 async function main() {
+  // Extension host bundle (Node.js, CJS)
   const ctx = await esbuild.context({
     entryPoints: ['src/extension.ts'],
     bundle: true,
@@ -39,11 +40,30 @@ async function main() {
     ],
   });
 
+  // Webview UI bundles (browser context, IIFE to avoid exports issue)
+  const webviewCtx = await esbuild.context({
+    entryPoints: [
+      'src/webview-ui/provider/main.ts',
+      'src/webview-ui/chat/main.ts',
+    ],
+    bundle: true,
+    format: 'iife',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'browser',
+    outdir: 'out/webview-ui',
+    logLevel: 'info',
+    plugins: [
+      ...(watch ? [esbuildProblemMatcherPlugin] : []),
+    ],
+  });
+
   if (watch) {
-    await ctx.watch();
+    await Promise.all([ctx.watch(), webviewCtx.watch()]);
   } else {
-    await ctx.rebuild();
-    await ctx.dispose();
+    await Promise.all([ctx.rebuild(), webviewCtx.rebuild()]);
+    await Promise.all([ctx.dispose(), webviewCtx.dispose()]);
   }
 }
 

--- a/packages/vscode/media/chat.css
+++ b/packages/vscode/media/chat.css
@@ -310,7 +310,7 @@ body {
   color: var(--vscode-symbolIcon-keywordForeground, #569cd6);
 }
 
-/* ── Tool Cards ────────────────────────────────────────────────────────────── */
+/* ── Tool Cards (vscode-collapsible) ──────────────────────────────────────── */
 
 .tool-card {
   margin: 8px 0;
@@ -319,48 +319,8 @@ body {
   overflow: hidden;
 }
 
-.tool-card.open .tool-card-body {
-  display: block;
-}
-
-.tool-card-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  background: var(--vscode-editorWidget-background);
-  cursor: pointer;
-  user-select: none;
-}
-
-.tool-card-header:hover {
-  background: var(--vscode-list-hoverBackground);
-}
-
-.tool-card-chevron {
-  font-size: 0.8em;
-  color: var(--vscode-descriptionForeground);
-  transition: transform 0.2s ease;
-}
-
-.tool-card.open .tool-card-chevron {
-  transform: rotate(90deg);
-}
-
-.tool-card-label {
-  font-size: 0.75em;
-  color: var(--vscode-descriptionForeground);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.tool-card-name {
-  flex: 1;
-  font-weight: 600;
-  color: var(--vscode-symbolIcon-functionForeground, #dcdcaa);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.tool-card::part(header) {
+  text-transform: none;
 }
 
 .tool-card-status {
@@ -377,14 +337,7 @@ body {
 }
 
 .tool-card-status.running {
-  animation: spin 1s linear infinite;
   color: var(--vscode-descriptionForeground);
-}
-
-.tool-card-body {
-  display: none;
-  padding: 10px;
-  background: var(--vscode-editor-background);
 }
 
 .tool-card-section {
@@ -481,51 +434,8 @@ body {
   gap: 8px;
 }
 
-.approval-btn-allow {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 4px;
-  background: var(--vscode-button-background);
-  color: var(--vscode-button-foreground);
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.85em;
-  font-weight: 500;
-}
-
-.approval-btn-allow:hover {
-  background: var(--vscode-button-hoverBackground);
-}
-
-.approval-btn-deny {
-  padding: 6px 12px;
-  border: 1px solid var(--vscode-button-border);
-  border-radius: 4px;
-  background: var(--vscode-button-secondaryBackground);
-  color: var(--vscode-button-secondaryForeground);
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.85em;
-}
-
-.approval-btn-deny:hover {
-  background: var(--vscode-button-secondaryHoverBackground);
-}
-
 .approval-btn-abort {
-  padding: 6px 12px;
-  border: 1px solid var(--vscode-errorForeground, #f48771);
-  border-radius: 4px;
-  background: transparent;
-  color: var(--vscode-errorForeground, #f48771);
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.85em;
   margin-left: auto;
-}
-
-.approval-btn-abort:hover {
-  background: var(--vscode-inputValidation-errorBackground, rgba(244, 135, 113, 0.1));
 }
 
 .approval-resolved {
@@ -587,22 +497,6 @@ body {
   }
 }
 
-.cursor {
-  display: inline-block;
-  width: 2px;
-  height: 1em;
-  background: var(--vscode-foreground);
-  margin-left: 1px;
-  vertical-align: text-bottom;
-  animation: blink 1s step-end infinite;
-}
-
-@keyframes blink {
-  50% {
-    opacity: 0;
-  }
-}
-
 /* ── Input Area ────────────────────────────────────────────────────────────── */
 
 .input-area {
@@ -649,53 +543,17 @@ body {
   gap: 6px;
 }
 
-.input-toolbar select {
-  padding: 2px 6px;
-  border: none;
-  background: transparent;
-  color: var(--vscode-descriptionForeground);
-  font: inherit;
-  font-size: 0.8em;
-  cursor: pointer;
-  border-radius: 4px;
-  min-width: 0;
+.toolbar-select {
   max-width: 45%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  min-width: 0;
 }
 
-.input-toolbar select:hover {
-  background: var(--vscode-toolbar-hoverBackground);
-}
-
-.input-toolbar select:focus {
-  outline: 1px solid var(--vscode-focusBorder);
+.toolbar-btn {
+  flex-shrink: 0;
 }
 
 .input-toolbar-spacer {
   flex: 1;
-}
-
-.session-btn {
-  padding: 2px 8px;
-  border: none;
-  background: transparent;
-  color: var(--vscode-descriptionForeground);
-  font: inherit;
-  font-size: 0.8em;
-  cursor: pointer;
-  border-radius: 4px;
-  white-space: nowrap;
-}
-
-.session-btn:hover {
-  background: var(--vscode-toolbar-hoverBackground);
-  color: var(--vscode-foreground);
-}
-
-.session-btn.icon-btn {
-  padding: 2px 4px;
-  font-size: 1em;
 }
 
 .send-btn,
@@ -760,10 +618,3 @@ body {
   font-size: 0.9em;
 }
 
-/* ── Animations ────────────────────────────────────────────────────────────── */
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/packages/vscode/media/chat.css
+++ b/packages/vscode/media/chat.css
@@ -1,0 +1,806 @@
+/* ══════════════════════════════════════════════════════════════════════════════
+   Abbenay Chat Sidebar CSS — Copilot-style layout with markdown & tool approvals
+   ══════════════════════════════════════════════════════════════════════════════ */
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  color: var(--vscode-foreground);
+  background-color: var(--vscode-sideBar-background);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ── Layout ────────────────────────────────────────────────────────────────── */
+
+#root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+/* ── Header ────────────────────────────────────────────────────────────────── */
+
+.chat-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+  background: var(--vscode-sideBar-background);
+  flex-shrink: 0;
+}
+
+.chat-header-left {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-header-title {
+  font-weight: 600;
+  font-size: 0.9em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.chat-header select {
+  flex: 1;
+  min-width: 0;
+  padding: 4px 8px;
+  border: 1px solid var(--vscode-input-border);
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font: inherit;
+  font-size: 0.85em;
+  border-radius: 4px;
+}
+
+.chat-header select:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+}
+
+.chat-header-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.chat-header-actions button {
+  padding: 4px 8px;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85em;
+  border-radius: 4px;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  white-space: nowrap;
+}
+
+.chat-header-actions button:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.chat-header-actions .icon-btn {
+  padding: 4px 6px;
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  font-size: 1.1em;
+}
+
+.chat-header-actions .icon-btn:hover {
+  color: var(--vscode-foreground);
+  background: var(--vscode-toolbar-hoverBackground);
+}
+
+/* ── Message List ──────────────────────────────────────────────────────────── */
+
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+}
+
+/* ── Welcome Screen ────────────────────────────────────────────────────────── */
+
+.welcome {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+}
+
+.welcome-icon {
+  margin-bottom: 12px;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.7;
+}
+
+.welcome h2 {
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  margin-bottom: 8px;
+}
+
+.welcome p {
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── Messages (Copilot-style) ──────────────────────────────────────────────── */
+
+.message {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.message:last-child {
+  border-bottom: none;
+}
+
+.msg-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7em;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.msg-avatar.user {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.msg-avatar.assistant {
+  background: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-widget-border);
+  color: var(--vscode-descriptionForeground);
+}
+
+.msg-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.msg-role {
+  font-size: 0.8em;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  margin-bottom: 4px;
+}
+
+.msg-body {
+  font-size: 0.9em;
+  line-height: 1.55;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+/* ── Markdown in .msg-body ─────────────────────────────────────────────────── */
+
+.msg-body p {
+  margin: 0 0 8px 0;
+}
+
+.msg-body p:last-child {
+  margin-bottom: 0;
+}
+
+.msg-body ul,
+.msg-body ol {
+  padding-left: 18px;
+  margin: 0 0 8px 0;
+}
+
+.msg-body li {
+  margin-bottom: 2px;
+}
+
+.msg-body h1 {
+  font-size: 1.4em;
+  font-weight: 600;
+  margin: 16px 0 8px 0;
+  border-bottom: 1px solid var(--vscode-widget-border);
+  padding-bottom: 4px;
+}
+
+.msg-body h2 {
+  font-size: 1.2em;
+  font-weight: 600;
+  margin: 14px 0 6px 0;
+}
+
+.msg-body h3 {
+  font-size: 1.1em;
+  font-weight: 600;
+  margin: 12px 0 6px 0;
+}
+
+.msg-body h4 {
+  font-size: 1em;
+  font-weight: 600;
+  margin: 10px 0 4px 0;
+}
+
+.msg-body code {
+  padding: 2px 4px;
+  border-radius: 3px;
+  background: var(--vscode-textCodeBlock-background);
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.9em;
+}
+
+.msg-body pre code {
+  padding: 0;
+  background: none;
+}
+
+.msg-body a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+}
+
+.msg-body a:hover {
+  text-decoration: underline;
+}
+
+.msg-body table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  width: 100%;
+}
+
+.msg-body th,
+.msg-body td {
+  border: 1px solid var(--vscode-widget-border);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.msg-body th {
+  background: var(--vscode-editorWidget-background);
+  font-weight: 600;
+}
+
+.msg-body blockquote {
+  border-left: 3px solid var(--vscode-widget-border);
+  padding-left: 12px;
+  margin: 8px 0;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* ── Code Blocks ───────────────────────────────────────────────────────────── */
+
+.code-block {
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 8px 0;
+}
+
+.code-block-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: var(--vscode-editorWidget-background);
+  border-bottom: 1px solid var(--vscode-widget-border);
+  font-size: 0.8em;
+}
+
+.code-block-language {
+  color: var(--vscode-descriptionForeground);
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.code-block-copy {
+  padding: 2px 8px;
+  border: none;
+  border-radius: 3px;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9em;
+}
+
+.code-block-copy:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.code-block pre {
+  padding: 10px;
+  margin: 0;
+  background: var(--vscode-editor-background);
+  overflow-x: auto;
+}
+
+.code-block pre code {
+  padding: 0;
+  background: none;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+/* ── highlight.js Theme (VS Code tokens) ───────────────────────────────────── */
+
+.hljs-keyword {
+  color: var(--vscode-symbolIcon-keywordForeground, #569cd6);
+  font-weight: 600;
+}
+
+.hljs-string {
+  color: var(--vscode-symbolIcon-stringForeground, #ce9178);
+}
+
+.hljs-comment {
+  color: var(--vscode-editorLineNumber-foreground, #6a9955);
+  font-style: italic;
+}
+
+.hljs-number {
+  color: var(--vscode-symbolIcon-numberForeground, #b5cea8);
+}
+
+.hljs-built_in,
+.hljs-function,
+.hljs-title {
+  color: var(--vscode-symbolIcon-functionForeground, #dcdcaa);
+}
+
+.hljs-type {
+  color: var(--vscode-symbolIcon-classForeground, #4ec9b0);
+}
+
+.hljs-variable,
+.hljs-params,
+.hljs-attr {
+  color: var(--vscode-symbolIcon-variableForeground, #9cdcfe);
+}
+
+.hljs-meta {
+  color: var(--vscode-symbolIcon-keywordForeground, #c586c0);
+}
+
+.hljs-tag,
+.hljs-name {
+  color: var(--vscode-symbolIcon-keywordForeground, #569cd6);
+}
+
+/* ── Tool Cards ────────────────────────────────────────────────────────────── */
+
+.tool-card {
+  margin: 8px 0;
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.tool-card.open .tool-card-body {
+  display: block;
+}
+
+.tool-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--vscode-editorWidget-background);
+  cursor: pointer;
+  user-select: none;
+}
+
+.tool-card-header:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.tool-card-chevron {
+  font-size: 0.8em;
+  color: var(--vscode-descriptionForeground);
+  transition: transform 0.2s ease;
+}
+
+.tool-card.open .tool-card-chevron {
+  transform: rotate(90deg);
+}
+
+.tool-card-label {
+  font-size: 0.75em;
+  color: var(--vscode-descriptionForeground);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.tool-card-name {
+  flex: 1;
+  font-weight: 600;
+  color: var(--vscode-symbolIcon-functionForeground, #dcdcaa);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-card-status {
+  font-size: 1em;
+  flex-shrink: 0;
+}
+
+.tool-card-status.success {
+  color: var(--vscode-testing-iconPassed, #73c991);
+}
+
+.tool-card-status.error {
+  color: var(--vscode-testing-iconFailed, #f48771);
+}
+
+.tool-card-status.running {
+  animation: spin 1s linear infinite;
+  color: var(--vscode-descriptionForeground);
+}
+
+.tool-card-body {
+  display: none;
+  padding: 10px;
+  background: var(--vscode-editor-background);
+}
+
+.tool-card-section {
+  margin-bottom: 8px;
+}
+
+.tool-card-section:last-child {
+  margin-bottom: 0;
+}
+
+.tool-card-section-label {
+  font-size: 0.75em;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.tool-card-section pre {
+  padding: 8px;
+  background: var(--vscode-textCodeBlock-background);
+  border-radius: 4px;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.85em;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* ── Approval Gates ────────────────────────────────────────────────────────── */
+
+.approval-gate {
+  margin: 10px 0;
+  border: 2px solid var(--vscode-editorWarning-foreground, #cca700);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.approval-gate.resolved {
+  opacity: 0.7;
+  border-color: var(--vscode-widget-border);
+}
+
+.approval-gate-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--vscode-editorWidget-background);
+  border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.approval-gate-icon {
+  font-size: 1.1em;
+  color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.approval-gate-title {
+  font-weight: 600;
+  font-size: 0.9em;
+  color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.approval-gate-body {
+  padding: 12px;
+  background: var(--vscode-editor-background);
+}
+
+.approval-tool-name {
+  font-weight: 600;
+  color: var(--vscode-symbolIcon-functionForeground, #dcdcaa);
+  margin-bottom: 8px;
+}
+
+.approval-args {
+  margin-bottom: 12px;
+}
+
+.approval-args pre {
+  padding: 8px;
+  background: var(--vscode-textCodeBlock-background);
+  border-radius: 4px;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 0.85em;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.approval-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.approval-btn-allow {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.approval-btn-allow:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+.approval-btn-deny {
+  padding: 6px 12px;
+  border: 1px solid var(--vscode-button-border);
+  border-radius: 4px;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85em;
+}
+
+.approval-btn-deny:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.approval-btn-abort {
+  padding: 6px 12px;
+  border: 1px solid var(--vscode-errorForeground, #f48771);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--vscode-errorForeground, #f48771);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85em;
+  margin-left: auto;
+}
+
+.approval-btn-abort:hover {
+  background: var(--vscode-inputValidation-errorBackground, rgba(244, 135, 113, 0.1));
+}
+
+.approval-resolved {
+  padding: 8px 12px;
+  text-align: center;
+  font-weight: 500;
+  font-size: 0.9em;
+}
+
+.approval-resolved.allowed {
+  color: var(--vscode-testing-iconPassed, #73c991);
+}
+
+.approval-resolved.denied {
+  color: var(--vscode-descriptionForeground);
+}
+
+.approval-resolved.aborted {
+  color: var(--vscode-errorForeground, #f48771);
+}
+
+/* ── Streaming / Thinking ──────────────────────────────────────────────────── */
+
+.thinking-dots {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.thinking-dots span {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--vscode-descriptionForeground);
+  animation: dotPulse 1.4s ease-in-out infinite;
+}
+
+.thinking-dots span:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.thinking-dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.thinking-dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes dotPulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--vscode-foreground);
+  margin-left: 1px;
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+/* ── Input Area ────────────────────────────────────────────────────────────── */
+
+.input-area {
+  flex-shrink: 0;
+  padding: 8px;
+}
+
+.input-box {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--vscode-input-border);
+  border-radius: 8px;
+  background: var(--vscode-input-background);
+  overflow: hidden;
+}
+
+.input-box:focus-within {
+  border-color: var(--vscode-focusBorder);
+}
+
+.input-box textarea {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-input-foreground);
+  font: inherit;
+  font-size: var(--vscode-font-size);
+  resize: none;
+  min-height: 40px;
+  max-height: 200px;
+  line-height: 1.5;
+  outline: none;
+}
+
+.input-box textarea::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+}
+
+.input-toolbar {
+  display: flex;
+  align-items: center;
+  padding: 0 6px 6px 6px;
+  gap: 6px;
+}
+
+.input-toolbar-spacer {
+  flex: 1;
+}
+
+.send-btn,
+.cancel-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  transition: background-color 0.15s ease;
+}
+
+.send-btn {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.send-btn:hover:not(:disabled) {
+  background: var(--vscode-button-hoverBackground);
+}
+
+.send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-descriptionForeground);
+}
+
+.cancel-btn {
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+.cancel-btn:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.input-hints {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 4px;
+  margin-top: 4px;
+  font-size: 0.7em;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* ── Error Messages ────────────────────────────────────────────────────────── */
+
+.message-error {
+  background: var(--vscode-inputValidation-errorBackground, rgba(244, 135, 113, 0.15));
+  border-left: 3px solid var(--vscode-inputValidation-errorBorder, #f48771);
+}
+
+.message-error .msg-body {
+  color: var(--vscode-errorForeground, #f48771);
+  font-size: 0.9em;
+}
+
+/* ── Animations ────────────────────────────────────────────────────────────── */
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/vscode/media/chat.css
+++ b/packages/vscode/media/chat.css
@@ -25,83 +25,6 @@ body {
   height: 100vh;
 }
 
-/* ── Header ────────────────────────────────────────────────────────────────── */
-
-.chat-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--vscode-widget-border);
-  background: var(--vscode-sideBar-background);
-  flex-shrink: 0;
-}
-
-.chat-header-left {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-  min-width: 0;
-}
-
-.chat-header select {
-  flex: 1;
-  min-width: 0;
-  padding: 5px 8px;
-  border: 1px solid var(--vscode-input-border);
-  background: var(--vscode-input-background);
-  color: var(--vscode-input-foreground);
-  font: inherit;
-  font-size: 0.85em;
-  border-radius: 4px;
-}
-
-.chat-header select:focus {
-  outline: 1px solid var(--vscode-focusBorder);
-}
-
-.chat-header-actions {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
-}
-
-.chat-header-actions button {
-  padding: 5px 10px;
-  border: none;
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.85em;
-  border-radius: 4px;
-  background: var(--vscode-button-secondaryBackground);
-  color: var(--vscode-button-secondaryForeground);
-  white-space: nowrap;
-}
-
-.chat-header-actions button:hover {
-  background: var(--vscode-button-secondaryHoverBackground);
-}
-
-.chat-header-actions .icon-btn {
-  padding: 4px 6px;
-  background: transparent;
-  color: var(--vscode-descriptionForeground);
-  font-size: 1.1em;
-}
-
-.chat-header-actions .icon-btn:hover {
-  color: var(--vscode-foreground);
-  background: var(--vscode-toolbar-hoverBackground);
-}
-
 /* ── Message List ──────────────────────────────────────────────────────────── */
 
 .message-list {
@@ -143,39 +66,41 @@ body {
   flex-direction: row;
   gap: 8px;
   padding: 10px 12px;
-  border-bottom: 1px solid var(--vscode-widget-border);
 }
 
-.message:last-child {
-  border-bottom: none;
+.message-user {
+  flex-direction: row-reverse;
 }
 
-.msg-avatar {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.7em;
-  font-weight: 700;
-  flex-shrink: 0;
+.message-user .msg-content {
+  align-items: flex-end;
 }
 
-.msg-avatar.user {
-  background: var(--vscode-button-background);
-  color: var(--vscode-button-foreground);
-}
-
-.msg-avatar.assistant {
+.message-user .msg-body {
   background: var(--vscode-editor-background);
   border: 1px solid var(--vscode-widget-border);
-  color: var(--vscode-descriptionForeground);
+  color: var(--vscode-foreground);
+  padding: 8px 12px;
+  border-radius: 12px 12px 0 12px;
+  display: inline-block;
+}
+
+.message-user .msg-role {
+  text-align: right;
+}
+
+.message-assistant .msg-body {
+  background: var(--vscode-editor-background);
+  padding: 8px 12px;
+  border-radius: 12px 12px 12px 0;
+  border: 1px solid var(--vscode-widget-border);
 }
 
 .msg-content {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .msg-role {
@@ -724,8 +649,53 @@ body {
   gap: 6px;
 }
 
+.input-toolbar select {
+  padding: 2px 6px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  font: inherit;
+  font-size: 0.8em;
+  cursor: pointer;
+  border-radius: 4px;
+  min-width: 0;
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.input-toolbar select:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+}
+
+.input-toolbar select:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+}
+
 .input-toolbar-spacer {
   flex: 1;
+}
+
+.session-btn {
+  padding: 2px 8px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  font: inherit;
+  font-size: 0.8em;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.session-btn:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+  color: var(--vscode-foreground);
+}
+
+.session-btn.icon-btn {
+  padding: 2px 4px;
+  font-size: 1em;
 }
 
 .send-btn,

--- a/packages/vscode/media/chat.css
+++ b/packages/vscode/media/chat.css
@@ -501,7 +501,7 @@ body {
 
 .input-area {
   flex-shrink: 0;
-  padding: 8px;
+  padding: 4px;
 }
 
 .input-box {
@@ -544,16 +544,14 @@ body {
 }
 
 .toolbar-select {
-  max-width: 45%;
+  flex: 1;
   min-width: 0;
 }
 
 .toolbar-btn {
   flex-shrink: 0;
-}
-
-.input-toolbar-spacer {
-  flex: 1;
+  --vscode-button-secondaryBackground: transparent;
+  --vscode-button-secondaryHoverBackground: var(--vscode-toolbar-hoverBackground);
 }
 
 .send-btn,

--- a/packages/vscode/media/chat.css
+++ b/packages/vscode/media/chat.css
@@ -50,17 +50,10 @@ body {
   min-width: 0;
 }
 
-.chat-header-title {
-  font-weight: 600;
-  font-size: 0.9em;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
 .chat-header select {
   flex: 1;
   min-width: 0;
-  padding: 4px 8px;
+  padding: 5px 8px;
   border: 1px solid var(--vscode-input-border);
   background: var(--vscode-input-background);
   color: var(--vscode-input-foreground);
@@ -82,7 +75,7 @@ body {
 }
 
 .chat-header-actions button {
-  padding: 4px 8px;
+  padding: 5px 10px;
   border: none;
   cursor: pointer;
   font: inherit;

--- a/packages/vscode/media/provider.css
+++ b/packages/vscode/media/provider.css
@@ -174,7 +174,11 @@ h2 {
 /* ─── Form Controls ───────────────────────────────────────────────── */
 
 vscode-form-group {
-  margin-bottom: 12px;
+  margin: 10px 0;
+}
+
+.accordion-body vscode-form-group:first-child {
+  margin-top: 0;
 }
 
 vscode-single-select {

--- a/packages/vscode/media/provider.css
+++ b/packages/vscode/media/provider.css
@@ -88,17 +88,90 @@ h2 {
   gap: 6px;
 }
 
-/* ─── Collapsible & Form ─────────────────────────────────────────── */
+.provider-actions vscode-button.card-action {
+  --vscode-button-secondaryBackground: transparent;
+  --vscode-button-secondaryHoverBackground: var(--vscode-toolbar-hoverBackground);
+}
 
-vscode-collapsible {
-  margin-bottom: 8px;
+/* ─── Accordion ───────────────────────────────────────────────────── */
+
+.accordion-section {
+  background-color: var(--vscode-editorWidget-background);
   border: 1px solid var(--vscode-widget-border);
   border-radius: 4px;
+  margin-bottom: 8px;
 }
 
-vscode-collapsible::part(header) {
-  text-transform: none;
+.accordion-section.open {
+  border-color: var(--vscode-focusBorder);
 }
+
+.accordion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.accordion-header:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.accordion-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.accordion-chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid var(--vscode-foreground);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.2s ease;
+  transform: rotate(0deg);
+}
+
+.accordion-section.open .accordion-chevron {
+  transform: rotate(90deg);
+}
+
+.accordion-title {
+  font-weight: 600;
+  font-size: 0.95em;
+}
+
+.accordion-status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85em;
+  color: var(--vscode-descriptionForeground);
+}
+
+.accordion-status.complete {
+  color: var(--vscode-testing-iconPassed);
+}
+
+.accordion-status.complete::before {
+  content: '✓';
+  font-weight: bold;
+}
+
+.accordion-body {
+  display: none;
+  padding: 0 14px 14px 14px;
+}
+
+.accordion-section.open .accordion-body {
+  display: block;
+}
+
+/* ─── Form Controls ───────────────────────────────────────────────── */
 
 vscode-form-group {
   margin-bottom: 12px;
@@ -110,11 +183,6 @@ vscode-single-select {
 
 vscode-textfield {
   width: 100%;
-}
-
-vscode-button.card-action {
-  padding: 4px 8px;
-  min-width: auto;
 }
 
 /* ─── Dual-List Model Selector ───────────────────────────────────── */

--- a/packages/vscode/media/provider.css
+++ b/packages/vscode/media/provider.css
@@ -30,55 +30,6 @@ h2 {
   margin: 0 0 24px 0;
 }
 
-/* ─── Buttons ─────────────────────────────────────────────────────── */
-
-button {
-  font-family: var(--vscode-font-family);
-  font-size: var(--vscode-font-size);
-  cursor: pointer;
-  border-radius: 3px;
-}
-
-button.primary {
-  padding: 6px 14px;
-  background-color: var(--vscode-button-background);
-  color: var(--vscode-button-foreground);
-  border: none;
-}
-
-button.primary:hover:not(:disabled) {
-  background-color: var(--vscode-button-hoverBackground);
-}
-
-button.primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-button.secondary {
-  padding: 6px 14px;
-  background-color: var(--vscode-button-secondaryBackground);
-  color: var(--vscode-button-secondaryForeground);
-  border: none;
-}
-
-button.secondary:hover:not(:disabled) {
-  background-color: var(--vscode-button-secondaryHoverBackground);
-}
-
-button.link {
-  padding: 0;
-  background: none;
-  border: none;
-  color: var(--vscode-textLink-foreground);
-  text-decoration: underline;
-  font-size: 0.9em;
-}
-
-button.link:hover {
-  color: var(--vscode-textLink-activeForeground);
-}
-
 /* ─── Provider Cards ──────────────────────────────────────────────── */
 
 .provider-card {
@@ -105,14 +56,6 @@ button.link:hover {
 
 .provider-name {
   font-weight: 600;
-}
-
-.provider-engine {
-  font-size: 0.85em;
-  padding: 1px 6px;
-  border-radius: 3px;
-  background-color: var(--vscode-badge-background);
-  color: var(--vscode-badge-foreground);
 }
 
 .provider-model-count {
@@ -145,152 +88,33 @@ button.link:hover {
   gap: 6px;
 }
 
-.provider-actions button {
-  padding: 4px 10px;
-  border: 1px solid var(--vscode-widget-border);
-  background: transparent;
-  color: var(--vscode-descriptionForeground);
-  cursor: pointer;
-  border-radius: 3px;
-  font-size: 0.85em;
-  font-family: var(--vscode-font-family);
-}
+/* ─── Collapsible & Form ─────────────────────────────────────────── */
 
-.provider-actions button:hover {
-  color: var(--vscode-foreground);
-  border-color: var(--vscode-foreground);
-}
-
-/* ─── Accordion ───────────────────────────────────────────────────── */
-
-.accordion-section {
-  background-color: var(--vscode-editorWidget-background);
+vscode-collapsible {
+  margin-bottom: 8px;
   border: 1px solid var(--vscode-widget-border);
   border-radius: 4px;
-  margin-bottom: 8px;
 }
 
-.accordion-section.open {
-  border-color: var(--vscode-focusBorder);
+vscode-collapsible::part(header) {
+  text-transform: none;
 }
 
-.accordion-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  cursor: pointer;
-  user-select: none;
+vscode-form-group {
+  margin-bottom: 12px;
 }
 
-.accordion-header:hover {
-  background-color: var(--vscode-list-hoverBackground);
-}
-
-.accordion-header-left {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.accordion-chevron {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-left: 5px solid var(--vscode-foreground);
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  transition: transform 0.2s ease;
-  transform: rotate(0deg);
-}
-
-.accordion-section.open .accordion-chevron {
-  transform: rotate(90deg);
-}
-
-.accordion-title {
-  font-weight: 600;
-  font-size: 0.95em;
-}
-
-.accordion-status {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.85em;
-  color: var(--vscode-descriptionForeground);
-}
-
-.accordion-status.complete {
-  color: var(--vscode-testing-iconPassed);
-}
-
-.accordion-status.complete::before {
-  content: '✓';
-  font-weight: bold;
-}
-
-.accordion-body {
-  display: none;
-  padding: 0 14px 14px 14px;
-}
-
-.accordion-section.open .accordion-body {
-  display: block;
-}
-
-/* ─── Toggle Group ────────────────────────────────────────────────── */
-
-.toggle-group {
-  display: flex;
-  gap: 0;
-  border: 1px solid var(--vscode-input-border);
-  border-radius: 3px;
-  overflow: hidden;
-  width: fit-content;
-}
-
-.toggle-group button {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 0;
-  background-color: var(--vscode-input-background);
-  color: var(--vscode-foreground);
-  cursor: pointer;
-  font-size: 0.9em;
-}
-
-.toggle-group button:not(:last-child) {
-  border-right: 1px solid var(--vscode-input-border);
-}
-
-.toggle-group button:hover:not(.active) {
-  background-color: var(--vscode-list-hoverBackground);
-}
-
-.toggle-group button.active {
-  background-color: var(--vscode-button-background);
-  color: var(--vscode-button-foreground);
-}
-
-/* ─── Model Search ────────────────────────────────────────────────── */
-
-.model-search {
+vscode-single-select {
   width: 100%;
-  padding: 6px 8px;
-  border: 1px solid var(--vscode-input-border);
-  background-color: var(--vscode-input-background);
-  color: var(--vscode-input-foreground);
-  font-family: var(--vscode-font-family);
-  font-size: var(--vscode-font-size);
-  border-radius: 3px;
-  box-sizing: border-box;
-  margin-bottom: 8px;
 }
 
-.model-search:focus {
-  outline: 1px solid var(--vscode-focusBorder);
-  border-color: var(--vscode-focusBorder);
+vscode-textfield {
+  width: 100%;
+}
+
+vscode-button.card-action {
+  padding: 4px 8px;
+  min-width: auto;
 }
 
 /* ─── Dual-List Model Selector ───────────────────────────────────── */
@@ -358,56 +182,7 @@ button.link:hover {
   padding: 0 4px;
 }
 
-.dual-list-center button {
-  padding: 6px 12px;
-  font-size: 0.85em;
-  white-space: nowrap;
-}
-
-.dual-list-center button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-/* ─── Form Elements ───────────────────────────────────────────────── */
-
-.form-group {
-  margin-bottom: 12px;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 4px;
-  font-size: 0.9em;
-  color: var(--vscode-foreground);
-  font-weight: 500;
-}
-
-.form-group .hint {
-  font-size: 0.8em;
-  color: var(--vscode-descriptionForeground);
-  margin-top: 2px;
-}
-
-input[type="text"],
-input[type="password"],
-select {
-  width: 100%;
-  padding: 6px 8px;
-  border: 1px solid var(--vscode-input-border);
-  background-color: var(--vscode-input-background);
-  color: var(--vscode-input-foreground);
-  font-family: var(--vscode-font-family);
-  font-size: var(--vscode-font-size);
-  border-radius: 3px;
-  box-sizing: border-box;
-}
-
-input:focus,
-select:focus {
-  outline: 1px solid var(--vscode-focusBorder);
-  border-color: var(--vscode-focusBorder);
-}
+/* ─── Form Actions ───────────────────────────────────────────────── */
 
 .form-actions {
   display: flex;
@@ -418,22 +193,6 @@ select:focus {
 }
 
 /* ─── Utility ─────────────────────────────────────────────────────── */
-
-.spinner {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--vscode-descriptionForeground);
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
 
 .loading-state {
   display: flex;

--- a/packages/vscode/media/provider.css
+++ b/packages/vscode/media/provider.css
@@ -273,7 +273,7 @@ button.link:hover {
   color: var(--vscode-button-foreground);
 }
 
-/* ─── Model Checklist ─────────────────────────────────────────────── */
+/* ─── Model Search ────────────────────────────────────────────────── */
 
 .model-search {
   width: 100%;
@@ -293,50 +293,80 @@ button.link:hover {
   border-color: var(--vscode-focusBorder);
 }
 
-.model-actions {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 8px;
+/* ─── Dual-List Model Selector ───────────────────────────────────── */
+
+.dual-list {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 8px;
+  min-height: 250px;
 }
 
-.model-counter {
-  font-size: 0.85em;
-  color: var(--vscode-descriptionForeground);
-  margin-bottom: 8px;
-}
-
-.model-list {
-  max-height: 240px;
-  overflow-y: auto;
+.dual-list-panel {
   border: 1px solid var(--vscode-widget-border);
   border-radius: 3px;
-  background-color: var(--vscode-input-background);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.model-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
+.dual-list-panel-header {
+  padding: 8px 12px;
+  background: var(--vscode-editorWidget-background);
+  font-weight: 500;
+  font-size: 0.85em;
+  color: var(--vscode-descriptionForeground);
   border-bottom: 1px solid var(--vscode-widget-border);
 }
 
-.model-item:last-child {
+.dual-list-items {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 280px;
+  background-color: var(--vscode-input-background);
+}
+
+.dual-list-item {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+  cursor: pointer;
+  font-size: 0.9em;
+  user-select: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dual-list-item:last-child {
   border-bottom: none;
 }
 
-.model-item:hover {
+.dual-list-item:hover {
   background-color: var(--vscode-list-hoverBackground);
 }
 
-.model-item input[type="checkbox"] {
-  cursor: pointer;
+.dual-list-item.selected {
+  background-color: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
 }
 
-.model-item label {
-  cursor: pointer;
-  flex: 1;
-  font-size: 0.9em;
+.dual-list-center {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 4px;
+}
+
+.dual-list-center button {
+  padding: 6px 12px;
+  font-size: 0.85em;
+  white-space: nowrap;
+}
+
+.dual-list-center button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* ─── Form Elements ───────────────────────────────────────────────── */

--- a/packages/vscode/media/provider.css
+++ b/packages/vscode/media/provider.css
@@ -1,0 +1,471 @@
+/* ─── Base Styles ─────────────────────────────────────────────────── */
+
+body {
+  padding: 20px 24px;
+  color: var(--vscode-foreground);
+  background-color: var(--vscode-editor-background);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  max-width: 720px;
+}
+
+h1 {
+  font-size: 1.3em;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+}
+
+h2 {
+  font-size: 0.85em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vscode-descriptionForeground);
+  margin: 28px 0 12px 0;
+}
+
+.subtitle {
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+  margin: 0 0 24px 0;
+}
+
+/* ─── Buttons ─────────────────────────────────────────────────────── */
+
+button {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+button.primary {
+  padding: 6px 14px;
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: none;
+}
+
+button.primary:hover:not(:disabled) {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+button.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  padding: 6px 14px;
+  background-color: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border: none;
+}
+
+button.secondary:hover:not(:disabled) {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+button.link {
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--vscode-textLink-foreground);
+  text-decoration: underline;
+  font-size: 0.9em;
+}
+
+button.link:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
+/* ─── Provider Cards ──────────────────────────────────────────────── */
+
+.provider-card {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  margin-bottom: 6px;
+  border-radius: 4px;
+  background-color: var(--vscode-editorWidget-background);
+  border: 1px solid var(--vscode-widget-border);
+}
+
+.provider-card:hover {
+  border-color: var(--vscode-focusBorder);
+}
+
+.provider-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.provider-name {
+  font-weight: 600;
+}
+
+.provider-engine {
+  font-size: 0.85em;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.provider-model-count {
+  font-size: 0.85em;
+  color: var(--vscode-descriptionForeground);
+}
+
+.provider-status {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 2px;
+}
+
+.provider-status.ready {
+  background-color: #73c991;
+}
+
+.provider-status.error {
+  background-color: #f48771;
+}
+
+.provider-status.unconfigured {
+  background-color: var(--vscode-descriptionForeground);
+}
+
+.provider-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.provider-actions button {
+  padding: 4px 10px;
+  border: 1px solid var(--vscode-widget-border);
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: var(--vscode-font-family);
+}
+
+.provider-actions button:hover {
+  color: var(--vscode-foreground);
+  border-color: var(--vscode-foreground);
+}
+
+/* ─── Accordion ───────────────────────────────────────────────────── */
+
+.accordion-section {
+  background-color: var(--vscode-editorWidget-background);
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.accordion-section.open {
+  border-color: var(--vscode-focusBorder);
+}
+
+.accordion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.accordion-header:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.accordion-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.accordion-chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid var(--vscode-foreground);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.2s ease;
+  transform: rotate(0deg);
+}
+
+.accordion-section.open .accordion-chevron {
+  transform: rotate(90deg);
+}
+
+.accordion-title {
+  font-weight: 600;
+  font-size: 0.95em;
+}
+
+.accordion-status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85em;
+  color: var(--vscode-descriptionForeground);
+}
+
+.accordion-status.complete {
+  color: var(--vscode-testing-iconPassed);
+}
+
+.accordion-status.complete::before {
+  content: '✓';
+  font-weight: bold;
+}
+
+.accordion-body {
+  display: none;
+  padding: 0 14px 14px 14px;
+}
+
+.accordion-section.open .accordion-body {
+  display: block;
+}
+
+/* ─── Toggle Group ────────────────────────────────────────────────── */
+
+.toggle-group {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--vscode-input-border);
+  border-radius: 3px;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.toggle-group button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 0;
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-foreground);
+  cursor: pointer;
+  font-size: 0.9em;
+}
+
+.toggle-group button:not(:last-child) {
+  border-right: 1px solid var(--vscode-input-border);
+}
+
+.toggle-group button:hover:not(.active) {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.toggle-group button.active {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+/* ─── Model Checklist ─────────────────────────────────────────────── */
+
+.model-search {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  border-radius: 3px;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+}
+
+.model-search:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  border-color: var(--vscode-focusBorder);
+}
+
+.model-actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.model-counter {
+  font-size: 0.85em;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 8px;
+}
+
+.model-list {
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 3px;
+  background-color: var(--vscode-input-background);
+}
+
+.model-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.model-item:last-child {
+  border-bottom: none;
+}
+
+.model-item:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.model-item input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.model-item label {
+  cursor: pointer;
+  flex: 1;
+  font-size: 0.9em;
+}
+
+/* ─── Form Elements ───────────────────────────────────────────────── */
+
+.form-group {
+  margin-bottom: 12px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 0.9em;
+  color: var(--vscode-foreground);
+  font-weight: 500;
+}
+
+.form-group .hint {
+  font-size: 0.8em;
+  color: var(--vscode-descriptionForeground);
+  margin-top: 2px;
+}
+
+input[type="text"],
+input[type="password"],
+select {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  border-radius: 3px;
+  box-sizing: border-box;
+}
+
+input:focus,
+select:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  border-color: var(--vscode-focusBorder);
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--vscode-widget-border);
+}
+
+/* ─── Utility ─────────────────────────────────────────────────────── */
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--vscode-descriptionForeground);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+}
+
+.inline-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px;
+  background-color: var(--vscode-inputValidation-errorBackground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+  border-radius: 3px;
+  color: var(--vscode-errorForeground);
+  font-size: 0.9em;
+  margin: 8px 0;
+}
+
+.inline-error::before {
+  content: '⚠';
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.toast {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  padding: 10px 16px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  z-index: 1000;
+  transition: opacity 0.3s;
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.toast.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.toast.success {
+  background-color: var(--vscode-testing-iconPassed);
+  color: var(--vscode-editor-background);
+}
+
+.toast.error {
+  background-color: var(--vscode-inputValidation-errorBackground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+  color: var(--vscode-errorForeground);
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -54,12 +54,6 @@
         "title": "Configure Providers",
         "category": "Abbenay",
         "icon": "$(gear)"
-      },
-      {
-        "command": "abbenay.openChat",
-        "title": "Open Chat",
-        "category": "Abbenay",
-        "icon": "$(comment-discussion)"
       }
     ],
     "viewsContainers": {
@@ -135,6 +129,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.5.1",
+    "@vscode-elements/elements": "^2.5.1",
     "highlight.js": "^11.11.1",
     "long": "^5.3.2",
     "marked": "^18.0.4",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -51,10 +51,35 @@
       },
       {
         "command": "abbenay.configureProvider",
-        "title": "Configure Provider",
-        "category": "Abbenay"
+        "title": "Configure Providers",
+        "category": "Abbenay",
+        "icon": "$(gear)"
+      },
+      {
+        "command": "abbenay.openChat",
+        "title": "Open Chat",
+        "category": "Abbenay",
+        "icon": "$(comment-discussion)"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "abbenay",
+          "title": "Abbenay",
+          "icon": "images/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "abbenay": [
+        {
+          "type": "webview",
+          "id": "abbenay.chatView",
+          "name": "Chat"
+        }
+      ]
+    },
     "configuration": {
       "title": "Abbenay Provider",
       "properties": {
@@ -95,10 +120,10 @@
     "package:all-platforms": "npm run bundle && vsce package --no-dependencies"
   },
   "devDependencies": {
+    "@eslint/js": "^9",
     "@types/mocha": "^10.0.0",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.99.0",
-    "@eslint/js": "^9",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/vsce": "^3.7.0",
@@ -110,7 +135,9 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.5.1",
+    "highlight.js": "^11.11.1",
     "long": "^5.3.2",
+    "marked": "^18.0.4",
     "nice-grpc": "^2.1.14",
     "nice-grpc-common": "^2.0.2"
   }

--- a/packages/vscode/src/daemon/client.ts
+++ b/packages/vscode/src/daemon/client.ts
@@ -370,6 +370,15 @@ export class DaemonClient {
     }
 
     /**
+     * List available engines (fixed set of API implementations)
+     */
+    async listEngines(): Promise<proto.Engine[]> {
+        const client = this.getClient();
+        const response = await client.listEngines({});
+        return response.engines;
+    }
+
+    /**
      * List available providers
      */
     async listProviders(): Promise<proto.Provider[]> {
@@ -447,8 +456,13 @@ export class DaemonClient {
         });
     }
 
-    // Note: Secret management (getSecret/setSecret) removed - secrets are now managed 
-    // by the daemon's keychain store or environment variables, configured via the web UI
+    /**
+     * Set a secret in the daemon's keychain store
+     */
+    async setSecret(key: string, value: string): Promise<void> {
+        const client = this.getClient();
+        await client.setSecret({ key, value });
+    }
 
     /**
      * Delete a secret

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -226,10 +226,4 @@ function registerCommands(context: vscode.ExtensionContext): void {
     })
   );
 
-  // Open chat command - reveals chat sidebar
-  context.subscriptions.push(
-    vscode.commands.registerCommand('abbenay.openChat', () => {
-      vscode.commands.executeCommand('abbenay.chatView.focus');
-    })
-  );
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -8,6 +8,8 @@ import {
   BackchannelHandler
 } from './daemon';
 import { AbbenayLanguageModelProvider } from './providers';
+import { ChatViewProvider } from './webviews/chat/ChatViewProvider';
+import { ProviderPanel } from './webviews/provider/ProviderPanel';
 
 // Default dashboard URL - daemon serves web UI here
 const DASHBOARD_URL = 'http://localhost:8787';
@@ -76,6 +78,13 @@ export async function activate(context: vscode.ExtensionContext) {
       `Abbenay: Could not connect to daemon — ${msg}`
     );
   }
+
+  // Register chat sidebar webview
+  const client = getDaemonClient();
+  const chatViewProvider = new ChatViewProvider(context.extensionUri, client);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(ChatViewProvider.viewType, chatViewProvider),
+  );
 
   // Register commands
   registerCommands(context);
@@ -208,11 +217,19 @@ function registerCommands(context: vscode.ExtensionContext): void {
     })
   );
 
-  // Configure provider command - opens dashboard for API key configuration
+  // Configure provider command - opens provider webview panel
   context.subscriptions.push(
     vscode.commands.registerCommand('abbenay.configureProvider', () => {
       console.log('[Abbenay] configureProvider command');
-      vscode.env.openExternal(vscode.Uri.parse(DASHBOARD_URL));
+      const client = getDaemonClient();
+      ProviderPanel.createOrShow(context.extensionUri, client);
+    })
+  );
+
+  // Open chat command - reveals chat sidebar
+  context.subscriptions.push(
+    vscode.commands.registerCommand('abbenay.openChat', () => {
+      vscode.commands.executeCommand('abbenay.chatView.focus');
     })
   );
 }

--- a/packages/vscode/src/test/extension.test.ts
+++ b/packages/vscode/src/test/extension.test.ts
@@ -42,6 +42,14 @@ suite('Extension Smoke Tests', () => {
     }
   });
 
+  test('Chat view should be registered', async () => {
+    const allCommands = await vscode.commands.getCommands(true);
+    assert.ok(
+      allCommands.includes('abbenay.chatView.focus'),
+      'Expected chat view focus command to be auto-registered',
+    );
+  });
+
   test('Configuration section should exist', () => {
     const config = vscode.workspace.getConfiguration('abbenay');
     const logLevel = config.get<string>('logLevel');

--- a/packages/vscode/src/test/helpers/mockDaemonClient.ts
+++ b/packages/vscode/src/test/helpers/mockDaemonClient.ts
@@ -1,0 +1,47 @@
+import { DaemonClient } from '../../daemon/client';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export function createMockDaemonClient(overrides: Record<string, any> = {}): DaemonClient {
+  const defaults: Record<string, any> = {
+    listProviders: async () => [],
+    listModels: async () => [],
+    listEngines: async () => [],
+    listSessions: async () => [],
+    listSecrets: async () => [],
+    getProviderTemplates: async () => [],
+    discoverModels: async () => [],
+    configureProvider: async () => ({}),
+    removeProvider: async () => {},
+    setSecret: async () => {},
+    deleteSecret: async () => {},
+    getKeyStatus: async () => false,
+    getConfig: async () => ({ config: {}, path: '' }),
+    updateConfig: async () => ({ config: {}, path: '' }),
+    createSession: async () => ({
+      id: 'test-session',
+      model: 'test/model',
+      topic: 'Test',
+      messages: [],
+      messageCount: 0,
+      createdBy: '',
+      createdAt: undefined,
+      updatedAt: undefined,
+      metadata: {},
+    }),
+    deleteSession: async () => {},
+    getSession: async () => ({
+      id: 'test-session',
+      model: 'test/model',
+      topic: 'Test',
+      messages: [],
+      messageCount: 0,
+      createdBy: '',
+      createdAt: undefined,
+      updatedAt: undefined,
+      metadata: {},
+    }),
+  };
+
+  return { ...defaults, ...overrides } as unknown as DaemonClient;
+}

--- a/packages/vscode/src/test/helpers/mockWebview.ts
+++ b/packages/vscode/src/test/helpers/mockWebview.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+
+export interface MockWebview extends vscode.Webview {
+  messages: unknown[];
+}
+
+export function createMockWebview(): MockWebview {
+  const messages: unknown[] = [];
+
+  return {
+    messages,
+    postMessage(message: unknown): Thenable<boolean> {
+      messages.push(message);
+      return Promise.resolve(true);
+    },
+    html: '',
+    options: {},
+    cspSource: 'https://test.vscode-resource.vscode-cdn.net',
+    onDidReceiveMessage: new vscode.EventEmitter<unknown>().event,
+    asWebviewUri(uri: vscode.Uri): vscode.Uri {
+      return uri;
+    },
+  };
+}

--- a/packages/vscode/src/test/webviews/chatHandler.test.ts
+++ b/packages/vscode/src/test/webviews/chatHandler.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import { handleChatMessage, cancelActiveStream } from '../../webviews/chat/chatHandler';
+import { createMockWebview } from '../helpers/mockWebview';
+import { createMockDaemonClient } from '../helpers/mockDaemonClient';
+
+suite('Chat Handler', () => {
+  test('ready message should send models and sessions', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient();
+
+    await handleChatMessage({ type: 'ready' }, webview, client);
+
+    const messageTypes = webview.messages.map((m: unknown) => (m as { type: string }).type);
+    assert.ok(messageTypes.includes('models'), 'Should send models');
+    assert.ok(messageTypes.includes('sessions'), 'Should send sessions');
+  });
+
+  test('listModels should send model list', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      listModels: async () => [
+        { id: 'openai/gpt-4', provider: 'openai', name: 'GPT-4', engine: 'openai' },
+        { id: 'ollama/llama3', provider: 'ollama', name: 'Llama 3', engine: 'ollama' },
+      ] as never,
+    });
+
+    await handleChatMessage({ type: 'listModels' }, webview, client);
+
+    const msg = webview.messages[0] as { type: string; models: { id: string }[] };
+    assert.strictEqual(msg.type, 'models');
+    assert.strictEqual(msg.models.length, 2);
+    assert.strictEqual(msg.models[0].id, 'openai/gpt-4');
+  });
+
+  test('createSession should send sessionCreated and refresh sessions', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      createSession: async (model: string, topic?: string) => ({
+        id: 'session-123',
+        model,
+        topic: topic || 'New Chat',
+        messages: [],
+        messageCount: 0,
+      }) as never,
+    });
+
+    await handleChatMessage(
+      { type: 'createSession', model: 'openai/gpt-4', topic: 'Test Chat' },
+      webview,
+      client,
+    );
+
+    const messageTypes = webview.messages.map((m: unknown) => (m as { type: string }).type);
+    assert.ok(messageTypes.includes('sessionCreated'), 'Should send sessionCreated');
+    assert.ok(messageTypes.includes('sessions'), 'Should refresh sessions list');
+
+    const created = webview.messages.find(
+      (m: unknown) => (m as { type: string }).type === 'sessionCreated',
+    ) as { type: string; session: { id: string; model: string } };
+    assert.strictEqual(created.session.id, 'session-123');
+    assert.strictEqual(created.session.model, 'openai/gpt-4');
+  });
+
+  test('deleteSession should call client and refresh sessions', async () => {
+    let deletedId = '';
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      deleteSession: async (id: string) => { deletedId = id; },
+    });
+
+    await handleChatMessage(
+      { type: 'deleteSession', sessionId: 'session-456' },
+      webview,
+      client,
+    );
+
+    assert.strictEqual(deletedId, 'session-456');
+    const messageTypes = webview.messages.map((m: unknown) => (m as { type: string }).type);
+    assert.ok(messageTypes.includes('sessions'), 'Should refresh sessions list');
+  });
+
+  test('cancelActiveStream should not throw when no stream active', () => {
+    assert.doesNotThrow(() => cancelActiveStream());
+  });
+
+  test('error in handler should send error message to webview', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      listModels: async () => { throw new Error('Daemon unavailable'); },
+    });
+
+    await handleChatMessage({ type: 'listModels' }, webview, client);
+
+    const msg = webview.messages[0] as { type: string; message: string; context: string };
+    assert.strictEqual(msg.type, 'error');
+    assert.strictEqual(msg.message, 'Daemon unavailable');
+    assert.strictEqual(msg.context, 'listModels');
+  });
+});

--- a/packages/vscode/src/test/webviews/getNonce.test.ts
+++ b/packages/vscode/src/test/webviews/getNonce.test.ts
@@ -1,0 +1,18 @@
+import * as assert from 'assert';
+import { getNonce } from '../../webviews/shared/getNonce';
+
+suite('getNonce', () => {
+  test('should return a 32-character hex string', () => {
+    const nonce = getNonce();
+    assert.strictEqual(nonce.length, 32);
+    assert.match(nonce, /^[0-9a-f]{32}$/);
+  });
+
+  test('should return unique values on consecutive calls', () => {
+    const nonces = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      nonces.add(getNonce());
+    }
+    assert.strictEqual(nonces.size, 100, 'All 100 nonces should be unique');
+  });
+});

--- a/packages/vscode/src/test/webviews/getWebviewContent.test.ts
+++ b/packages/vscode/src/test/webviews/getWebviewContent.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { getWebviewContent } from '../../webviews/shared/getWebviewContent';
+
+suite('getWebviewContent', () => {
+  let mockWebview: vscode.Webview;
+  let extensionUri: vscode.Uri;
+
+  suiteSetup(() => {
+    extensionUri = vscode.Uri.file('/test/extension');
+    mockWebview = {
+      html: '',
+      options: {},
+      cspSource: 'https://test.vscode-resource.vscode-cdn.net',
+      onDidReceiveMessage: new vscode.EventEmitter<unknown>().event,
+      postMessage: () => Promise.resolve(true),
+      asWebviewUri: (uri: vscode.Uri) => uri,
+    };
+  });
+
+  test('should return valid HTML with doctype', () => {
+    const html = getWebviewContent(mockWebview, extensionUri, 'provider', 'Test Title');
+    assert.ok(html.startsWith('<!DOCTYPE html>'));
+    assert.ok(html.includes('<html lang="en">'));
+    assert.ok(html.includes('</html>'));
+  });
+
+  test('should include CSP meta tag with nonce', () => {
+    const html = getWebviewContent(mockWebview, extensionUri, 'provider', 'Test Title');
+    assert.ok(html.includes('Content-Security-Policy'));
+    assert.ok(html.includes("script-src 'nonce-"));
+    assert.ok(html.includes(mockWebview.cspSource));
+  });
+
+  test('should include script tag with nonce', () => {
+    const html = getWebviewContent(mockWebview, extensionUri, 'provider', 'Test Title');
+    const nonceMatch = html.match(/nonce-([a-f0-9]+)/);
+    assert.ok(nonceMatch, 'Should have a nonce in CSP');
+    const nonce = nonceMatch![1];
+    assert.ok(html.includes(`nonce="${nonce}"`), 'Script tag should use the same nonce');
+  });
+
+  test('should include root div', () => {
+    const html = getWebviewContent(mockWebview, extensionUri, 'provider', 'Test Title');
+    assert.ok(html.includes('<div id="root"></div>'));
+  });
+
+  test('should set the title', () => {
+    const html = getWebviewContent(mockWebview, extensionUri, 'provider', 'My Custom Title');
+    assert.ok(html.includes('<title>My Custom Title</title>'));
+  });
+
+  test('should reference panel-specific CSS and JS', () => {
+    const html = getWebviewContent(mockWebview, extensionUri, 'chat', 'Chat');
+    assert.ok(html.includes('chat.css'), 'Should reference chat CSS');
+    assert.ok(html.includes('chat'), 'Should reference chat JS bundle');
+  });
+});

--- a/packages/vscode/src/test/webviews/providerHandler.test.ts
+++ b/packages/vscode/src/test/webviews/providerHandler.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+import { handleProviderMessage } from '../../webviews/provider/providerHandler';
+import { createMockWebview } from '../helpers/mockWebview';
+import { createMockDaemonClient } from '../helpers/mockDaemonClient';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+suite('Provider Handler', () => {
+  test('ready message should send providers, templates, engines, and secrets', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient();
+
+    await handleProviderMessage({ type: 'ready' }, webview, client);
+
+    const messageTypes = webview.messages.map((m: unknown) => (m as { type: string }).type);
+    assert.ok(messageTypes.includes('providers'), 'Should send providers');
+    assert.ok(messageTypes.includes('templates'), 'Should send templates');
+    assert.ok(messageTypes.includes('engines'), 'Should send engines');
+    assert.ok(messageTypes.includes('secrets'), 'Should send secrets');
+  });
+
+  test('getEngines should send engine list', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      listEngines: async () => [
+        { id: 'openai', requiresKey: true, defaultBaseUrl: 'https://api.openai.com/v1', defaultEnvVar: 'OPENAI_API_KEY' },
+        { id: 'ollama', requiresKey: false, defaultBaseUrl: 'http://localhost:11434', defaultEnvVar: '' },
+      ] as never,
+    });
+
+    await handleProviderMessage({ type: 'getEngines' }, webview, client);
+
+    const msg = webview.messages[0] as { type: string; engines: { id: string; requiresKey: boolean }[] };
+    assert.strictEqual(msg.type, 'engines');
+    assert.strictEqual(msg.engines.length, 2);
+    assert.strictEqual(msg.engines[0].id, 'openai');
+    assert.strictEqual(msg.engines[0].requiresKey, true);
+  });
+
+  test('discoverModels should pass apiKey and baseUrl to client', async () => {
+    let capturedOptions: any = {};
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      discoverModels: async (_engineId: string, options?: any) => {
+        capturedOptions = options || {};
+        return [
+          { id: 'gpt-4', provider: 'openai', name: 'GPT-4', engine: 'openai' },
+        ];
+      },
+    });
+
+    await handleProviderMessage(
+      { type: 'discoverModels', engineId: 'openai', apiKey: 'sk-test', baseUrl: 'https://custom.api/v1' },
+      webview,
+      client,
+    );
+
+    assert.strictEqual(capturedOptions.apiKey, 'sk-test');
+    assert.strictEqual(capturedOptions.baseUrl, 'https://custom.api/v1');
+
+    const msg = webview.messages[0] as { type: string; models: { id: string }[] };
+    assert.strictEqual(msg.type, 'discoveredModels');
+    assert.strictEqual(msg.models.length, 1);
+    assert.strictEqual(msg.models[0].id, 'gpt-4');
+  });
+
+  test('getConfig should forward config from client', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      getConfig: async () => ({
+        config: { providers: { 'my-openai': { engine: 'openai' } } } as any,
+        path: '/home/user/.config/abbenay/config.yaml',
+      }),
+    });
+
+    await handleProviderMessage({ type: 'getConfig' }, webview, client);
+
+    const msg = webview.messages[0] as { type: string; config: unknown; path: string };
+    assert.strictEqual(msg.type, 'config');
+    assert.strictEqual(msg.path, '/home/user/.config/abbenay/config.yaml');
+  });
+
+  test('error in handler should send error message to webview', async () => {
+    const webview = createMockWebview();
+    const client = createMockDaemonClient({
+      listEngines: async () => { throw new Error('Connection refused'); },
+    });
+
+    await handleProviderMessage({ type: 'getEngines' }, webview, client);
+
+    const msg = webview.messages[0] as { type: string; message: string; context: string };
+    assert.strictEqual(msg.type, 'error');
+    assert.strictEqual(msg.message, 'Connection refused');
+    assert.strictEqual(msg.context, 'getEngines');
+  });
+});

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -1,0 +1,872 @@
+// ══════════════════════════════════════════════════════════════════════════════
+// Abbenay Chat Sidebar UI — Copilot-style with markdown, tool cards, approvals
+// ══════════════════════════════════════════════════════════════════════════════
+
+import { marked } from 'marked';
+import hljs from 'highlight.js/lib/core';
+import typescript from 'highlight.js/lib/languages/typescript';
+import javascript from 'highlight.js/lib/languages/javascript';
+import python from 'highlight.js/lib/languages/python';
+import bash from 'highlight.js/lib/languages/bash';
+import json from 'highlight.js/lib/languages/json';
+import yaml from 'highlight.js/lib/languages/yaml';
+import xml from 'highlight.js/lib/languages/xml';
+import css from 'highlight.js/lib/languages/css';
+
+// Register highlight.js languages
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('css', css);
+
+// Register aliases
+hljs.registerAliases('shell', { languageName: 'bash' });
+hljs.registerAliases('yml', { languageName: 'yaml' });
+hljs.registerAliases('html', { languageName: 'xml' });
+
+// ── VS Code API ──────────────────────────────────────────────────────────────
+
+declare function acquireVsCodeApi(): {
+  postMessage(msg: unknown): void;
+  getState(): unknown;
+  setState(state: unknown): void;
+};
+
+const api = acquireVsCodeApi();
+
+// ── Type Definitions ─────────────────────────────────────────────────────────
+
+type ModelInfo = {
+  id: string;
+  provider: string;
+  name: string;
+  engine: string;
+};
+
+type SessionInfo = {
+  id: string;
+  model: string;
+  topic: string;
+  messageCount: number;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type MessageInfo = {
+  role: string;
+  content: string;
+  toolCalls?: {
+    id: string;
+    name: string;
+    arguments: string;
+  }[];
+};
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+const state = {
+  models: [] as ModelInfo[],
+  sessions: [] as SessionInfo[],
+  currentSessionId: null as string | null,
+  currentModel: '',
+  messages: [] as MessageInfo[],
+  isStreaming: false,
+  currentAssistantText: '',
+  pendingToolCalls: new Map<string, { name: string; args: string; result?: string; isError?: boolean }>(),
+  pendingApprovals: new Map<string, { toolName: string; args: string }>(),
+  approvalWaiting: false,
+  userScrolledUp: false,
+};
+
+// ── DOM References ───────────────────────────────────────────────────────────
+
+let $modelSelect: HTMLSelectElement;
+let $messageList: HTMLElement;
+let $textarea: HTMLTextAreaElement;
+let $sendBtn: HTMLButtonElement;
+let $cancelBtn: HTMLButtonElement;
+
+// ── Configure marked ─────────────────────────────────────────────────────────
+
+const renderer = new marked.Renderer();
+
+renderer.code = function ({ text, lang }: { text: string; lang?: string }): string {
+  const language = lang || 'plaintext';
+  let highlighted: string;
+
+  try {
+    if (hljs.getLanguage(language)) {
+      highlighted = hljs.highlight(text, { language }).value;
+    } else {
+      highlighted = esc(text);
+    }
+  } catch {
+    highlighted = esc(text);
+  }
+
+  const encodedCode = encodeURIComponent(text);
+
+  return `
+    <div class="code-block">
+      <div class="code-block-header">
+        <span class="code-block-language">${esc(language)}</span>
+        <button class="code-block-copy" data-code="${encodedCode}">Copy</button>
+      </div>
+      <pre><code>${highlighted}</code></pre>
+    </div>
+  `;
+};
+
+marked.setOptions({
+  renderer,
+  breaks: true,
+});
+
+// ── Initialization ───────────────────────────────────────────────────────────
+
+function init(): void {
+  const root = document.getElementById('root')!;
+
+  root.innerHTML = `
+    <div class="chat-header">
+      <div class="chat-header-left">
+        <span class="chat-header-title">Abbenay</span>
+        <select id="modelSelect">
+          <option value="">Select model...</option>
+        </select>
+      </div>
+      <div class="chat-header-actions">
+        <button id="newSessionBtn" title="New session">+ New</button>
+        <button id="deleteSessionBtn" class="icon-btn" title="Delete session">&times;</button>
+      </div>
+    </div>
+    <div id="messageList" class="message-list">
+      <div class="welcome">
+        <div class="welcome-icon">
+          <svg width="36" height="36" viewBox="0 0 256 256">
+            <circle cx="128" cy="128" r="128" fill="var(--vscode-descriptionForeground)" opacity="0.15"/>
+            <path d="m130.46 78.23 33.01 81.48-49.86-39.28 16.85-42.2zm58.64 100.24-50.78-122.2c-1.45-3.52-4.35-5.39-7.87-5.39-3.52 0-6.63 1.87-8.08 5.39l-55.73 134.04h19.07l22.06-55.27 65.84 53.19c2.65 2.14 4.56 3.11 7.04 3.11 4.97 0 9.32-3.73 9.32-9.11 0-.88-.31-2.27-.87-3.76z" fill="var(--vscode-descriptionForeground)" opacity="0.6"/>
+          </svg>
+        </div>
+        <h2>Abbenay Chat</h2>
+        <p>Select a model and start a new chat to begin.</p>
+      </div>
+    </div>
+    <div class="input-area">
+      <div class="input-box">
+        <textarea id="msgInput" placeholder="Ask Abbenay..." rows="1"></textarea>
+        <div class="input-toolbar">
+          <div class="input-toolbar-spacer"></div>
+          <button id="sendBtn" class="send-btn" disabled title="Send (Enter)">&#9650;</button>
+          <button id="cancelBtn" class="cancel-btn" style="display: none;" title="Cancel">&#9632;</button>
+        </div>
+      </div>
+      <div class="input-hints">
+        <span>Shift+Enter for newline</span>
+        <span>Enter to send</span>
+      </div>
+    </div>
+  `;
+
+  $modelSelect = document.getElementById('modelSelect') as HTMLSelectElement;
+  $messageList = document.getElementById('messageList') as HTMLElement;
+  $textarea = document.getElementById('msgInput') as HTMLTextAreaElement;
+  $sendBtn = document.getElementById('sendBtn') as HTMLButtonElement;
+  $cancelBtn = document.getElementById('cancelBtn') as HTMLButtonElement;
+
+  // Event listeners
+  document.getElementById('newSessionBtn')!.addEventListener('click', handleNewSession);
+  document.getElementById('deleteSessionBtn')!.addEventListener('click', handleDeleteSession);
+  $modelSelect.addEventListener('change', () => {
+    state.currentModel = $modelSelect.value;
+  });
+  $sendBtn.addEventListener('click', handleSend);
+  $cancelBtn.addEventListener('click', handleCancel);
+  $textarea.addEventListener('keydown', handleTextareaKeydown);
+  $textarea.addEventListener('input', autoResize);
+  $messageList.addEventListener('scroll', handleScroll);
+
+  window.addEventListener('message', onMessage);
+  api.postMessage({ type: 'ready' });
+}
+
+// ── Event Handlers ───────────────────────────────────────────────────────────
+
+function handleNewSession(): void {
+  if (!$modelSelect.value) {
+    showError('Please select a model first');
+    return;
+  }
+  api.postMessage({ type: 'createSession', model: $modelSelect.value, topic: 'New Chat' });
+}
+
+function handleDeleteSession(): void {
+  if (!state.currentSessionId) {return;}
+  api.postMessage({ type: 'deleteSession', sessionId: state.currentSessionId });
+  state.currentSessionId = null;
+  state.messages = [];
+  state.currentAssistantText = '';
+  state.pendingToolCalls.clear();
+  state.pendingApprovals.clear();
+  state.approvalWaiting = false;
+  renderMessages();
+  updateInputState();
+}
+
+function handleSend(): void {
+  const text = $textarea.value.trim();
+  if (!text || !state.currentSessionId || state.isStreaming || state.approvalWaiting) {
+    return;
+  }
+
+  // Push user message
+  state.messages.push({ role: 'user', content: text });
+  appendMsg({ role: 'user', content: text });
+
+  // Clear input
+  $textarea.value = '';
+  autoResize();
+
+  // Set streaming state
+  state.isStreaming = true;
+  updateInputState();
+
+  // Show thinking indicator
+  showThinkingIndicator();
+
+  // Send to host
+  api.postMessage({
+    type: 'sendMessage',
+    sessionId: state.currentSessionId,
+    content: text,
+  });
+
+  state.userScrolledUp = false;
+  scrollToBottom();
+}
+
+function handleCancel(): void {
+  api.postMessage({ type: 'cancelStream' });
+  state.isStreaming = false;
+  updateInputState();
+  removeThinkingIndicator();
+}
+
+function handleTextareaKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    handleSend();
+  }
+}
+
+function handleScroll(): void {
+  const atBottom = $messageList.scrollHeight - $messageList.scrollTop - $messageList.clientHeight <= 30;
+  state.userScrolledUp = !atBottom;
+}
+
+// ── Message Handler ──────────────────────────────────────────────────────────
+
+function onMessage(event: MessageEvent): void {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case 'models':
+      state.models = msg.models;
+      renderModels();
+      break;
+
+    case 'sessions':
+      state.sessions = msg.sessions;
+      renderSessions();
+      break;
+
+    case 'sessionCreated':
+      state.currentSessionId = msg.session.id;
+      state.currentModel = msg.session.model;
+      state.messages = [];
+      state.currentAssistantText = '';
+      state.pendingToolCalls.clear();
+      state.pendingApprovals.clear();
+      state.approvalWaiting = false;
+      renderMessages();
+      updateInputState();
+      $textarea.focus();
+      break;
+
+    case 'sessionLoaded':
+      state.currentSessionId = msg.session.id;
+      state.currentModel = msg.session.model;
+      state.messages = msg.session.messages.filter((m: MessageInfo) => m.role !== 'system');
+      state.currentAssistantText = '';
+      state.pendingToolCalls.clear();
+      state.pendingApprovals.clear();
+      state.approvalWaiting = false;
+      renderMessages();
+      updateInputState();
+      state.userScrolledUp = false;
+      scrollToBottom();
+      break;
+
+    case 'streamChunk':
+      removeThinkingIndicator();
+      state.currentAssistantText += msg.text;
+      updateStreamingMsg();
+      break;
+
+    case 'streamDone':
+      removeThinkingIndicator();
+      finalizeStream();
+      state.isStreaming = false;
+      updateInputState();
+      break;
+
+    case 'toolCall':
+      removeThinkingIndicator();
+      addToolCard(msg.id, msg.name, msg.args, true);
+      break;
+
+    case 'toolResult':
+      updateToolCard(msg.callId, msg.content, msg.isError);
+      break;
+
+    case 'toolApprovalRequest':
+      createApprovalGate(msg.requestId, msg.toolName, msg.prompt);
+      state.pendingApprovals.set(msg.requestId, { toolName: msg.toolName, args: msg.prompt });
+      state.approvalWaiting = true;
+      updateInputState();
+      state.userScrolledUp = false;
+      scrollToBottom();
+      break;
+
+    case 'error':
+      removeThinkingIndicator();
+      showError(msg.message, msg.context);
+      state.isStreaming = false;
+      updateInputState();
+      break;
+  }
+}
+
+// ── Render Functions ─────────────────────────────────────────────────────────
+
+function renderModels(): void {
+  const currentValue = $modelSelect.value;
+  while ($modelSelect.options.length > 1) {
+    $modelSelect.remove(1);
+  }
+  state.models.forEach((m) => {
+    const opt = document.createElement('option');
+    opt.value = m.id;
+    opt.textContent = m.id;
+    $modelSelect.appendChild(opt);
+  });
+  if (state.currentModel) {
+    $modelSelect.value = state.currentModel;
+  } else if (currentValue) {
+    $modelSelect.value = currentValue;
+  }
+}
+
+function renderSessions(): void {
+  // Sessions dropdown removed per spec — sessions managed via API only
+}
+
+function renderMessages(): void {
+  $messageList.innerHTML = '';
+
+  if (state.messages.length === 0) {
+    $messageList.innerHTML = `
+      <div class="welcome">
+        <div class="welcome-icon">
+          <svg width="36" height="36" viewBox="0 0 256 256">
+            <circle cx="128" cy="128" r="128" fill="var(--vscode-descriptionForeground)" opacity="0.15"/>
+            <path d="m130.46 78.23 33.01 81.48-49.86-39.28 16.85-42.2zm58.64 100.24-50.78-122.2c-1.45-3.52-4.35-5.39-7.87-5.39-3.52 0-6.63 1.87-8.08 5.39l-55.73 134.04h19.07l22.06-55.27 65.84 53.19c2.65 2.14 4.56 3.11 7.04 3.11 4.97 0 9.32-3.73 9.32-9.11 0-.88-.31-2.27-.87-3.76z" fill="var(--vscode-descriptionForeground)" opacity="0.6"/>
+          </svg>
+        </div>
+        <h2>Abbenay Chat</h2>
+        <p>${state.currentSessionId ? 'Ask anything below.' : 'Select a model and start a new chat.'}</p>
+      </div>
+    `;
+    return;
+  }
+
+  state.messages.forEach((m) => appendMsg(m));
+}
+
+function appendMsg(msg: MessageInfo): void {
+  const el = document.createElement('div');
+  el.className = `message message-${msg.role}`;
+
+  // Create avatar
+  const avatar = document.createElement('span');
+  avatar.className = `msg-avatar ${msg.role}`;
+  if (msg.role === 'user') {
+    avatar.textContent = 'U';
+  } else if (msg.role === 'assistant') {
+    avatar.textContent = '✨';
+  }
+
+  // Create content container
+  const content = document.createElement('div');
+  content.className = 'msg-content';
+
+  // Add role label
+  const role = document.createElement('div');
+  role.className = 'msg-role';
+  role.textContent = msg.role === 'user' ? 'You' : 'Abbenay';
+  content.appendChild(role);
+
+  // Add body
+  const body = document.createElement('div');
+  body.className = 'msg-body';
+
+  if (msg.role === 'user') {
+    // User messages: plain text (no markdown)
+    body.textContent = msg.content;
+  } else {
+    // Assistant messages: rendered markdown (marked.parse handles escaping)
+    body.innerHTML = marked.parse(msg.content) as string;
+    attachCopyListeners(body);
+  }
+
+  content.appendChild(body);
+
+  // Add tool calls if present
+  if (msg.toolCalls) {
+    msg.toolCalls.forEach((tc) => {
+      content.appendChild(createToolCard(tc.id, tc.name, tc.arguments, false));
+    });
+  }
+
+  el.appendChild(avatar);
+  el.appendChild(content);
+  $messageList.appendChild(el);
+}
+
+// ── Streaming Functions ──────────────────────────────────────────────────────
+
+function updateStreamingMsg(): void {
+  let el = $messageList.querySelector('.streaming') as HTMLElement;
+
+  if (!el) {
+    // Create streaming message
+    state.messages.push({ role: 'assistant', content: '' });
+
+    el = document.createElement('div');
+    el.className = 'message message-assistant streaming';
+
+    const avatar = document.createElement('span');
+    avatar.className = 'msg-avatar assistant';
+    avatar.textContent = '✨';
+
+    const content = document.createElement('div');
+    content.className = 'msg-content';
+
+    const role = document.createElement('div');
+    role.className = 'msg-role';
+    role.textContent = 'Abbenay';
+
+    const body = document.createElement('div');
+    body.className = 'msg-body';
+
+    content.appendChild(role);
+    content.appendChild(body);
+    el.appendChild(avatar);
+    el.appendChild(content);
+    $messageList.appendChild(el);
+  }
+
+  const body = el.querySelector('.msg-body') as HTMLElement;
+  // Rendered markdown (marked.parse handles escaping)
+  body.innerHTML = marked.parse(state.currentAssistantText) as string;
+  attachCopyListeners(body);
+
+  // Auto-scroll if user hasn't scrolled up
+  if (!state.userScrolledUp) {
+    scrollToBottom();
+  }
+}
+
+function finalizeStream(): void {
+  const el = $messageList.querySelector('.streaming') as HTMLElement;
+  if (el) {
+    el.classList.remove('streaming');
+  }
+
+  const last = state.messages[state.messages.length - 1];
+  if (last?.role === 'assistant') {
+    last.content = state.currentAssistantText;
+  }
+  state.currentAssistantText = '';
+}
+
+// ── Thinking Indicator ───────────────────────────────────────────────────────
+
+function showThinkingIndicator(): void {
+  removeThinkingIndicator();
+
+  const el = document.createElement('div');
+  el.className = 'message thinking-indicator';
+  el.id = 'thinkingIndicator';
+
+  const avatar = document.createElement('span');
+  avatar.className = 'msg-avatar assistant';
+  avatar.textContent = '✨';
+
+  const content = document.createElement('div');
+  content.className = 'msg-content';
+
+  const role = document.createElement('div');
+  role.className = 'msg-role';
+  role.textContent = 'Abbenay';
+
+  const body = document.createElement('div');
+  body.className = 'msg-body';
+  body.innerHTML = '<div class="thinking-dots"><span></span><span></span><span></span></div>';
+
+  content.appendChild(role);
+  content.appendChild(body);
+  el.appendChild(avatar);
+  el.appendChild(content);
+  $messageList.appendChild(el);
+
+  if (!state.userScrolledUp) {
+    scrollToBottom();
+  }
+}
+
+function removeThinkingIndicator(): void {
+  const el = document.getElementById('thinkingIndicator');
+  if (el) {
+    el.remove();
+  }
+}
+
+// ── Tool Cards ───────────────────────────────────────────────────────────────
+
+function addToolCard(id: string, name: string, args: string, isRunning: boolean): void {
+  state.pendingToolCalls.set(id, { name, args });
+
+  const lastMsg = $messageList.querySelector('.streaming, .message:last-child .msg-content') as HTMLElement;
+  if (lastMsg) {
+    lastMsg.appendChild(createToolCard(id, name, args, isRunning));
+  }
+}
+
+function createToolCard(id: string, name: string, args: string, isRunning: boolean): HTMLElement {
+  const card = document.createElement('div');
+  card.className = isRunning ? 'tool-card' : 'tool-card open';
+  card.dataset.toolId = id;
+
+  const header = document.createElement('div');
+  header.className = 'tool-card-header';
+
+  const chevron = document.createElement('span');
+  chevron.className = 'tool-card-chevron';
+  chevron.textContent = '▶';
+
+  const label = document.createElement('span');
+  label.className = 'tool-card-label';
+  label.textContent = isRunning ? 'Running' : 'Used';
+
+  const toolName = document.createElement('span');
+  toolName.className = 'tool-card-name';
+  toolName.textContent = name;
+
+  const status = document.createElement('span');
+  status.className = isRunning ? 'tool-card-status running' : 'tool-card-status';
+  status.innerHTML = isRunning ? '&#10227;' : '';
+
+  header.appendChild(chevron);
+  header.appendChild(label);
+  header.appendChild(toolName);
+  header.appendChild(status);
+
+  const body = document.createElement('div');
+  body.className = 'tool-card-body';
+
+  // Arguments section
+  const argsSection = document.createElement('div');
+  argsSection.className = 'tool-card-section';
+
+  const argsLabel = document.createElement('div');
+  argsLabel.className = 'tool-card-section-label';
+  argsLabel.textContent = 'Arguments';
+
+  const argsPre = document.createElement('pre');
+  try {
+    argsPre.textContent = JSON.stringify(JSON.parse(args), null, 2);
+  } catch {
+    argsPre.textContent = args;
+  }
+
+  argsSection.appendChild(argsLabel);
+  argsSection.appendChild(argsPre);
+  body.appendChild(argsSection);
+
+  card.appendChild(header);
+  card.appendChild(body);
+
+  // Toggle open/close on header click
+  header.addEventListener('click', () => {
+    card.classList.toggle('open');
+  });
+
+  return card;
+}
+
+function updateToolCard(callId: string, content: string, isError: boolean): void {
+  const tc = state.pendingToolCalls.get(callId);
+  if (tc) {
+    tc.result = content;
+    tc.isError = isError;
+  }
+
+  const card = document.querySelector(`[data-tool-id="${callId}"]`) as HTMLElement;
+  if (!card) {return;}
+
+  // Update status icon
+  const status = card.querySelector('.tool-card-status') as HTMLElement;
+  if (status) {
+    status.className = `tool-card-status ${isError ? 'error' : 'success'}`;
+    status.innerHTML = isError ? '✗' : '✓';
+  }
+
+  // Update label
+  const label = card.querySelector('.tool-card-label') as HTMLElement;
+  if (label) {
+    label.textContent = 'Used';
+  }
+
+  // Add result section
+  const body = card.querySelector('.tool-card-body') as HTMLElement;
+  if (body) {
+    const resultSection = document.createElement('div');
+    resultSection.className = 'tool-card-section';
+
+    const resultLabel = document.createElement('div');
+    resultLabel.className = 'tool-card-section-label';
+    resultLabel.textContent = 'Result';
+
+    const resultPre = document.createElement('pre');
+    resultPre.textContent = content;
+
+    resultSection.appendChild(resultLabel);
+    resultSection.appendChild(resultPre);
+    body.appendChild(resultSection);
+  }
+
+  // Collapse card
+  card.classList.remove('open');
+}
+
+// ── Approval Gates ───────────────────────────────────────────────────────────
+
+function createApprovalGate(requestId: string, toolName: string, promptText: string): void {
+  const gate = document.createElement('div');
+  gate.className = 'approval-gate';
+  gate.id = `approval-${requestId}`;
+
+  const header = document.createElement('div');
+  header.className = 'approval-gate-header';
+
+  const icon = document.createElement('span');
+  icon.className = 'approval-gate-icon';
+  icon.textContent = '⚠';
+
+  const title = document.createElement('span');
+  title.className = 'approval-gate-title';
+  title.textContent = 'Tool Approval Required';
+
+  header.appendChild(icon);
+  header.appendChild(title);
+
+  const body = document.createElement('div');
+  body.className = 'approval-gate-body';
+
+  const name = document.createElement('div');
+  name.className = 'approval-tool-name';
+  name.textContent = toolName;
+
+  const argsDiv = document.createElement('div');
+  argsDiv.className = 'approval-args';
+
+  const argsPre = document.createElement('pre');
+  try {
+    argsPre.textContent = JSON.stringify(JSON.parse(promptText), null, 2);
+  } catch {
+    argsPre.textContent = promptText;
+  }
+
+  argsDiv.appendChild(argsPre);
+
+  const buttons = document.createElement('div');
+  buttons.className = 'approval-buttons';
+
+  const allowBtn = document.createElement('button');
+  allowBtn.className = 'approval-btn-allow';
+  allowBtn.textContent = 'Allow';
+  allowBtn.addEventListener('click', () => {
+    api.postMessage({ type: 'approveToolCall', requestId, decision: 'allow' });
+    resolveApprovalGate(requestId, 'allow');
+  });
+
+  const denyBtn = document.createElement('button');
+  denyBtn.className = 'approval-btn-deny';
+  denyBtn.textContent = 'Deny';
+  denyBtn.addEventListener('click', () => {
+    api.postMessage({ type: 'approveToolCall', requestId, decision: 'deny' });
+    resolveApprovalGate(requestId, 'deny');
+  });
+
+  const abortBtn = document.createElement('button');
+  abortBtn.className = 'approval-btn-abort';
+  abortBtn.textContent = 'Abort';
+  abortBtn.addEventListener('click', () => {
+    api.postMessage({ type: 'approveToolCall', requestId, decision: 'abort' });
+    resolveApprovalGate(requestId, 'abort');
+  });
+
+  buttons.appendChild(allowBtn);
+  buttons.appendChild(denyBtn);
+  buttons.appendChild(abortBtn);
+
+  body.appendChild(name);
+  body.appendChild(argsDiv);
+  body.appendChild(buttons);
+
+  gate.appendChild(header);
+  gate.appendChild(body);
+
+  // Find last message or streaming indicator
+  const lastMsg = $messageList.querySelector('.streaming, .message:last-child .msg-content') as HTMLElement;
+  if (lastMsg) {
+    lastMsg.appendChild(gate);
+  } else {
+    $messageList.appendChild(gate);
+  }
+}
+
+function resolveApprovalGate(requestId: string, decision: 'allow' | 'deny' | 'abort'): void {
+  const gate = document.getElementById(`approval-${requestId}`) as HTMLElement;
+  if (!gate) {return;}
+
+  gate.classList.add('resolved');
+  gate.innerHTML = '';
+
+  const resolved = document.createElement('div');
+  resolved.className = `approval-resolved ${decision === 'allow' ? 'allowed' : decision === 'deny' ? 'denied' : 'aborted'}`;
+
+  if (decision === 'allow') {
+    resolved.textContent = '✓ Allowed';
+  } else if (decision === 'deny') {
+    resolved.textContent = '✗ Denied';
+  } else {
+    resolved.textContent = '✗ Aborted';
+  }
+
+  gate.appendChild(resolved);
+
+  state.pendingApprovals.delete(requestId);
+  if (state.pendingApprovals.size === 0) {
+    state.approvalWaiting = false;
+    updateInputState();
+  }
+}
+
+// ── Error Display ────────────────────────────────────────────────────────────
+
+function showError(message: string, context?: string): void {
+  const el = document.createElement('div');
+  el.className = 'message message-error';
+
+  const avatar = document.createElement('span');
+  avatar.className = 'msg-avatar assistant';
+  avatar.textContent = '✗';
+
+  const content = document.createElement('div');
+  content.className = 'msg-content';
+
+  const body = document.createElement('div');
+  body.className = 'msg-body';
+  body.textContent = context ? `${context}: ${message}` : message;
+
+  content.appendChild(body);
+  el.appendChild(avatar);
+  el.appendChild(content);
+  $messageList.appendChild(el);
+
+  if (!state.userScrolledUp) {
+    scrollToBottom();
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function updateInputState(): void {
+  const canSend = !state.isStreaming && !state.approvalWaiting && state.currentSessionId !== null;
+
+  $sendBtn.disabled = !canSend;
+  $textarea.disabled = state.isStreaming || state.approvalWaiting;
+
+  if (state.approvalWaiting) {
+    $textarea.placeholder = 'Waiting for approval...';
+  } else {
+    $textarea.placeholder = 'Ask Abbenay...';
+  }
+
+  // Toggle send/cancel buttons
+  if (state.isStreaming) {
+    $sendBtn.style.display = 'none';
+    $cancelBtn.style.display = 'flex';
+  } else {
+    $sendBtn.style.display = 'flex';
+    $cancelBtn.style.display = 'none';
+  }
+}
+
+function scrollToBottom(): void {
+  if (!state.userScrolledUp) {
+    $messageList.scrollTop = $messageList.scrollHeight;
+  }
+}
+
+function autoResize(): void {
+  $textarea.style.height = 'auto';
+  const newHeight = Math.min(Math.max($textarea.scrollHeight, 40), 200);
+  $textarea.style.height = `${newHeight}px`;
+}
+
+function attachCopyListeners(container: HTMLElement): void {
+  const copyButtons = container.querySelectorAll('.code-block-copy');
+  copyButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const code = decodeURIComponent((btn as HTMLElement).dataset.code || '');
+      navigator.clipboard.writeText(code).then(() => {
+        const originalText = btn.textContent;
+        btn.textContent = 'Copied!';
+        setTimeout(() => {
+          btn.textContent = originalText;
+        }, 2000);
+      });
+    });
+  });
+}
+
+function esc(text: string): string {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+// ── Boot ─────────────────────────────────────────────────────────────────────
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -132,17 +132,6 @@ function init(): void {
   const root = document.getElementById('root')!;
 
   root.innerHTML = `
-    <div class="chat-header">
-      <div class="chat-header-left">
-        <select id="modelSelect">
-          <option value="">Select model...</option>
-        </select>
-      </div>
-      <div class="chat-header-actions">
-        <button id="newSessionBtn" title="New session">+ New</button>
-        <button id="deleteSessionBtn" class="icon-btn" title="Delete session">&times;</button>
-      </div>
-    </div>
     <div id="messageList" class="message-list">
       <div class="welcome">
         <div class="welcome-icon">
@@ -159,7 +148,12 @@ function init(): void {
       <div class="input-box">
         <textarea id="msgInput" placeholder="Ask Abbenay..." rows="1"></textarea>
         <div class="input-toolbar">
+          <select id="modelSelect">
+            <option value="">Select model...</option>
+          </select>
           <div class="input-toolbar-spacer"></div>
+          <button id="newSessionBtn" class="session-btn" title="New session">+ New</button>
+          <button id="deleteSessionBtn" class="session-btn icon-btn" title="Delete session">&times;</button>
           <button id="sendBtn" class="send-btn" disabled title="Send (Enter)">&#9650;</button>
           <button id="cancelBtn" class="cancel-btn" style="display: none;" title="Cancel">&#9632;</button>
         </div>
@@ -400,24 +394,17 @@ function appendMsg(msg: MessageInfo): void {
   const el = document.createElement('div');
   el.className = `message message-${msg.role}`;
 
-  // Create avatar
-  const avatar = document.createElement('span');
-  avatar.className = `msg-avatar ${msg.role}`;
-  if (msg.role === 'user') {
-    avatar.textContent = 'U';
-  } else if (msg.role === 'assistant') {
-    avatar.textContent = '✨';
-  }
-
   // Create content container
   const content = document.createElement('div');
   content.className = 'msg-content';
 
-  // Add role label
-  const role = document.createElement('div');
-  role.className = 'msg-role';
-  role.textContent = msg.role === 'user' ? 'You' : 'Abbenay';
-  content.appendChild(role);
+  // Add role label (assistant only)
+  if (msg.role === 'assistant') {
+    const role = document.createElement('div');
+    role.className = 'msg-role';
+    role.textContent = 'Abbenay';
+    content.appendChild(role);
+  }
 
   // Add body
   const body = document.createElement('div');
@@ -441,7 +428,6 @@ function appendMsg(msg: MessageInfo): void {
     });
   }
 
-  el.appendChild(avatar);
   el.appendChild(content);
   $messageList.appendChild(el);
 }
@@ -458,10 +444,6 @@ function updateStreamingMsg(): void {
     el = document.createElement('div');
     el.className = 'message message-assistant streaming';
 
-    const avatar = document.createElement('span');
-    avatar.className = 'msg-avatar assistant';
-    avatar.textContent = '✨';
-
     const content = document.createElement('div');
     content.className = 'msg-content';
 
@@ -474,7 +456,6 @@ function updateStreamingMsg(): void {
 
     content.appendChild(role);
     content.appendChild(body);
-    el.appendChild(avatar);
     el.appendChild(content);
     $messageList.appendChild(el);
   }
@@ -512,10 +493,6 @@ function showThinkingIndicator(): void {
   el.className = 'message thinking-indicator';
   el.id = 'thinkingIndicator';
 
-  const avatar = document.createElement('span');
-  avatar.className = 'msg-avatar assistant';
-  avatar.textContent = '✨';
-
   const content = document.createElement('div');
   content.className = 'msg-content';
 
@@ -529,7 +506,6 @@ function showThinkingIndicator(): void {
 
   content.appendChild(role);
   content.appendChild(body);
-  el.appendChild(avatar);
   el.appendChild(content);
   $messageList.appendChild(el);
 
@@ -783,10 +759,6 @@ function showError(message: string, context?: string): void {
   const el = document.createElement('div');
   el.className = 'message message-error';
 
-  const avatar = document.createElement('span');
-  avatar.className = 'msg-avatar assistant';
-  avatar.textContent = '✗';
-
   const content = document.createElement('div');
   content.className = 'msg-content';
 
@@ -795,7 +767,6 @@ function showError(message: string, context?: string): void {
   body.textContent = context ? `${context}: ${message}` : message;
 
   content.appendChild(body);
-  el.appendChild(avatar);
   el.appendChild(content);
   $messageList.appendChild(el);
 

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -155,10 +155,9 @@ function init(): void {
       <div class="input-box">
         <textarea id="msgInput" placeholder="Ask Abbenay..." rows="1"></textarea>
         <div class="input-toolbar">
-          <vscode-single-select id="modelSelect" class="toolbar-select">
+          <vscode-single-select id="modelSelect" class="toolbar-select" position="above">
             <vscode-option value="">Select model...</vscode-option>
           </vscode-single-select>
-          <div class="input-toolbar-spacer"></div>
           <vscode-button id="newSessionBtn" secondary class="toolbar-btn" title="New session">+ New</vscode-button>
           <vscode-button id="deleteSessionBtn" secondary class="toolbar-btn" title="Delete session">&times;</vscode-button>
           <button id="sendBtn" class="send-btn" disabled title="Send (Enter)">&#9650;</button>

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -128,6 +128,10 @@ renderer.code = function ({ text, lang }: { text: string; lang?: string }): stri
   `;
 };
 
+renderer.html = function ({ text }: { text: string }): string {
+  return esc(text);
+};
+
 marked.setOptions({
   renderer,
   breaks: true,
@@ -333,8 +337,8 @@ function onMessage(event: MessageEvent): void {
       break;
 
     case 'toolApprovalRequest':
-      createApprovalGate(msg.requestId, msg.toolName, msg.prompt);
-      state.pendingApprovals.set(msg.requestId, { toolName: msg.toolName, args: msg.prompt });
+      createApprovalGate(msg.requestId, msg.toolName, msg.promptText);
+      state.pendingApprovals.set(msg.requestId, { toolName: msg.toolName, args: msg.promptText });
       state.approvalWaiting = true;
       updateInputState();
       state.userScrolledUp = false;
@@ -537,7 +541,7 @@ function removeThinkingIndicator(): void {
 function addToolCard(id: string, name: string, args: string, isRunning: boolean): void {
   state.pendingToolCalls.set(id, { name, args });
 
-  const lastMsg = $messageList.querySelector('.streaming, .message:last-child .msg-content') as HTMLElement;
+  const lastMsg = $messageList.querySelector('.streaming .msg-content, .message:last-child .msg-content') as HTMLElement;
   if (lastMsg) {
     lastMsg.appendChild(createToolCard(id, name, args, isRunning));
   }
@@ -702,8 +706,7 @@ function createApprovalGate(requestId: string, toolName: string, promptText: str
   gate.appendChild(header);
   gate.appendChild(body);
 
-  // Find last message or streaming indicator
-  const lastMsg = $messageList.querySelector('.streaming, .message:last-child .msg-content') as HTMLElement;
+  const lastMsg = $messageList.querySelector('.streaming .msg-content, .message:last-child .msg-content') as HTMLElement;
   if (lastMsg) {
     lastMsg.appendChild(gate);
   } else {

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -2,6 +2,13 @@
 // Abbenay Chat Sidebar UI — Copilot-style with markdown, tool cards, approvals
 // ══════════════════════════════════════════════════════════════════════════════
 
+import '@vscode-elements/elements/dist/vscode-button/index.js';
+import '@vscode-elements/elements/dist/vscode-single-select/index.js';
+import '@vscode-elements/elements/dist/vscode-option/index.js';
+import '@vscode-elements/elements/dist/vscode-collapsible/index.js';
+import '@vscode-elements/elements/dist/vscode-progress-ring/index.js';
+import '@vscode-elements/elements/dist/vscode-badge/index.js';
+
 import { marked } from 'marked';
 import hljs from 'highlight.js/lib/core';
 import typescript from 'highlight.js/lib/languages/typescript';
@@ -84,7 +91,7 @@ const state = {
 
 // ── DOM References ───────────────────────────────────────────────────────────
 
-let $modelSelect: HTMLSelectElement;
+let $modelSelect: HTMLElement & { value: string };
 let $messageList: HTMLElement;
 let $textarea: HTMLTextAreaElement;
 let $sendBtn: HTMLButtonElement;
@@ -148,12 +155,12 @@ function init(): void {
       <div class="input-box">
         <textarea id="msgInput" placeholder="Ask Abbenay..." rows="1"></textarea>
         <div class="input-toolbar">
-          <select id="modelSelect">
-            <option value="">Select model...</option>
-          </select>
+          <vscode-single-select id="modelSelect" class="toolbar-select">
+            <vscode-option value="">Select model...</vscode-option>
+          </vscode-single-select>
           <div class="input-toolbar-spacer"></div>
-          <button id="newSessionBtn" class="session-btn" title="New session">+ New</button>
-          <button id="deleteSessionBtn" class="session-btn icon-btn" title="Delete session">&times;</button>
+          <vscode-button id="newSessionBtn" secondary class="toolbar-btn" title="New session">+ New</vscode-button>
+          <vscode-button id="deleteSessionBtn" secondary class="toolbar-btn" title="Delete session">&times;</vscode-button>
           <button id="sendBtn" class="send-btn" disabled title="Send (Enter)">&#9650;</button>
           <button id="cancelBtn" class="cancel-btn" style="display: none;" title="Cancel">&#9632;</button>
         </div>
@@ -165,7 +172,7 @@ function init(): void {
     </div>
   `;
 
-  $modelSelect = document.getElementById('modelSelect') as HTMLSelectElement;
+  $modelSelect = document.getElementById('modelSelect') as HTMLElement & { value: string };
   $messageList = document.getElementById('messageList') as HTMLElement;
   $textarea = document.getElementById('msgInput') as HTMLTextAreaElement;
   $sendBtn = document.getElementById('sendBtn') as HTMLButtonElement;
@@ -348,15 +355,20 @@ function onMessage(event: MessageEvent): void {
 
 function renderModels(): void {
   const currentValue = $modelSelect.value;
-  while ($modelSelect.options.length > 1) {
-    $modelSelect.remove(1);
-  }
+
+  // Remove all options except the first placeholder
+  const existingOptions = $modelSelect.querySelectorAll('vscode-option');
+  existingOptions.forEach((opt, i) => {
+    if (i > 0) {opt.remove();}
+  });
+
   state.models.forEach((m) => {
-    const opt = document.createElement('option');
-    opt.value = m.id;
+    const opt = document.createElement('vscode-option') as HTMLElement;
+    opt.setAttribute('value', m.id);
     opt.textContent = m.id;
     $modelSelect.appendChild(opt);
   });
+
   if (state.currentModel) {
     $modelSelect.value = state.currentModel;
   } else if (currentValue) {
@@ -533,36 +545,24 @@ function addToolCard(id: string, name: string, args: string, isRunning: boolean)
 }
 
 function createToolCard(id: string, name: string, args: string, isRunning: boolean): HTMLElement {
-  const card = document.createElement('div');
-  card.className = isRunning ? 'tool-card' : 'tool-card open';
+  const card = document.createElement('vscode-collapsible') as HTMLElement;
+  card.className = 'tool-card';
+  card.setAttribute('heading', name);
+  card.setAttribute('description', isRunning ? 'Running' : 'Used');
   card.dataset.toolId = id;
+  if (!isRunning) {card.setAttribute('open', '');}
 
-  const header = document.createElement('div');
-  header.className = 'tool-card-header';
-
-  const chevron = document.createElement('span');
-  chevron.className = 'tool-card-chevron';
-  chevron.textContent = '▶';
-
-  const label = document.createElement('span');
-  label.className = 'tool-card-label';
-  label.textContent = isRunning ? 'Running' : 'Used';
-
-  const toolName = document.createElement('span');
-  toolName.className = 'tool-card-name';
-  toolName.textContent = name;
-
+  // Status indicator in decorations slot
   const status = document.createElement('span');
+  status.slot = 'decorations';
   status.className = isRunning ? 'tool-card-status running' : 'tool-card-status';
-  status.innerHTML = isRunning ? '&#10227;' : '';
-
-  header.appendChild(chevron);
-  header.appendChild(label);
-  header.appendChild(toolName);
-  header.appendChild(status);
-
-  const body = document.createElement('div');
-  body.className = 'tool-card-body';
+  if (isRunning) {
+    const ring = document.createElement('vscode-progress-ring') as HTMLElement;
+    ring.style.width = '14px';
+    ring.style.height = '14px';
+    status.appendChild(ring);
+  }
+  card.appendChild(status);
 
   // Arguments section
   const argsSection = document.createElement('div');
@@ -581,15 +581,7 @@ function createToolCard(id: string, name: string, args: string, isRunning: boole
 
   argsSection.appendChild(argsLabel);
   argsSection.appendChild(argsPre);
-  body.appendChild(argsSection);
-
-  card.appendChild(header);
-  card.appendChild(body);
-
-  // Toggle open/close on header click
-  header.addEventListener('click', () => {
-    card.classList.toggle('open');
-  });
+  card.appendChild(argsSection);
 
   return card;
 }
@@ -604,39 +596,33 @@ function updateToolCard(callId: string, content: string, isError: boolean): void
   const card = document.querySelector(`[data-tool-id="${callId}"]`) as HTMLElement;
   if (!card) {return;}
 
-  // Update status icon
+  // Update status icon in decorations slot
   const status = card.querySelector('.tool-card-status') as HTMLElement;
   if (status) {
     status.className = `tool-card-status ${isError ? 'error' : 'success'}`;
     status.innerHTML = isError ? '✗' : '✓';
   }
 
-  // Update label
-  const label = card.querySelector('.tool-card-label') as HTMLElement;
-  if (label) {
-    label.textContent = 'Used';
-  }
+  // Update description
+  card.setAttribute('description', 'Used');
 
   // Add result section
-  const body = card.querySelector('.tool-card-body') as HTMLElement;
-  if (body) {
-    const resultSection = document.createElement('div');
-    resultSection.className = 'tool-card-section';
+  const resultSection = document.createElement('div');
+  resultSection.className = 'tool-card-section';
 
-    const resultLabel = document.createElement('div');
-    resultLabel.className = 'tool-card-section-label';
-    resultLabel.textContent = 'Result';
+  const resultLabel = document.createElement('div');
+  resultLabel.className = 'tool-card-section-label';
+  resultLabel.textContent = 'Result';
 
-    const resultPre = document.createElement('pre');
-    resultPre.textContent = content;
+  const resultPre = document.createElement('pre');
+  resultPre.textContent = content;
 
-    resultSection.appendChild(resultLabel);
-    resultSection.appendChild(resultPre);
-    body.appendChild(resultSection);
-  }
+  resultSection.appendChild(resultLabel);
+  resultSection.appendChild(resultPre);
+  card.appendChild(resultSection);
 
   // Collapse card
-  card.classList.remove('open');
+  card.removeAttribute('open');
 }
 
 // ── Approval Gates ───────────────────────────────────────────────────────────
@@ -663,9 +649,9 @@ function createApprovalGate(requestId: string, toolName: string, promptText: str
   const body = document.createElement('div');
   body.className = 'approval-gate-body';
 
-  const name = document.createElement('div');
-  name.className = 'approval-tool-name';
-  name.textContent = toolName;
+  const nameEl = document.createElement('div');
+  nameEl.className = 'approval-tool-name';
+  nameEl.textContent = toolName;
 
   const argsDiv = document.createElement('div');
   argsDiv.className = 'approval-args';
@@ -682,23 +668,23 @@ function createApprovalGate(requestId: string, toolName: string, promptText: str
   const buttons = document.createElement('div');
   buttons.className = 'approval-buttons';
 
-  const allowBtn = document.createElement('button');
-  allowBtn.className = 'approval-btn-allow';
+  const allowBtn = document.createElement('vscode-button') as HTMLElement;
   allowBtn.textContent = 'Allow';
   allowBtn.addEventListener('click', () => {
     api.postMessage({ type: 'approveToolCall', requestId, decision: 'allow' });
     resolveApprovalGate(requestId, 'allow');
   });
 
-  const denyBtn = document.createElement('button');
-  denyBtn.className = 'approval-btn-deny';
+  const denyBtn = document.createElement('vscode-button') as HTMLElement;
+  denyBtn.setAttribute('secondary', '');
   denyBtn.textContent = 'Deny';
   denyBtn.addEventListener('click', () => {
     api.postMessage({ type: 'approveToolCall', requestId, decision: 'deny' });
     resolveApprovalGate(requestId, 'deny');
   });
 
-  const abortBtn = document.createElement('button');
+  const abortBtn = document.createElement('vscode-button') as HTMLElement;
+  abortBtn.setAttribute('secondary', '');
   abortBtn.className = 'approval-btn-abort';
   abortBtn.textContent = 'Abort';
   abortBtn.addEventListener('click', () => {
@@ -710,7 +696,7 @@ function createApprovalGate(requestId: string, toolName: string, promptText: str
   buttons.appendChild(denyBtn);
   buttons.appendChild(abortBtn);
 
-  body.appendChild(name);
+  body.appendChild(nameEl);
   body.appendChild(argsDiv);
   body.appendChild(buttons);
 

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -134,7 +134,6 @@ function init(): void {
   root.innerHTML = `
     <div class="chat-header">
       <div class="chat-header-left">
-        <span class="chat-header-title">Abbenay</span>
         <select id="modelSelect">
           <option value="">Select model...</option>
         </select>

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -1,3 +1,16 @@
+import '@vscode-elements/elements/dist/vscode-button/index.js';
+import '@vscode-elements/elements/dist/vscode-textfield/index.js';
+import '@vscode-elements/elements/dist/vscode-single-select/index.js';
+import '@vscode-elements/elements/dist/vscode-option/index.js';
+import '@vscode-elements/elements/dist/vscode-collapsible/index.js';
+import '@vscode-elements/elements/dist/vscode-form-group/index.js';
+import '@vscode-elements/elements/dist/vscode-label/index.js';
+import '@vscode-elements/elements/dist/vscode-form-helper/index.js';
+import '@vscode-elements/elements/dist/vscode-radio-group/index.js';
+import '@vscode-elements/elements/dist/vscode-radio/index.js';
+import '@vscode-elements/elements/dist/vscode-badge/index.js';
+import '@vscode-elements/elements/dist/vscode-progress-ring/index.js';
+
 declare function acquireVsCodeApi(): {
   postMessage(msg: unknown): void;
   getState(): unknown;
@@ -95,9 +108,8 @@ function buildInitialDOM(): void {
   const buttonContainer = document.createElement('div');
   buttonContainer.style.margin = '12px 0';
 
-  const addBtn = document.createElement('button');
+  const addBtn = document.createElement('vscode-button') as HTMLElement;
   addBtn.id = 'add-provider-btn';
-  addBtn.className = 'primary';
   addBtn.textContent = '+ Add Provider';
   addBtn.addEventListener('click', () => {
     editingProviderId = null;
@@ -164,8 +176,7 @@ function renderProviders(): void {
     name.className = 'provider-name';
     name.textContent = p.id;
 
-    const engine = document.createElement('span');
-    engine.className = 'provider-engine';
+    const engine = document.createElement('vscode-badge') as HTMLElement;
     engine.textContent = p.engine;
 
     const modelCount = document.createElement('span');
@@ -180,12 +191,16 @@ function renderProviders(): void {
     const actions = document.createElement('div');
     actions.className = 'provider-actions';
 
-    const editBtn = document.createElement('button');
+    const editBtn = document.createElement('vscode-button') as HTMLElement;
+    editBtn.setAttribute('secondary', '');
+    editBtn.className = 'card-action';
     editBtn.textContent = '✎';
     editBtn.title = 'Edit provider';
     editBtn.addEventListener('click', () => startEdit(p));
 
-    const deleteBtn = document.createElement('button');
+    const deleteBtn = document.createElement('vscode-button') as HTMLElement;
+    deleteBtn.setAttribute('secondary', '');
+    deleteBtn.className = 'card-action';
     deleteBtn.textContent = '×';
     deleteBtn.title = 'Delete provider';
     deleteBtn.addEventListener('click', () => {
@@ -246,70 +261,45 @@ function renderAccordion(): void {
   const section1Complete = selectedEngine !== '';
   const section2Complete = selectedModels.size > 0;
 
-  // Create wrapper
   const wrapper = document.createElement('div');
 
-  // Section 1
-  const section1 = document.createElement('div');
-  section1.className = `accordion-section ${section1Open ? 'open' : ''}`;
-  section1.id = 'accordion-section-1';
+  // ── Section 1: Provider Setup ──
+  const section1 = document.createElement('vscode-collapsible') as HTMLElement;
+  section1.setAttribute('heading', '1. Provider Setup');
+  if (section1Open) {section1.setAttribute('open', '');}
+  section1.addEventListener('vsc-collapsible-toggle', ((e: CustomEvent<{ open: boolean }>) => {
+    section1Open = e.detail.open;
+  }) as EventListener);
 
-  const header1 = document.createElement('div');
-  header1.className = 'accordion-header';
-  header1.id = 'accordion-header-1';
-  header1.addEventListener('click', () => {
-    section1Open = !section1Open;
-    renderAccordion();
-  });
-
-  const header1Left = document.createElement('div');
-  header1Left.className = 'accordion-header-left';
-
-  const chevron1 = document.createElement('span');
-  chevron1.className = 'accordion-chevron';
-
-  const title1 = document.createElement('span');
-  title1.className = 'accordion-title';
-  title1.textContent = '1. Provider Setup';
-
-  header1Left.appendChild(chevron1);
-  header1Left.appendChild(title1);
-
-  const status1 = document.createElement('span');
-  status1.className = `accordion-status ${section1Complete ? 'complete' : ''}`;
   if (section1Complete) {
-    status1.textContent = 'Complete';
+    const status1 = document.createElement('vscode-badge') as HTMLElement;
+    status1.slot = 'decorations';
+    status1.textContent = '✓ Complete';
+    section1.appendChild(status1);
   }
 
-  header1.appendChild(header1Left);
-  header1.appendChild(status1);
-
-  const body1 = document.createElement('div');
-  body1.className = 'accordion-body';
-  body1.id = 'accordion-body-1';
-
   // Engine dropdown
-  const engineGroup = document.createElement('div');
-  engineGroup.className = 'form-group';
+  const engineGroup = document.createElement('vscode-form-group') as HTMLElement;
+  engineGroup.setAttribute('variant', 'vertical');
 
-  const engineLabel = document.createElement('label');
-  engineLabel.htmlFor = 'engine-select';
+  const engineLabel = document.createElement('vscode-label') as HTMLElement;
+  engineLabel.setAttribute('for', 'engine-select');
   engineLabel.textContent = 'Engine';
 
-  const engineSelect = document.createElement('select');
+  const engineSelect = document.createElement('vscode-single-select') as HTMLElement & { value: string };
   engineSelect.id = 'engine-select';
 
-  const engineDefaultOption = document.createElement('option');
-  engineDefaultOption.value = '';
+  const engineDefaultOption = document.createElement('vscode-option') as HTMLElement;
+  engineDefaultOption.setAttribute('value', '');
   engineDefaultOption.textContent = 'Choose an engine...';
   engineSelect.appendChild(engineDefaultOption);
 
   [...engines].sort((a, b) => a.id.localeCompare(b.id)).forEach((e) => {
-    const option = document.createElement('option');
-    option.value = e.id;
+    const option = document.createElement('vscode-option') as HTMLElement;
+    option.setAttribute('value', e.id);
     option.textContent = e.id;
     if (e.id === selectedEngine) {
-      option.selected = true;
+      option.setAttribute('selected', '');
     }
     engineSelect.appendChild(option);
   });
@@ -332,48 +322,45 @@ function renderAccordion(): void {
   engineGroup.appendChild(engineSelect);
 
   // Provider name
-  const nameGroup = document.createElement('div');
-  nameGroup.className = 'form-group';
+  const nameGroup = document.createElement('vscode-form-group') as HTMLElement;
+  nameGroup.setAttribute('variant', 'vertical');
 
-  const nameLabel = document.createElement('label');
-  nameLabel.htmlFor = 'provider-name-input';
+  const nameLabel = document.createElement('vscode-label') as HTMLElement;
+  nameLabel.setAttribute('for', 'provider-name-input');
   nameLabel.textContent = 'Provider Name';
 
-  const nameInput = document.createElement('input');
-  nameInput.type = 'text';
+  const nameInput = document.createElement('vscode-textfield') as HTMLElement & { value: string };
   nameInput.id = 'provider-name-input';
-  nameInput.value = editing ? editing.id : providerName;
-  nameInput.placeholder = 'e.g. openai-prod';
+  nameInput.setAttribute('value', editing ? editing.id : providerName);
+  nameInput.setAttribute('placeholder', 'e.g. openai-prod');
   if (editing) {
-    nameInput.readOnly = true;
+    nameInput.setAttribute('readonly', '');
   }
   nameInput.addEventListener('input', () => {
     providerName = nameInput.value;
   });
 
-  const nameHint = document.createElement('div');
-  nameHint.className = 'hint';
-  nameHint.textContent = 'Letters, numbers, dots, underscores, and dashes only';
+  const nameHelper = document.createElement('vscode-form-helper') as HTMLElement;
+  nameHelper.innerHTML = '<p>Letters, numbers, dots, underscores, and dashes only</p>';
 
   nameGroup.appendChild(nameLabel);
   nameGroup.appendChild(nameInput);
-  nameGroup.appendChild(nameHint);
+  nameGroup.appendChild(nameHelper);
 
   // Base URL
-  const baseUrlGroup = document.createElement('div');
-  baseUrlGroup.className = 'form-group';
+  const baseUrlGroup = document.createElement('vscode-form-group') as HTMLElement;
+  baseUrlGroup.setAttribute('variant', 'vertical');
   baseUrlGroup.id = 'base-url-group';
   baseUrlGroup.style.display = engineInfo?.defaultBaseUrl ? 'block' : 'none';
 
-  const baseUrlLabel = document.createElement('label');
-  baseUrlLabel.htmlFor = 'base-url-input';
+  const baseUrlLabel = document.createElement('vscode-label') as HTMLElement;
+  baseUrlLabel.setAttribute('for', 'base-url-input');
   baseUrlLabel.textContent = 'Base URL';
 
-  const baseUrlInput = document.createElement('input');
-  baseUrlInput.type = 'text';
+  const baseUrlInput = document.createElement('vscode-textfield') as HTMLElement & { value: string };
   baseUrlInput.id = 'base-url-input';
-  baseUrlInput.value = editing?.baseUrl || engineInfo?.defaultBaseUrl || '';
-  baseUrlInput.placeholder = engineInfo?.defaultBaseUrl || '';
+  baseUrlInput.setAttribute('value', editing?.baseUrl || engineInfo?.defaultBaseUrl || '');
+  baseUrlInput.setAttribute('placeholder', engineInfo?.defaultBaseUrl || '');
 
   baseUrlGroup.appendChild(baseUrlLabel);
   baseUrlGroup.appendChild(baseUrlInput);
@@ -383,70 +370,69 @@ function renderAccordion(): void {
   apiKeyGroupDiv.id = 'api-key-group';
   apiKeyGroupDiv.style.display = requiresKey ? 'block' : 'none';
 
-  const toggleGroup = document.createElement('div');
-  toggleGroup.className = 'form-group';
+  const toggleGroup = document.createElement('vscode-form-group') as HTMLElement;
+  toggleGroup.setAttribute('variant', 'vertical');
 
-  const toggleLabel = document.createElement('label');
+  const toggleLabel = document.createElement('vscode-label') as HTMLElement;
   toggleLabel.textContent = 'API Key Storage';
 
-  const toggleButtons = document.createElement('div');
-  toggleButtons.className = 'toggle-group';
+  const radioGroup = document.createElement('vscode-radio-group') as HTMLElement & { value: string };
 
-  const toggleKeychain = document.createElement('button');
-  toggleKeychain.id = 'toggle-keychain';
-  toggleKeychain.textContent = 'Keychain';
-  toggleKeychain.className = apiKeyMethod === 'keychain' ? 'active' : '';
-  toggleKeychain.addEventListener('click', () => {
-    apiKeyMethod = 'keychain';
-    renderAccordion();
+  const keychainRadio = document.createElement('vscode-radio') as HTMLElement;
+  keychainRadio.setAttribute('label', 'Keychain');
+  keychainRadio.setAttribute('value', 'keychain');
+  if (apiKeyMethod === 'keychain') {keychainRadio.setAttribute('checked', '');}
+
+  const envRadio = document.createElement('vscode-radio') as HTMLElement;
+  envRadio.setAttribute('label', 'Environment Variable');
+  envRadio.setAttribute('value', 'env');
+  if (apiKeyMethod === 'env') {envRadio.setAttribute('checked', '');}
+
+  radioGroup.appendChild(keychainRadio);
+  radioGroup.appendChild(envRadio);
+
+  radioGroup.addEventListener('change', () => {
+    const checked = radioGroup.querySelector('vscode-radio[checked]') as HTMLElement | null;
+    const val = checked?.getAttribute('value');
+    if (val === 'keychain' || val === 'env') {
+      apiKeyMethod = val;
+      renderAccordion();
+    }
   });
-
-  const toggleEnv = document.createElement('button');
-  toggleEnv.id = 'toggle-env';
-  toggleEnv.textContent = 'Environment Variable';
-  toggleEnv.className = apiKeyMethod === 'env' ? 'active' : '';
-  toggleEnv.addEventListener('click', () => {
-    apiKeyMethod = 'env';
-    renderAccordion();
-  });
-
-  toggleButtons.appendChild(toggleKeychain);
-  toggleButtons.appendChild(toggleEnv);
 
   toggleGroup.appendChild(toggleLabel);
-  toggleGroup.appendChild(toggleButtons);
+  toggleGroup.appendChild(radioGroup);
 
-  const keychainField = document.createElement('div');
-  keychainField.className = 'form-group';
+  const keychainField = document.createElement('vscode-form-group') as HTMLElement;
+  keychainField.setAttribute('variant', 'vertical');
   keychainField.id = 'keychain-field';
   keychainField.style.display = apiKeyMethod === 'keychain' ? 'block' : 'none';
 
-  const apiKeyLabel = document.createElement('label');
-  apiKeyLabel.htmlFor = 'api-key-input';
+  const apiKeyLabel = document.createElement('vscode-label') as HTMLElement;
+  apiKeyLabel.setAttribute('for', 'api-key-input');
   apiKeyLabel.textContent = 'API Key';
 
-  const apiKeyInput = document.createElement('input');
-  apiKeyInput.type = 'password';
+  const apiKeyInput = document.createElement('vscode-textfield') as HTMLElement & { value: string };
   apiKeyInput.id = 'api-key-input';
-  apiKeyInput.placeholder = 'Stored securely in system keychain';
+  apiKeyInput.setAttribute('type', 'password');
+  apiKeyInput.setAttribute('placeholder', 'Stored securely in system keychain');
 
   keychainField.appendChild(apiKeyLabel);
   keychainField.appendChild(apiKeyInput);
 
-  const envField = document.createElement('div');
-  envField.className = 'form-group';
+  const envField = document.createElement('vscode-form-group') as HTMLElement;
+  envField.setAttribute('variant', 'vertical');
   envField.id = 'env-field';
   envField.style.display = apiKeyMethod === 'env' ? 'block' : 'none';
 
-  const envVarLabel = document.createElement('label');
-  envVarLabel.htmlFor = 'env-var-input';
+  const envVarLabel = document.createElement('vscode-label') as HTMLElement;
+  envVarLabel.setAttribute('for', 'env-var-input');
   envVarLabel.textContent = 'Variable Name';
 
-  const envVarInput = document.createElement('input');
-  envVarInput.type = 'text';
+  const envVarInput = document.createElement('vscode-textfield') as HTMLElement & { value: string };
   envVarInput.id = 'env-var-input';
-  envVarInput.value = engineInfo?.defaultEnvVar || '';
-  envVarInput.placeholder = 'e.g. OPENAI_API_KEY';
+  envVarInput.setAttribute('value', engineInfo?.defaultEnvVar || '');
+  envVarInput.setAttribute('placeholder', 'e.g. OPENAI_API_KEY');
 
   envField.appendChild(envVarLabel);
   envField.appendChild(envVarInput);
@@ -455,73 +441,43 @@ function renderAccordion(): void {
   apiKeyGroupDiv.appendChild(keychainField);
   apiKeyGroupDiv.appendChild(envField);
 
-  body1.appendChild(engineGroup);
-  body1.appendChild(nameGroup);
-  body1.appendChild(baseUrlGroup);
-  body1.appendChild(apiKeyGroupDiv);
+  section1.appendChild(engineGroup);
+  section1.appendChild(nameGroup);
+  section1.appendChild(baseUrlGroup);
+  section1.appendChild(apiKeyGroupDiv);
 
-  section1.appendChild(header1);
-  section1.appendChild(body1);
+  // ── Section 2: Select Models ──
+  const section2 = document.createElement('vscode-collapsible') as HTMLElement;
+  section2.setAttribute('heading', '2. Select Models');
+  if (section2Open) {section2.setAttribute('open', '');}
+  section2.addEventListener('vsc-collapsible-toggle', ((e: CustomEvent<{ open: boolean }>) => {
+    section2Open = e.detail.open;
+  }) as EventListener);
 
-  // Section 2
-  const section2 = document.createElement('div');
-  section2.className = `accordion-section ${section2Open ? 'open' : ''}`;
-  section2.id = 'accordion-section-2';
-
-  const header2 = document.createElement('div');
-  header2.className = 'accordion-header';
-  header2.id = 'accordion-header-2';
-  header2.addEventListener('click', () => {
-    section2Open = !section2Open;
-    renderAccordion();
-  });
-
-  const header2Left = document.createElement('div');
-  header2Left.className = 'accordion-header-left';
-
-  const chevron2 = document.createElement('span');
-  chevron2.className = 'accordion-chevron';
-
-  const title2 = document.createElement('span');
-  title2.className = 'accordion-title';
-  title2.textContent = '2. Select Models';
-
-  header2Left.appendChild(chevron2);
-  header2Left.appendChild(title2);
-
-  const status2 = document.createElement('span');
-  status2.className = `accordion-status ${section2Complete ? 'complete' : ''}`;
   if (section2Complete) {
+    const status2 = document.createElement('vscode-badge') as HTMLElement;
+    status2.slot = 'decorations';
     status2.textContent = `${selectedModels.size} selected`;
+    section2.appendChild(status2);
   }
-
-  header2.appendChild(header2Left);
-  header2.appendChild(status2);
-
-  const body2 = document.createElement('div');
-  body2.className = 'accordion-body';
-  body2.id = 'accordion-body-2';
 
   const modelSectionContent = document.createElement('div');
   modelSectionContent.id = 'model-section-content';
 
-  body2.appendChild(modelSectionContent);
-  section2.appendChild(header2);
-  section2.appendChild(body2);
+  section2.appendChild(modelSectionContent);
 
   // Form actions
   const formActions = document.createElement('div');
   formActions.className = 'form-actions';
 
-  const saveBtn = document.createElement('button');
+  const saveBtn = document.createElement('vscode-button') as HTMLElement;
   saveBtn.id = 'save-provider-btn';
-  saveBtn.className = 'primary';
   saveBtn.textContent = editing ? 'Update Provider' : 'Save Provider';
   saveBtn.addEventListener('click', handleSave);
 
-  const cancelBtn = document.createElement('button');
+  const cancelBtn = document.createElement('vscode-button') as HTMLElement;
   cancelBtn.id = 'cancel-btn';
-  cancelBtn.className = 'secondary';
+  cancelBtn.setAttribute('secondary', '');
   cancelBtn.textContent = 'Cancel';
   cancelBtn.addEventListener('click', () => {
     editingProviderId = null;
@@ -557,7 +513,6 @@ function renderModelSection(): void {
   const container = document.getElementById('model-section-content');
   if (!container) {return;}
 
-  // For early-exit states (loading/error/empty), clear everything
   if (isDiscovering || discoverError || discoveredModels.length === 0) {
     container.innerHTML = '';
 
@@ -565,8 +520,7 @@ function renderModelSection(): void {
       const loading = document.createElement('div');
       loading.className = 'loading-state';
 
-      const spinner = document.createElement('span');
-      spinner.className = 'spinner';
+      const spinner = document.createElement('vscode-progress-ring') as HTMLElement;
 
       const loadingText = document.createElement('span');
       loadingText.textContent = 'Discovering models...';
@@ -581,17 +535,17 @@ function renderModelSection(): void {
       const errorText = document.createElement('span');
       errorText.textContent = discoverError;
 
-      const retryLink = document.createElement('button');
-      retryLink.className = 'link';
-      retryLink.textContent = 'Retry';
-      retryLink.style.marginLeft = '8px';
-      retryLink.addEventListener('click', () => {
+      const retryBtn = document.createElement('vscode-button') as HTMLElement;
+      retryBtn.setAttribute('secondary', '');
+      retryBtn.textContent = 'Retry';
+      retryBtn.style.marginLeft = '8px';
+      retryBtn.addEventListener('click', () => {
         discoverError = null;
         triggerModelDiscovery();
       });
 
       errorDiv.appendChild(errorText);
-      errorDiv.appendChild(retryLink);
+      errorDiv.appendChild(retryBtn);
       container.appendChild(errorDiv);
     } else {
       const empty = document.createElement('div');
@@ -602,39 +556,32 @@ function renderModelSection(): void {
     return;
   }
 
-  // Available: all discovered models matching search (always shown, even if already enabled)
   const availableModels = discoveredModels.filter((m) => {
     if (modelFilter === '') {return true;}
     const display = (m.name || m.id).toLowerCase();
     return display.includes(modelFilter.toLowerCase());
   });
 
-  // Enabled: entries from the selectedModels map (name → model_id)
   const enabledEntries = Array.from(selectedModels.entries());
 
-  // Create search input only once; on subsequent renders it stays in the DOM untouched
   if (!document.getElementById('model-search-input')) {
-    const searchInput = document.createElement('input');
-    searchInput.type = 'text';
-    searchInput.className = 'model-search';
+    const searchInput = document.createElement('vscode-textfield') as HTMLElement & { value: string };
     searchInput.id = 'model-search-input';
-    searchInput.placeholder = 'Search models...';
-    searchInput.value = modelFilter;
-    searchInput.addEventListener('input', (e) => {
-      modelFilter = (e.target as HTMLInputElement).value;
+    searchInput.setAttribute('placeholder', 'Search models...');
+    searchInput.setAttribute('value', modelFilter);
+    searchInput.addEventListener('input', () => {
+      modelFilter = searchInput.value;
       leftSelected.clear();
       renderModelSection();
     });
     container.appendChild(searchInput);
   }
 
-  // Only rebuild the dual-list; remove the old one if present
   const oldDualList = container.querySelector('.dual-list');
   if (oldDualList) {
     oldDualList.remove();
   }
 
-  // Dual-list grid container
   const dualList = document.createElement('div');
   dualList.className = 'dual-list';
 
@@ -671,10 +618,10 @@ function renderModelSection(): void {
   const center = document.createElement('div');
   center.className = 'dual-list-center';
 
-  const addBtn = document.createElement('button');
-  addBtn.className = 'secondary';
+  const addBtn = document.createElement('vscode-button') as HTMLElement;
+  addBtn.setAttribute('secondary', '');
   addBtn.textContent = 'Add →';
-  addBtn.disabled = leftSelected.size === 0;
+  if (leftSelected.size === 0) {addBtn.setAttribute('disabled', '');}
   addBtn.addEventListener('click', () => {
     for (const id of leftSelected) {
       let name = id;
@@ -690,10 +637,10 @@ function renderModelSection(): void {
     renderAccordion();
   });
 
-  const removeBtn = document.createElement('button');
-  removeBtn.className = 'secondary';
+  const removeBtn = document.createElement('vscode-button') as HTMLElement;
+  removeBtn.setAttribute('secondary', '');
   removeBtn.textContent = '← Remove';
-  removeBtn.disabled = rightSelected.size === 0;
+  if (rightSelected.size === 0) {removeBtn.setAttribute('disabled', '');}
   removeBtn.addEventListener('click', () => {
     for (const name of rightSelected) {
       selectedModels.delete(name);
@@ -759,8 +706,8 @@ function applyPendingModels(): void {
 // ─── Trigger Model Discovery ─────────────────────────────────────────
 
 function triggerModelDiscovery(): void {
-  const engineSelect = document.getElementById('engine-select') as HTMLSelectElement;
-  const providerNameInput = document.getElementById('provider-name-input') as HTMLInputElement;
+  const engineSelect = document.getElementById('engine-select') as HTMLElement & { value: string } | null;
+  const providerNameInput = document.getElementById('provider-name-input') as HTMLElement & { value: string } | null;
 
   const engineId = engineSelect?.value || '';
   const providerId = providerNameInput?.value.trim() || editingProviderId || '';
@@ -781,11 +728,11 @@ function triggerModelDiscovery(): void {
 // ─── Handle Save ─────────────────────────────────────────────────────
 
 function handleSave(): void {
-  const providerNameInput = document.getElementById('provider-name-input') as HTMLInputElement;
-  const engineSelect = document.getElementById('engine-select') as HTMLSelectElement;
-  const baseUrlInput = document.getElementById('base-url-input') as HTMLInputElement;
-  const apiKeyInput = document.getElementById('api-key-input') as HTMLInputElement;
-  const envVarInput = document.getElementById('env-var-input') as HTMLInputElement;
+  const providerNameInput = document.getElementById('provider-name-input') as HTMLElement & { value: string } | null;
+  const engineSelect = document.getElementById('engine-select') as HTMLElement & { value: string } | null;
+  const baseUrlInput = document.getElementById('base-url-input') as HTMLElement & { value: string } | null;
+  const apiKeyInput = document.getElementById('api-key-input') as HTMLElement & { value: string } | null;
+  const envVarInput = document.getElementById('env-var-input') as HTMLElement & { value: string } | null;
 
   const providerId = providerNameInput?.value.trim() || '';
   const engine = engineSelect?.value || '';

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -477,6 +477,9 @@ function renderAccordion(): void {
   header2.className = 'accordion-header';
   header2.addEventListener('click', () => {
     section2Open = !section2Open;
+    if (section2Open && discoveredModels.length === 0 && !isDiscovering && selectedEngineId) {
+      triggerModelDiscovery();
+    }
     renderAccordion();
   });
 
@@ -754,6 +757,8 @@ function applyPendingModels(): void {
 function triggerModelDiscovery(): void {
   const engineSelect = document.getElementById('engine-select') as HTMLElement & { value: string } | null;
   const providerNameInput = document.getElementById('provider-name-input') as HTMLElement & { value: string } | null;
+  const apiKeyInput = document.getElementById('api-key-input') as HTMLElement & { value: string } | null;
+  const baseUrlInput = document.getElementById('base-url-input') as HTMLElement & { value: string } | null;
 
   const engineId = engineSelect?.value || '';
   const providerId = providerNameInput?.value.trim() || editingProviderId || '';
@@ -764,11 +769,19 @@ function triggerModelDiscovery(): void {
   discoverError = null;
   renderModelSection();
 
-  vsCodeApi.postMessage({
+  const msg: Record<string, unknown> = {
     type: 'discoverModels',
     engineId,
     providerId: providerId || undefined,
-  });
+  };
+
+  const apiKey = apiKeyInput?.value.trim();
+  if (apiKey) {msg.apiKey = apiKey;}
+
+  const baseUrl = baseUrlInput?.value.trim();
+  if (baseUrl) {msg.baseUrl = baseUrl;}
+
+  vsCodeApi.postMessage(msg);
 }
 
 // ─── Handle Save ─────────────────────────────────────────────────────

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -38,7 +38,9 @@ let providers: ProviderInfo[] = [];
 let engines: EngineInfo[] = [];
 let discoveredModels: ModelInfo[] = [];
 
-const selectedModels: Set<string> = new Set();
+const selectedModels: Map<string, string> = new Map();
+const leftSelected: Set<string> = new Set();
+const rightSelected: Set<string> = new Set();
 let editingProviderId: string | null = null;
 
 let section1Open = true;
@@ -50,6 +52,7 @@ let apiKeyMethod: 'keychain' | 'env' = 'keychain';
 let isDiscovering = false;
 let discoverError: string | null = null;
 let modelFilter = '';
+let pendingEditModels: Record<string, { model_id?: string }> | null = null;
 
 // ─── Notification ────────────────────────────────────────────────────
 
@@ -103,6 +106,8 @@ function buildInitialDOM(): void {
     section1Open = true;
     section2Open = false;
     selectedModels.clear();
+    leftSelected.clear();
+    rightSelected.clear();
     discoveredModels = [];
     discoverError = null;
     isDiscovering = false;
@@ -204,10 +209,15 @@ function startEdit(p: ProviderInfo): void {
   section1Open = true;
   section2Open = false;
   selectedModels.clear();
+  leftSelected.clear();
+  rightSelected.clear();
   discoveredModels = [];
   discoverError = null;
   isDiscovering = false;
   modelFilter = '';
+  pendingEditModels = null;
+
+  vsCodeApi.postMessage({ type: 'getConfig' });
 
   renderAccordion();
 
@@ -294,7 +304,7 @@ function renderAccordion(): void {
   engineDefaultOption.textContent = 'Choose an engine...';
   engineSelect.appendChild(engineDefaultOption);
 
-  engines.forEach((e) => {
+  [...engines].sort((a, b) => a.id.localeCompare(b.id)).forEach((e) => {
     const option = document.createElement('option');
     option.value = e.id;
     option.textContent = e.id;
@@ -308,6 +318,8 @@ function renderAccordion(): void {
     selectedEngineId = engineSelect.value;
     discoveredModels = [];
     selectedModels.clear();
+    leftSelected.clear();
+    rightSelected.clear();
     discoverError = null;
     isDiscovering = false;
     renderAccordion();
@@ -518,6 +530,8 @@ function renderAccordion(): void {
     section1Open = false;
     section2Open = false;
     selectedModels.clear();
+    leftSelected.clear();
+    rightSelected.clear();
     discoveredModels = [];
     discoverError = null;
     isDiscovering = false;
@@ -543,137 +557,203 @@ function renderModelSection(): void {
   const container = document.getElementById('model-section-content');
   if (!container) {return;}
 
-  container.innerHTML = '';
+  // For early-exit states (loading/error/empty), clear everything
+  if (isDiscovering || discoverError || discoveredModels.length === 0) {
+    container.innerHTML = '';
 
-  if (isDiscovering) {
-    const loading = document.createElement('div');
-    loading.className = 'loading-state';
+    if (isDiscovering) {
+      const loading = document.createElement('div');
+      loading.className = 'loading-state';
 
-    const spinner = document.createElement('span');
-    spinner.className = 'spinner';
+      const spinner = document.createElement('span');
+      spinner.className = 'spinner';
 
-    const loadingText = document.createElement('span');
-    loadingText.textContent = 'Discovering models...';
+      const loadingText = document.createElement('span');
+      loadingText.textContent = 'Discovering models...';
 
-    loading.appendChild(spinner);
-    loading.appendChild(loadingText);
-    container.appendChild(loading);
+      loading.appendChild(spinner);
+      loading.appendChild(loadingText);
+      container.appendChild(loading);
+    } else if (discoverError) {
+      const errorDiv = document.createElement('div');
+      errorDiv.className = 'inline-error';
+
+      const errorText = document.createElement('span');
+      errorText.textContent = discoverError;
+
+      const retryLink = document.createElement('button');
+      retryLink.className = 'link';
+      retryLink.textContent = 'Retry';
+      retryLink.style.marginLeft = '8px';
+      retryLink.addEventListener('click', () => {
+        discoverError = null;
+        triggerModelDiscovery();
+      });
+
+      errorDiv.appendChild(errorText);
+      errorDiv.appendChild(retryLink);
+      container.appendChild(errorDiv);
+    } else {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'Select an engine and provider to discover models';
+      container.appendChild(empty);
+    }
     return;
   }
 
-  if (discoverError) {
-    const errorDiv = document.createElement('div');
-    errorDiv.className = 'inline-error';
-
-    const errorText = document.createElement('span');
-    errorText.textContent = discoverError;
-
-    const retryLink = document.createElement('button');
-    retryLink.className = 'link';
-    retryLink.textContent = 'Retry';
-    retryLink.style.marginLeft = '8px';
-    retryLink.addEventListener('click', () => {
-      discoverError = null;
-      triggerModelDiscovery();
-    });
-
-    errorDiv.appendChild(errorText);
-    errorDiv.appendChild(retryLink);
-    container.appendChild(errorDiv);
-    return;
-  }
-
-  if (discoveredModels.length === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'empty-state';
-    empty.textContent = 'Select an engine and provider to discover models';
-    container.appendChild(empty);
-    return;
-  }
-
-  // Filter models
-  const filteredModels = discoveredModels.filter((m) => {
+  // Available: all discovered models matching search (always shown, even if already enabled)
+  const availableModels = discoveredModels.filter((m) => {
     if (modelFilter === '') {return true;}
     const display = (m.name || m.id).toLowerCase();
     return display.includes(modelFilter.toLowerCase());
   });
 
-  const searchInput = document.createElement('input');
-  searchInput.type = 'text';
-  searchInput.className = 'model-search';
-  searchInput.id = 'model-search-input';
-  searchInput.placeholder = 'Search models...';
-  searchInput.value = modelFilter;
-  searchInput.addEventListener('input', (e) => {
-    modelFilter = (e.target as HTMLInputElement).value;
-    renderModelSection();
-  });
+  // Enabled: entries from the selectedModels map (name → model_id)
+  const enabledEntries = Array.from(selectedModels.entries());
 
-  const modelActions = document.createElement('div');
-  modelActions.className = 'model-actions';
+  // Create search input only once; on subsequent renders it stays in the DOM untouched
+  if (!document.getElementById('model-search-input')) {
+    const searchInput = document.createElement('input');
+    searchInput.type = 'text';
+    searchInput.className = 'model-search';
+    searchInput.id = 'model-search-input';
+    searchInput.placeholder = 'Search models...';
+    searchInput.value = modelFilter;
+    searchInput.addEventListener('input', (e) => {
+      modelFilter = (e.target as HTMLInputElement).value;
+      leftSelected.clear();
+      renderModelSection();
+    });
+    container.appendChild(searchInput);
+  }
 
-  const selectAllLink = document.createElement('button');
-  selectAllLink.className = 'link';
-  selectAllLink.id = 'select-all-link';
-  selectAllLink.textContent = 'Select all';
-  selectAllLink.addEventListener('click', () => {
-    filteredModels.forEach((m) => selectedModels.add(m.id));
-    renderModelSection();
-    renderAccordion();
-  });
+  // Only rebuild the dual-list; remove the old one if present
+  const oldDualList = container.querySelector('.dual-list');
+  if (oldDualList) {
+    oldDualList.remove();
+  }
 
-  const deselectAllLink = document.createElement('button');
-  deselectAllLink.className = 'link';
-  deselectAllLink.id = 'deselect-all-link';
-  deselectAllLink.textContent = 'Deselect all';
-  deselectAllLink.addEventListener('click', () => {
-    selectedModels.clear();
-    renderModelSection();
-    renderAccordion();
-  });
+  // Dual-list grid container
+  const dualList = document.createElement('div');
+  dualList.className = 'dual-list';
 
-  modelActions.appendChild(selectAllLink);
-  modelActions.appendChild(deselectAllLink);
+  // --- Left panel: Available ---
+  const leftPanel = document.createElement('div');
+  leftPanel.className = 'dual-list-panel';
 
-  const modelCounter = document.createElement('div');
-  modelCounter.className = 'model-counter';
-  modelCounter.textContent = `${selectedModels.size} of ${filteredModels.length} selected`;
+  const leftHeader = document.createElement('div');
+  leftHeader.className = 'dual-list-panel-header';
+  leftHeader.textContent = `Available (${availableModels.length})`;
 
-  const modelList = document.createElement('div');
-  modelList.className = 'model-list';
-  modelList.id = 'model-list';
+  const leftItems = document.createElement('div');
+  leftItems.className = 'dual-list-items';
 
-  filteredModels.forEach((m) => {
+  availableModels.forEach((m) => {
     const item = document.createElement('div');
-    item.className = 'model-item';
-
-    const checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
-    checkbox.id = `model-${m.id}`;
-    checkbox.checked = selectedModels.has(m.id);
-    checkbox.addEventListener('change', (e) => {
-      if ((e.target as HTMLInputElement).checked) {
-        selectedModels.add(m.id);
+    item.className = `dual-list-item${leftSelected.has(m.id) ? ' selected' : ''}`;
+    item.textContent = m.name || m.id;
+    item.addEventListener('click', () => {
+      if (leftSelected.has(m.id)) {
+        leftSelected.delete(m.id);
       } else {
-        selectedModels.delete(m.id);
+        leftSelected.add(m.id);
       }
       renderModelSection();
-      renderAccordion();
     });
-
-    const label = document.createElement('label');
-    label.htmlFor = `model-${m.id}`;
-    label.textContent = m.name || m.id;
-
-    item.appendChild(checkbox);
-    item.appendChild(label);
-    modelList.appendChild(item);
+    leftItems.appendChild(item);
   });
 
-  container.appendChild(searchInput);
-  container.appendChild(modelActions);
-  container.appendChild(modelCounter);
-  container.appendChild(modelList);
+  leftPanel.appendChild(leftHeader);
+  leftPanel.appendChild(leftItems);
+
+  // --- Center: Action buttons ---
+  const center = document.createElement('div');
+  center.className = 'dual-list-center';
+
+  const addBtn = document.createElement('button');
+  addBtn.className = 'secondary';
+  addBtn.textContent = 'Add →';
+  addBtn.disabled = leftSelected.size === 0;
+  addBtn.addEventListener('click', () => {
+    for (const id of leftSelected) {
+      let name = id;
+      if (selectedModels.has(name)) {
+        let i = 1;
+        while (selectedModels.has(`${id}-${i}`)) {i++;}
+        name = `${id}-${i}`;
+      }
+      selectedModels.set(name, id);
+    }
+    leftSelected.clear();
+    renderModelSection();
+    renderAccordion();
+  });
+
+  const removeBtn = document.createElement('button');
+  removeBtn.className = 'secondary';
+  removeBtn.textContent = '← Remove';
+  removeBtn.disabled = rightSelected.size === 0;
+  removeBtn.addEventListener('click', () => {
+    for (const name of rightSelected) {
+      selectedModels.delete(name);
+    }
+    rightSelected.clear();
+    renderModelSection();
+    renderAccordion();
+  });
+
+  center.appendChild(addBtn);
+  center.appendChild(removeBtn);
+
+  // --- Right panel: Enabled ---
+  const rightPanel = document.createElement('div');
+  rightPanel.className = 'dual-list-panel';
+
+  const rightHeader = document.createElement('div');
+  rightHeader.className = 'dual-list-panel-header';
+  rightHeader.textContent = `Enabled (${enabledEntries.length})`;
+
+  const rightItems = document.createElement('div');
+  rightItems.className = 'dual-list-items';
+
+  enabledEntries.forEach(([name]) => {
+    const item = document.createElement('div');
+    item.className = `dual-list-item${rightSelected.has(name) ? ' selected' : ''}`;
+    item.textContent = name;
+    item.addEventListener('click', () => {
+      if (rightSelected.has(name)) {
+        rightSelected.delete(name);
+      } else {
+        rightSelected.add(name);
+      }
+      renderModelSection();
+    });
+    rightItems.appendChild(item);
+  });
+
+  rightPanel.appendChild(rightHeader);
+  rightPanel.appendChild(rightItems);
+
+  dualList.appendChild(leftPanel);
+  dualList.appendChild(center);
+  dualList.appendChild(rightPanel);
+
+  container.appendChild(dualList);
+}
+
+// ─── Apply Pending Models (edit flow) ────────────────────────────────
+
+function applyPendingModels(): void {
+  if (!pendingEditModels || discoveredModels.length === 0) {return;}
+
+  for (const [name, cfg] of Object.entries(pendingEditModels)) {
+    const modelId = cfg.model_id || name;
+    selectedModels.set(name, modelId);
+  }
+  pendingEditModels = null;
+  renderModelSection();
+  renderAccordion();
 }
 
 // ─── Trigger Model Discovery ─────────────────────────────────────────
@@ -729,7 +809,9 @@ function handleSave(): void {
     type: 'configureProvider',
     providerId,
     engine,
-    models: Array.from(selectedModels),
+    models: Object.fromEntries(
+      Array.from(selectedModels.entries()).map(([name, modelId]) => [name, { model_id: modelId }]),
+    ),
   };
 
   const baseUrl = baseUrlInput?.value.trim();
@@ -779,10 +861,23 @@ window.addEventListener('message', (event) => {
       }
       break;
 
+    case 'config':
+      if (editingProviderId && msg.config) {
+        const cfgProviders = (msg.config as Record<string, unknown>).providers as Record<string, Record<string, unknown>> | undefined;
+        const providerCfg = cfgProviders?.[editingProviderId];
+        const models = providerCfg?.models as Record<string, { model_id?: string }> | undefined;
+        if (models && Object.keys(models).length > 0) {
+          pendingEditModels = models;
+          applyPendingModels();
+        }
+      }
+      break;
+
     case 'discoveredModels':
       isDiscovering = false;
       discoveredModels = msg.models || [];
       discoverError = null;
+      applyPendingModels();
       renderModelSection();
       break;
 
@@ -795,6 +890,8 @@ window.addEventListener('message', (event) => {
         section1Open = false;
         section2Open = false;
         selectedModels.clear();
+        leftSelected.clear();
+        rightSelected.clear();
         discoveredModels = [];
         discoverError = null;
         isDiscovering = false;

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -45,6 +45,7 @@ let section1Open = true;
 let section2Open = false;
 let selectedEngineId = '';
 
+let providerName = '';
 let apiKeyMethod: 'keychain' | 'env' = 'keychain';
 let isDiscovering = false;
 let discoverError: string | null = null;
@@ -98,6 +99,7 @@ function buildInitialDOM(): void {
   addBtn.addEventListener('click', () => {
     editingProviderId = null;
     selectedEngineId = '';
+    providerName = '';
     section1Open = true;
     section2Open = false;
     selectedModels.clear();
@@ -328,11 +330,14 @@ function renderAccordion(): void {
   const nameInput = document.createElement('input');
   nameInput.type = 'text';
   nameInput.id = 'provider-name-input';
-  nameInput.value = editing ? editing.id : '';
+  nameInput.value = editing ? editing.id : providerName;
   nameInput.placeholder = 'e.g. openai-prod';
   if (editing) {
     nameInput.readOnly = true;
   }
+  nameInput.addEventListener('input', () => {
+    providerName = nameInput.value;
+  });
 
   const nameHint = document.createElement('div');
   nameHint.className = 'hint';
@@ -509,6 +514,7 @@ function renderAccordion(): void {
   cancelBtn.addEventListener('click', () => {
     editingProviderId = null;
     selectedEngineId = '';
+    providerName = '';
     section1Open = false;
     section2Open = false;
     selectedModels.clear();
@@ -785,6 +791,7 @@ window.addEventListener('message', (event) => {
         showNotification(`Provider ${msg.providerId} ${editingProviderId ? 'updated' : 'added'} successfully`);
         editingProviderId = null;
         selectedEngineId = '';
+        providerName = '';
         section1Open = false;
         section2Open = false;
         selectedModels.clear();

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -2,7 +2,6 @@ import '@vscode-elements/elements/dist/vscode-button/index.js';
 import '@vscode-elements/elements/dist/vscode-textfield/index.js';
 import '@vscode-elements/elements/dist/vscode-single-select/index.js';
 import '@vscode-elements/elements/dist/vscode-option/index.js';
-import '@vscode-elements/elements/dist/vscode-collapsible/index.js';
 import '@vscode-elements/elements/dist/vscode-form-group/index.js';
 import '@vscode-elements/elements/dist/vscode-label/index.js';
 import '@vscode-elements/elements/dist/vscode-form-helper/index.js';
@@ -264,19 +263,40 @@ function renderAccordion(): void {
   const wrapper = document.createElement('div');
 
   // ── Section 1: Provider Setup ──
-  const section1 = document.createElement('vscode-collapsible') as HTMLElement;
-  section1.setAttribute('heading', '1. Provider Setup');
-  if (section1Open) {section1.setAttribute('open', '');}
-  section1.addEventListener('vsc-collapsible-toggle', ((e: CustomEvent<{ open: boolean }>) => {
-    section1Open = e.detail.open;
-  }) as EventListener);
+  const section1 = document.createElement('div');
+  section1.className = `accordion-section ${section1Open ? 'open' : ''}`;
 
+  const header1 = document.createElement('div');
+  header1.className = 'accordion-header';
+  header1.addEventListener('click', () => {
+    section1Open = !section1Open;
+    renderAccordion();
+  });
+
+  const header1Left = document.createElement('div');
+  header1Left.className = 'accordion-header-left';
+
+  const chevron1 = document.createElement('span');
+  chevron1.className = 'accordion-chevron';
+
+  const title1 = document.createElement('span');
+  title1.className = 'accordion-title';
+  title1.textContent = '1. Provider Setup';
+
+  header1Left.appendChild(chevron1);
+  header1Left.appendChild(title1);
+
+  const status1 = document.createElement('span');
+  status1.className = `accordion-status ${section1Complete ? 'complete' : ''}`;
   if (section1Complete) {
-    const status1 = document.createElement('vscode-badge') as HTMLElement;
-    status1.slot = 'decorations';
-    status1.textContent = '✓ Complete';
-    section1.appendChild(status1);
+    status1.textContent = 'Complete';
   }
+
+  header1.appendChild(header1Left);
+  header1.appendChild(status1);
+
+  const body1 = document.createElement('div');
+  body1.className = 'accordion-body';
 
   // Engine dropdown
   const engineGroup = document.createElement('vscode-form-group') as HTMLElement;
@@ -441,30 +461,56 @@ function renderAccordion(): void {
   apiKeyGroupDiv.appendChild(keychainField);
   apiKeyGroupDiv.appendChild(envField);
 
-  section1.appendChild(engineGroup);
-  section1.appendChild(nameGroup);
-  section1.appendChild(baseUrlGroup);
-  section1.appendChild(apiKeyGroupDiv);
+  body1.appendChild(engineGroup);
+  body1.appendChild(nameGroup);
+  body1.appendChild(baseUrlGroup);
+  body1.appendChild(apiKeyGroupDiv);
+
+  section1.appendChild(header1);
+  section1.appendChild(body1);
 
   // ── Section 2: Select Models ──
-  const section2 = document.createElement('vscode-collapsible') as HTMLElement;
-  section2.setAttribute('heading', '2. Select Models');
-  if (section2Open) {section2.setAttribute('open', '');}
-  section2.addEventListener('vsc-collapsible-toggle', ((e: CustomEvent<{ open: boolean }>) => {
-    section2Open = e.detail.open;
-  }) as EventListener);
+  const section2 = document.createElement('div');
+  section2.className = `accordion-section ${section2Open ? 'open' : ''}`;
 
+  const header2 = document.createElement('div');
+  header2.className = 'accordion-header';
+  header2.addEventListener('click', () => {
+    section2Open = !section2Open;
+    renderAccordion();
+  });
+
+  const header2Left = document.createElement('div');
+  header2Left.className = 'accordion-header-left';
+
+  const chevron2 = document.createElement('span');
+  chevron2.className = 'accordion-chevron';
+
+  const title2 = document.createElement('span');
+  title2.className = 'accordion-title';
+  title2.textContent = '2. Select Models';
+
+  header2Left.appendChild(chevron2);
+  header2Left.appendChild(title2);
+
+  const status2 = document.createElement('span');
+  status2.className = `accordion-status ${section2Complete ? 'complete' : ''}`;
   if (section2Complete) {
-    const status2 = document.createElement('vscode-badge') as HTMLElement;
-    status2.slot = 'decorations';
     status2.textContent = `${selectedModels.size} selected`;
-    section2.appendChild(status2);
   }
+
+  header2.appendChild(header2Left);
+  header2.appendChild(status2);
+
+  const body2 = document.createElement('div');
+  body2.className = 'accordion-body';
 
   const modelSectionContent = document.createElement('div');
   modelSectionContent.id = 'model-section-content';
 
-  section2.appendChild(modelSectionContent);
+  body2.appendChild(modelSectionContent);
+  section2.appendChild(header2);
+  section2.appendChild(body2);
 
   // Form actions
   const formActions = document.createElement('div');

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -1,0 +1,823 @@
+declare function acquireVsCodeApi(): {
+  postMessage(msg: unknown): void;
+  getState(): unknown;
+  setState(state: unknown): void;
+};
+
+// ─── Interfaces (local redeclaration for browser bundle) ────────────
+
+interface ProviderInfo {
+  id: string;
+  engine: string;
+  configured: boolean;
+  healthy: boolean;
+  requiresKey: boolean;
+  baseUrl?: string;
+  modelCount: number;
+}
+
+interface EngineInfo {
+  id: string;
+  requiresKey: boolean;
+  defaultBaseUrl?: string;
+  defaultEnvVar?: string;
+}
+
+interface ModelInfo {
+  id: string;
+  provider: string;
+  name: string;
+  engine: string;
+}
+
+// ─── State ───────────────────────────────────────────────────────────
+
+const vsCodeApi = acquireVsCodeApi();
+
+let providers: ProviderInfo[] = [];
+let engines: EngineInfo[] = [];
+let discoveredModels: ModelInfo[] = [];
+
+const selectedModels: Set<string> = new Set();
+let editingProviderId: string | null = null;
+
+let section1Open = true;
+let section2Open = false;
+let selectedEngineId = '';
+
+let apiKeyMethod: 'keychain' | 'env' = 'keychain';
+let isDiscovering = false;
+let discoverError: string | null = null;
+let modelFilter = '';
+
+// ─── Notification ────────────────────────────────────────────────────
+
+function showNotification(message: string, isError = false): void {
+  let toast = document.getElementById('toast-notification');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'toast-notification';
+    toast.className = 'toast';
+    document.body.appendChild(toast);
+  }
+  toast.textContent = message;
+  toast.className = `toast show ${isError ? 'error' : 'success'}`;
+  setTimeout(() => {
+    if (toast) {
+      toast.className = 'toast';
+    }
+  }, 4000);
+}
+
+// ─── Initial DOM ─────────────────────────────────────────────────────
+
+function buildInitialDOM(): void {
+  const root = document.getElementById('root');
+  if (!root) {return;}
+
+  const title = document.createElement('h1');
+  title.textContent = 'Provider Configuration';
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'subtitle';
+  subtitle.textContent = 'Manage LLM providers and model selections';
+
+  const sectionTitle = document.createElement('h2');
+  sectionTitle.textContent = 'Providers';
+
+  const providerList = document.createElement('div');
+  providerList.id = 'provider-list';
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.style.margin = '12px 0';
+
+  const addBtn = document.createElement('button');
+  addBtn.id = 'add-provider-btn';
+  addBtn.className = 'primary';
+  addBtn.textContent = '+ Add Provider';
+  addBtn.addEventListener('click', () => {
+    editingProviderId = null;
+    selectedEngineId = '';
+    section1Open = true;
+    section2Open = false;
+    selectedModels.clear();
+    discoveredModels = [];
+    discoverError = null;
+    isDiscovering = false;
+    modelFilter = '';
+    renderAccordion();
+  });
+
+  buttonContainer.appendChild(addBtn);
+
+  const accordionContainer = document.createElement('div');
+  accordionContainer.id = 'accordion-container';
+
+  root.innerHTML = '';
+  root.appendChild(title);
+  root.appendChild(subtitle);
+  root.appendChild(sectionTitle);
+  root.appendChild(providerList);
+  root.appendChild(buttonContainer);
+  root.appendChild(accordionContainer);
+
+  renderProviders();
+  renderAccordion();
+}
+
+// ─── Render Providers ────────────────────────────────────────────────
+
+function renderProviders(): void {
+  const container = document.getElementById('provider-list');
+  if (!container) {return;}
+
+  container.innerHTML = '';
+
+  if (providers.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'No providers configured yet';
+    container.appendChild(empty);
+    return;
+  }
+
+  providers.forEach((p) => {
+    const card = document.createElement('div');
+    card.className = 'provider-card';
+
+    const statusClass = p.healthy ? 'ready' : p.configured ? 'error' : 'unconfigured';
+
+    const info = document.createElement('div');
+    info.className = 'provider-info';
+
+    const statusDot = document.createElement('span');
+    statusDot.className = `provider-status ${statusClass}`;
+
+    const name = document.createElement('span');
+    name.className = 'provider-name';
+    name.textContent = p.id;
+
+    const engine = document.createElement('span');
+    engine.className = 'provider-engine';
+    engine.textContent = p.engine;
+
+    const modelCount = document.createElement('span');
+    modelCount.className = 'provider-model-count';
+    modelCount.textContent = `${p.modelCount} ${p.modelCount === 1 ? 'model' : 'models'}`;
+
+    info.appendChild(statusDot);
+    info.appendChild(name);
+    info.appendChild(engine);
+    info.appendChild(modelCount);
+
+    const actions = document.createElement('div');
+    actions.className = 'provider-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.textContent = '✎';
+    editBtn.title = 'Edit provider';
+    editBtn.addEventListener('click', () => startEdit(p));
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.textContent = '×';
+    deleteBtn.title = 'Delete provider';
+    deleteBtn.addEventListener('click', () => {
+      vsCodeApi.postMessage({ type: 'removeProvider', providerId: p.id });
+    });
+
+    actions.appendChild(editBtn);
+    actions.appendChild(deleteBtn);
+
+    card.appendChild(info);
+    card.appendChild(actions);
+    container.appendChild(card);
+  });
+}
+
+// ─── Start Edit ──────────────────────────────────────────────────────
+
+function startEdit(p: ProviderInfo): void {
+  editingProviderId = p.id;
+  selectedEngineId = p.engine;
+  section1Open = true;
+  section2Open = false;
+  selectedModels.clear();
+  discoveredModels = [];
+  discoverError = null;
+  isDiscovering = false;
+  modelFilter = '';
+
+  renderAccordion();
+
+  setTimeout(() => {
+    triggerModelDiscovery();
+  }, 100);
+}
+
+// ─── Render Accordion ────────────────────────────────────────────────
+
+function renderAccordion(): void {
+  const container = document.getElementById('accordion-container');
+  if (!container) {return;}
+
+  container.innerHTML = '';
+
+  if (editingProviderId === null && section1Open === false) {
+    return;
+  }
+
+  const editing = providers.find((p) => p.id === editingProviderId);
+  const selectedEngine = selectedEngineId || editing?.engine || '';
+  const engineInfo = engines.find((e) => e.id === selectedEngine);
+  const requiresKey = engineInfo?.requiresKey ?? false;
+
+  const section1Complete = selectedEngine !== '';
+  const section2Complete = selectedModels.size > 0;
+
+  // Create wrapper
+  const wrapper = document.createElement('div');
+
+  // Section 1
+  const section1 = document.createElement('div');
+  section1.className = `accordion-section ${section1Open ? 'open' : ''}`;
+  section1.id = 'accordion-section-1';
+
+  const header1 = document.createElement('div');
+  header1.className = 'accordion-header';
+  header1.id = 'accordion-header-1';
+  header1.addEventListener('click', () => {
+    section1Open = !section1Open;
+    renderAccordion();
+  });
+
+  const header1Left = document.createElement('div');
+  header1Left.className = 'accordion-header-left';
+
+  const chevron1 = document.createElement('span');
+  chevron1.className = 'accordion-chevron';
+
+  const title1 = document.createElement('span');
+  title1.className = 'accordion-title';
+  title1.textContent = '1. Provider Setup';
+
+  header1Left.appendChild(chevron1);
+  header1Left.appendChild(title1);
+
+  const status1 = document.createElement('span');
+  status1.className = `accordion-status ${section1Complete ? 'complete' : ''}`;
+  if (section1Complete) {
+    status1.textContent = 'Complete';
+  }
+
+  header1.appendChild(header1Left);
+  header1.appendChild(status1);
+
+  const body1 = document.createElement('div');
+  body1.className = 'accordion-body';
+  body1.id = 'accordion-body-1';
+
+  // Engine dropdown
+  const engineGroup = document.createElement('div');
+  engineGroup.className = 'form-group';
+
+  const engineLabel = document.createElement('label');
+  engineLabel.htmlFor = 'engine-select';
+  engineLabel.textContent = 'Engine';
+
+  const engineSelect = document.createElement('select');
+  engineSelect.id = 'engine-select';
+
+  const engineDefaultOption = document.createElement('option');
+  engineDefaultOption.value = '';
+  engineDefaultOption.textContent = 'Choose an engine...';
+  engineSelect.appendChild(engineDefaultOption);
+
+  engines.forEach((e) => {
+    const option = document.createElement('option');
+    option.value = e.id;
+    option.textContent = e.id;
+    if (e.id === selectedEngine) {
+      option.selected = true;
+    }
+    engineSelect.appendChild(option);
+  });
+
+  engineSelect.addEventListener('change', () => {
+    selectedEngineId = engineSelect.value;
+    discoveredModels = [];
+    selectedModels.clear();
+    discoverError = null;
+    isDiscovering = false;
+    renderAccordion();
+    if (selectedEngineId) {
+      triggerModelDiscovery();
+    }
+  });
+
+  engineGroup.appendChild(engineLabel);
+  engineGroup.appendChild(engineSelect);
+
+  // Provider name
+  const nameGroup = document.createElement('div');
+  nameGroup.className = 'form-group';
+
+  const nameLabel = document.createElement('label');
+  nameLabel.htmlFor = 'provider-name-input';
+  nameLabel.textContent = 'Provider Name';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.id = 'provider-name-input';
+  nameInput.value = editing ? editing.id : '';
+  nameInput.placeholder = 'e.g. openai-prod';
+  if (editing) {
+    nameInput.readOnly = true;
+  }
+
+  const nameHint = document.createElement('div');
+  nameHint.className = 'hint';
+  nameHint.textContent = 'Letters, numbers, dots, underscores, and dashes only';
+
+  nameGroup.appendChild(nameLabel);
+  nameGroup.appendChild(nameInput);
+  nameGroup.appendChild(nameHint);
+
+  // Base URL
+  const baseUrlGroup = document.createElement('div');
+  baseUrlGroup.className = 'form-group';
+  baseUrlGroup.id = 'base-url-group';
+  baseUrlGroup.style.display = engineInfo?.defaultBaseUrl ? 'block' : 'none';
+
+  const baseUrlLabel = document.createElement('label');
+  baseUrlLabel.htmlFor = 'base-url-input';
+  baseUrlLabel.textContent = 'Base URL';
+
+  const baseUrlInput = document.createElement('input');
+  baseUrlInput.type = 'text';
+  baseUrlInput.id = 'base-url-input';
+  baseUrlInput.value = editing?.baseUrl || engineInfo?.defaultBaseUrl || '';
+  baseUrlInput.placeholder = engineInfo?.defaultBaseUrl || '';
+
+  baseUrlGroup.appendChild(baseUrlLabel);
+  baseUrlGroup.appendChild(baseUrlInput);
+
+  // API key group
+  const apiKeyGroupDiv = document.createElement('div');
+  apiKeyGroupDiv.id = 'api-key-group';
+  apiKeyGroupDiv.style.display = requiresKey ? 'block' : 'none';
+
+  const toggleGroup = document.createElement('div');
+  toggleGroup.className = 'form-group';
+
+  const toggleLabel = document.createElement('label');
+  toggleLabel.textContent = 'API Key Storage';
+
+  const toggleButtons = document.createElement('div');
+  toggleButtons.className = 'toggle-group';
+
+  const toggleKeychain = document.createElement('button');
+  toggleKeychain.id = 'toggle-keychain';
+  toggleKeychain.textContent = 'Keychain';
+  toggleKeychain.className = apiKeyMethod === 'keychain' ? 'active' : '';
+  toggleKeychain.addEventListener('click', () => {
+    apiKeyMethod = 'keychain';
+    renderAccordion();
+  });
+
+  const toggleEnv = document.createElement('button');
+  toggleEnv.id = 'toggle-env';
+  toggleEnv.textContent = 'Environment Variable';
+  toggleEnv.className = apiKeyMethod === 'env' ? 'active' : '';
+  toggleEnv.addEventListener('click', () => {
+    apiKeyMethod = 'env';
+    renderAccordion();
+  });
+
+  toggleButtons.appendChild(toggleKeychain);
+  toggleButtons.appendChild(toggleEnv);
+
+  toggleGroup.appendChild(toggleLabel);
+  toggleGroup.appendChild(toggleButtons);
+
+  const keychainField = document.createElement('div');
+  keychainField.className = 'form-group';
+  keychainField.id = 'keychain-field';
+  keychainField.style.display = apiKeyMethod === 'keychain' ? 'block' : 'none';
+
+  const apiKeyLabel = document.createElement('label');
+  apiKeyLabel.htmlFor = 'api-key-input';
+  apiKeyLabel.textContent = 'API Key';
+
+  const apiKeyInput = document.createElement('input');
+  apiKeyInput.type = 'password';
+  apiKeyInput.id = 'api-key-input';
+  apiKeyInput.placeholder = 'Stored securely in system keychain';
+
+  keychainField.appendChild(apiKeyLabel);
+  keychainField.appendChild(apiKeyInput);
+
+  const envField = document.createElement('div');
+  envField.className = 'form-group';
+  envField.id = 'env-field';
+  envField.style.display = apiKeyMethod === 'env' ? 'block' : 'none';
+
+  const envVarLabel = document.createElement('label');
+  envVarLabel.htmlFor = 'env-var-input';
+  envVarLabel.textContent = 'Variable Name';
+
+  const envVarInput = document.createElement('input');
+  envVarInput.type = 'text';
+  envVarInput.id = 'env-var-input';
+  envVarInput.value = engineInfo?.defaultEnvVar || '';
+  envVarInput.placeholder = 'e.g. OPENAI_API_KEY';
+
+  envField.appendChild(envVarLabel);
+  envField.appendChild(envVarInput);
+
+  apiKeyGroupDiv.appendChild(toggleGroup);
+  apiKeyGroupDiv.appendChild(keychainField);
+  apiKeyGroupDiv.appendChild(envField);
+
+  body1.appendChild(engineGroup);
+  body1.appendChild(nameGroup);
+  body1.appendChild(baseUrlGroup);
+  body1.appendChild(apiKeyGroupDiv);
+
+  section1.appendChild(header1);
+  section1.appendChild(body1);
+
+  // Section 2
+  const section2 = document.createElement('div');
+  section2.className = `accordion-section ${section2Open ? 'open' : ''}`;
+  section2.id = 'accordion-section-2';
+
+  const header2 = document.createElement('div');
+  header2.className = 'accordion-header';
+  header2.id = 'accordion-header-2';
+  header2.addEventListener('click', () => {
+    section2Open = !section2Open;
+    renderAccordion();
+  });
+
+  const header2Left = document.createElement('div');
+  header2Left.className = 'accordion-header-left';
+
+  const chevron2 = document.createElement('span');
+  chevron2.className = 'accordion-chevron';
+
+  const title2 = document.createElement('span');
+  title2.className = 'accordion-title';
+  title2.textContent = '2. Select Models';
+
+  header2Left.appendChild(chevron2);
+  header2Left.appendChild(title2);
+
+  const status2 = document.createElement('span');
+  status2.className = `accordion-status ${section2Complete ? 'complete' : ''}`;
+  if (section2Complete) {
+    status2.textContent = `${selectedModels.size} selected`;
+  }
+
+  header2.appendChild(header2Left);
+  header2.appendChild(status2);
+
+  const body2 = document.createElement('div');
+  body2.className = 'accordion-body';
+  body2.id = 'accordion-body-2';
+
+  const modelSectionContent = document.createElement('div');
+  modelSectionContent.id = 'model-section-content';
+
+  body2.appendChild(modelSectionContent);
+  section2.appendChild(header2);
+  section2.appendChild(body2);
+
+  // Form actions
+  const formActions = document.createElement('div');
+  formActions.className = 'form-actions';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.id = 'save-provider-btn';
+  saveBtn.className = 'primary';
+  saveBtn.textContent = editing ? 'Update Provider' : 'Save Provider';
+  saveBtn.addEventListener('click', handleSave);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.id = 'cancel-btn';
+  cancelBtn.className = 'secondary';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => {
+    editingProviderId = null;
+    selectedEngineId = '';
+    section1Open = false;
+    section2Open = false;
+    selectedModels.clear();
+    discoveredModels = [];
+    discoverError = null;
+    isDiscovering = false;
+    modelFilter = '';
+    renderAccordion();
+  });
+
+  formActions.appendChild(saveBtn);
+  formActions.appendChild(cancelBtn);
+
+  wrapper.appendChild(section1);
+  wrapper.appendChild(section2);
+  wrapper.appendChild(formActions);
+
+  container.appendChild(wrapper);
+
+  renderModelSection();
+}
+
+// ─── Render Model Section ────────────────────────────────────────────
+
+function renderModelSection(): void {
+  const container = document.getElementById('model-section-content');
+  if (!container) {return;}
+
+  container.innerHTML = '';
+
+  if (isDiscovering) {
+    const loading = document.createElement('div');
+    loading.className = 'loading-state';
+
+    const spinner = document.createElement('span');
+    spinner.className = 'spinner';
+
+    const loadingText = document.createElement('span');
+    loadingText.textContent = 'Discovering models...';
+
+    loading.appendChild(spinner);
+    loading.appendChild(loadingText);
+    container.appendChild(loading);
+    return;
+  }
+
+  if (discoverError) {
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'inline-error';
+
+    const errorText = document.createElement('span');
+    errorText.textContent = discoverError;
+
+    const retryLink = document.createElement('button');
+    retryLink.className = 'link';
+    retryLink.textContent = 'Retry';
+    retryLink.style.marginLeft = '8px';
+    retryLink.addEventListener('click', () => {
+      discoverError = null;
+      triggerModelDiscovery();
+    });
+
+    errorDiv.appendChild(errorText);
+    errorDiv.appendChild(retryLink);
+    container.appendChild(errorDiv);
+    return;
+  }
+
+  if (discoveredModels.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Select an engine and provider to discover models';
+    container.appendChild(empty);
+    return;
+  }
+
+  // Filter models
+  const filteredModels = discoveredModels.filter((m) => {
+    if (modelFilter === '') {return true;}
+    const display = (m.name || m.id).toLowerCase();
+    return display.includes(modelFilter.toLowerCase());
+  });
+
+  const searchInput = document.createElement('input');
+  searchInput.type = 'text';
+  searchInput.className = 'model-search';
+  searchInput.id = 'model-search-input';
+  searchInput.placeholder = 'Search models...';
+  searchInput.value = modelFilter;
+  searchInput.addEventListener('input', (e) => {
+    modelFilter = (e.target as HTMLInputElement).value;
+    renderModelSection();
+  });
+
+  const modelActions = document.createElement('div');
+  modelActions.className = 'model-actions';
+
+  const selectAllLink = document.createElement('button');
+  selectAllLink.className = 'link';
+  selectAllLink.id = 'select-all-link';
+  selectAllLink.textContent = 'Select all';
+  selectAllLink.addEventListener('click', () => {
+    filteredModels.forEach((m) => selectedModels.add(m.id));
+    renderModelSection();
+    renderAccordion();
+  });
+
+  const deselectAllLink = document.createElement('button');
+  deselectAllLink.className = 'link';
+  deselectAllLink.id = 'deselect-all-link';
+  deselectAllLink.textContent = 'Deselect all';
+  deselectAllLink.addEventListener('click', () => {
+    selectedModels.clear();
+    renderModelSection();
+    renderAccordion();
+  });
+
+  modelActions.appendChild(selectAllLink);
+  modelActions.appendChild(deselectAllLink);
+
+  const modelCounter = document.createElement('div');
+  modelCounter.className = 'model-counter';
+  modelCounter.textContent = `${selectedModels.size} of ${filteredModels.length} selected`;
+
+  const modelList = document.createElement('div');
+  modelList.className = 'model-list';
+  modelList.id = 'model-list';
+
+  filteredModels.forEach((m) => {
+    const item = document.createElement('div');
+    item.className = 'model-item';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = `model-${m.id}`;
+    checkbox.checked = selectedModels.has(m.id);
+    checkbox.addEventListener('change', (e) => {
+      if ((e.target as HTMLInputElement).checked) {
+        selectedModels.add(m.id);
+      } else {
+        selectedModels.delete(m.id);
+      }
+      renderModelSection();
+      renderAccordion();
+    });
+
+    const label = document.createElement('label');
+    label.htmlFor = `model-${m.id}`;
+    label.textContent = m.name || m.id;
+
+    item.appendChild(checkbox);
+    item.appendChild(label);
+    modelList.appendChild(item);
+  });
+
+  container.appendChild(searchInput);
+  container.appendChild(modelActions);
+  container.appendChild(modelCounter);
+  container.appendChild(modelList);
+}
+
+// ─── Trigger Model Discovery ─────────────────────────────────────────
+
+function triggerModelDiscovery(): void {
+  const engineSelect = document.getElementById('engine-select') as HTMLSelectElement;
+  const providerNameInput = document.getElementById('provider-name-input') as HTMLInputElement;
+
+  const engineId = engineSelect?.value || '';
+  const providerId = providerNameInput?.value.trim() || editingProviderId || '';
+
+  if (!engineId) {return;}
+
+  isDiscovering = true;
+  discoverError = null;
+  renderModelSection();
+
+  vsCodeApi.postMessage({
+    type: 'discoverModels',
+    engineId,
+    providerId: providerId || undefined,
+  });
+}
+
+// ─── Handle Save ─────────────────────────────────────────────────────
+
+function handleSave(): void {
+  const providerNameInput = document.getElementById('provider-name-input') as HTMLInputElement;
+  const engineSelect = document.getElementById('engine-select') as HTMLSelectElement;
+  const baseUrlInput = document.getElementById('base-url-input') as HTMLInputElement;
+  const apiKeyInput = document.getElementById('api-key-input') as HTMLInputElement;
+  const envVarInput = document.getElementById('env-var-input') as HTMLInputElement;
+
+  const providerId = providerNameInput?.value.trim() || '';
+  const engine = engineSelect?.value || '';
+
+  if (!providerId) {
+    showNotification('Provider name is required', true);
+    return;
+  }
+
+  if (!/^[a-zA-Z0-9._-]+$/.test(providerId)) {
+    showNotification('Provider name must contain only letters, numbers, dots, underscores, and dashes', true);
+    return;
+  }
+
+  if (!engine) {
+    showNotification('Engine is required', true);
+    return;
+  }
+
+  const msg: Record<string, unknown> = {
+    type: 'configureProvider',
+    providerId,
+    engine,
+    models: Array.from(selectedModels),
+  };
+
+  const baseUrl = baseUrlInput?.value.trim();
+  if (baseUrl) {
+    msg.baseUrl = baseUrl;
+  }
+
+  const engineInfo = engines.find((e) => e.id === engine);
+  if (engineInfo?.requiresKey) {
+    if (apiKeyMethod === 'keychain') {
+      const key = apiKeyInput?.value.trim() || '';
+      if (!key && !editingProviderId) {
+        showNotification('API key is required', true);
+        return;
+      }
+      if (key) {
+        msg.apiKey = key;
+      }
+    } else {
+      const envVar = envVarInput?.value.trim() || '';
+      if (!envVar) {
+        showNotification('Variable name is required', true);
+        return;
+      }
+      msg.envVarName = envVar;
+    }
+  }
+
+  vsCodeApi.postMessage(msg);
+}
+
+// ─── Message Handler ─────────────────────────────────────────────────
+
+window.addEventListener('message', (event) => {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case 'providers':
+      providers = msg.providers || [];
+      renderProviders();
+      break;
+
+    case 'engines':
+      engines = msg.engines || [];
+      if (section1Open) {
+        renderAccordion();
+      }
+      break;
+
+    case 'discoveredModels':
+      isDiscovering = false;
+      discoveredModels = msg.models || [];
+      discoverError = null;
+      renderModelSection();
+      break;
+
+    case 'configureResult':
+      if (msg.success) {
+        showNotification(`Provider ${msg.providerId} ${editingProviderId ? 'updated' : 'added'} successfully`);
+        editingProviderId = null;
+        selectedEngineId = '';
+        section1Open = false;
+        section2Open = false;
+        selectedModels.clear();
+        discoveredModels = [];
+        discoverError = null;
+        isDiscovering = false;
+        modelFilter = '';
+        renderAccordion();
+      } else {
+        showNotification(`Failed: ${msg.error}`, true);
+      }
+      break;
+
+    case 'error':
+      if (msg.context === 'discoverModels') {
+        isDiscovering = false;
+        discoverError = msg.message;
+        renderModelSection();
+      } else {
+        showNotification(msg.message, true);
+      }
+      break;
+  }
+});
+
+// ─── Init ────────────────────────────────────────────────────────────
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    buildInitialDOM();
+    vsCodeApi.postMessage({ type: 'ready' });
+  });
+} else {
+  buildInitialDOM();
+  vsCodeApi.postMessage({ type: 'ready' });
+}

--- a/packages/vscode/src/webviews/chat/ChatViewProvider.ts
+++ b/packages/vscode/src/webviews/chat/ChatViewProvider.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+import { DaemonClient } from '../../daemon/client';
+import { getWebviewContent } from '../shared/getWebviewContent';
+import { ChatToHostMessage } from '../shared/types';
+import { handleChatMessage, cancelActiveStream } from './chatHandler';
+import { getLogger } from '../../utils/logger';
+
+export class ChatViewProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'abbenay.chatView';
+  private _view?: vscode.WebviewView;
+  private readonly _logger = getLogger();
+
+  constructor(
+    private readonly _extensionUri: vscode.Uri,
+    private readonly _client: DaemonClient,
+  ) {}
+
+  public resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ): void {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        vscode.Uri.joinPath(this._extensionUri, 'out'),
+        vscode.Uri.joinPath(this._extensionUri, 'media'),
+      ],
+    };
+
+    webviewView.webview.html = getWebviewContent(
+      webviewView.webview,
+      this._extensionUri,
+      'chat',
+      'Abbenay Chat',
+    );
+
+    webviewView.webview.onDidReceiveMessage(async (message: ChatToHostMessage) => {
+      try {
+        await handleChatMessage(message, webviewView.webview, this._client);
+      } catch (error) {
+        this._logger.error('[ChatView] Error handling message:', error);
+        webviewView.webview.postMessage({
+          type: 'error',
+          message: error instanceof Error ? error.message : String(error),
+          context: 'handler',
+        });
+      }
+    });
+
+    webviewView.onDidDispose(() => {
+      cancelActiveStream();
+      this._view = undefined;
+    });
+  }
+
+  public async refreshModels(): Promise<void> {
+    if (!this._view) {return;}
+    try {
+      const models = await this._client.listModels();
+      this._view.webview.postMessage({
+        type: 'models',
+        models: models.map(m => ({ id: m.id, provider: m.provider, name: m.name, engine: m.engine })),
+      });
+    } catch (error) {
+      this._logger.error('[ChatView] Error refreshing models:', error);
+    }
+  }
+
+  public reveal(): void {
+    if (this._view) {
+      this._view.show(true);
+    }
+  }
+}

--- a/packages/vscode/src/webviews/chat/chatHandler.ts
+++ b/packages/vscode/src/webviews/chat/chatHandler.ts
@@ -1,0 +1,429 @@
+import * as vscode from 'vscode';
+import { DaemonClient } from '../../daemon/client';
+import * as proto from '../../proto/abbenay/v1/service';
+import {
+  ChatToHostMessage,
+  HostToChatMessage,
+  ModelInfo,
+  SessionInfo,
+  SessionDetail,
+  MessageInfo,
+  ToolCallInfo,
+} from '../shared/types';
+import { getLogger } from '../../utils/logger';
+
+const logger = getLogger();
+
+/**
+ * Active stream abort handler.
+ */
+let activeStreamAbort: (() => void) | null = null;
+
+/**
+ * Pending tool approval requests.
+ */
+const pendingApprovals = new Map<string, {
+  resolve: (decision: 'allow' | 'deny' | 'abort') => void;
+}>();
+
+/**
+ * Cancel the currently active stream.
+ */
+export function cancelActiveStream(): void {
+  if (activeStreamAbort) {
+    activeStreamAbort();
+    activeStreamAbort = null;
+  }
+  pendingApprovals.clear();
+}
+
+/**
+ * Handle tool approval decision from webview.
+ */
+function handleApproveToolCall(requestId: string, decision: 'allow' | 'deny' | 'abort'): void {
+  const pending = pendingApprovals.get(requestId);
+  if (pending) {
+    logger.info('[ChatHandler] Tool approval:', requestId, decision);
+    pending.resolve(decision);
+    pendingApprovals.delete(requestId);
+  } else {
+    logger.warn('[ChatHandler] No pending approval for requestId:', requestId);
+  }
+}
+
+/**
+ * Handle messages from the webview.
+ */
+export async function handleChatMessage(
+  message: ChatToHostMessage,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  logger.debug('[ChatHandler] Received message:', message.type);
+
+  try {
+    switch (message.type) {
+      case 'ready':
+        await handleReady(webview, client);
+        break;
+
+      case 'listModels':
+        await handleListModels(webview, client);
+        break;
+
+      case 'listSessions':
+        await handleListSessions(webview, client);
+        break;
+
+      case 'createSession':
+        await handleCreateSession(webview, client, message.model, message.topic);
+        break;
+
+      case 'deleteSession':
+        await handleDeleteSession(webview, client, message.sessionId);
+        break;
+
+      case 'getSession':
+        await handleGetSession(webview, client, message.sessionId);
+        break;
+
+      case 'sendMessage':
+        await handleSendMessage(webview, client, message.sessionId, message.content);
+        break;
+
+      case 'cancelStream':
+        cancelActiveStream();
+        break;
+
+      case 'approveToolCall':
+        handleApproveToolCall(message.requestId, message.decision);
+        break;
+
+      default:
+        logger.warn('[ChatHandler] Unknown message type:', (message as { type: string }).type);
+    }
+  } catch (error) {
+    logger.error('[ChatHandler] Error handling message:', error);
+    const errorMessage: HostToChatMessage = {
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error),
+      context: message.type,
+    };
+    webview.postMessage(errorMessage);
+  }
+}
+
+/**
+ * Handle webview ready event - send initial data.
+ */
+async function handleReady(
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  await Promise.all([
+    handleListModels(webview, client),
+    handleListSessions(webview, client),
+  ]);
+}
+
+/**
+ * List available models.
+ */
+async function handleListModels(
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const models = await client.listModels();
+  const modelInfos: ModelInfo[] = models.map(m => ({
+    id: m.id,
+    provider: m.provider,
+    name: m.name,
+    engine: m.engine,
+  }));
+
+  const response: HostToChatMessage = {
+    type: 'models',
+    models: modelInfos,
+  };
+  webview.postMessage(response);
+}
+
+/**
+ * List chat sessions.
+ */
+async function handleListSessions(
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const sessions = await client.listSessions();
+  const sessionInfos: SessionInfo[] = sessions.map(s => ({
+    id: s.id,
+    model: s.model,
+    topic: s.topic,
+    messageCount: s.messageCount,
+    createdAt: timestampToISO(s.createdAt),
+    updatedAt: timestampToISO(s.updatedAt),
+  }));
+
+  const response: HostToChatMessage = {
+    type: 'sessions',
+    sessions: sessionInfos,
+  };
+  webview.postMessage(response);
+}
+
+/**
+ * Create a new session.
+ */
+async function handleCreateSession(
+  webview: vscode.Webview,
+  client: DaemonClient,
+  model: string,
+  topic?: string,
+): Promise<void> {
+  const session = await client.createSession(model, topic);
+  const sessionDetail: SessionDetail = {
+    id: session.id,
+    model: session.model,
+    topic: session.topic,
+    messageCount: session.messages.length,
+    createdAt: timestampToISO(session.createdAt),
+    updatedAt: timestampToISO(session.updatedAt),
+    messages: session.messages.map(mapMessageToView),
+  };
+
+  const response: HostToChatMessage = {
+    type: 'sessionCreated',
+    session: sessionDetail,
+  };
+  webview.postMessage(response);
+
+  // Refresh sessions list
+  await handleListSessions(webview, client);
+}
+
+/**
+ * Delete a session.
+ */
+async function handleDeleteSession(
+  webview: vscode.Webview,
+  client: DaemonClient,
+  sessionId: string,
+): Promise<void> {
+  await client.deleteSession(sessionId);
+  await handleListSessions(webview, client);
+}
+
+/**
+ * Get session details with messages.
+ */
+async function handleGetSession(
+  webview: vscode.Webview,
+  client: DaemonClient,
+  sessionId: string,
+): Promise<void> {
+  const session = await client.getSession(sessionId, true);
+  const sessionDetail: SessionDetail = {
+    id: session.id,
+    model: session.model,
+    topic: session.topic,
+    messageCount: session.messages.length,
+    createdAt: timestampToISO(session.createdAt),
+    updatedAt: timestampToISO(session.updatedAt),
+    messages: session.messages.map(mapMessageToView),
+  };
+
+  const response: HostToChatMessage = {
+    type: 'sessionLoaded',
+    session: sessionDetail,
+  };
+  webview.postMessage(response);
+}
+
+/**
+ * Send a message and stream the response.
+ */
+async function handleSendMessage(
+  webview: vscode.Webview,
+  client: DaemonClient,
+  sessionId: string,
+  content: string,
+): Promise<void> {
+  let aborted = false;
+
+  // Set up abort handler
+  activeStreamAbort = () => {
+    aborted = true;
+  };
+
+  try {
+    const stream = client.sessionChat({
+      sessionId,
+      message: {
+        role: proto.Role.ROLE_USER,
+        content,
+        toolCalls: [],
+        toolCallId: '',
+        name: '',
+      },
+      options: {
+        toolMode: 'auto',
+        enableTools: true,
+      },
+    });
+
+    for await (const chunk of stream) {
+      if (aborted) {
+        logger.info('[ChatHandler] Stream aborted by user');
+        break;
+      }
+
+      if (!chunk.chunk) {
+        continue;
+      }
+
+      switch (chunk.chunk.$case) {
+        case 'text': {
+          const response: HostToChatMessage = {
+            type: 'streamChunk',
+            text: chunk.chunk.text.text,
+          };
+          webview.postMessage(response);
+          break;
+        }
+
+        case 'toolCall': {
+          const response: HostToChatMessage = {
+            type: 'toolCall',
+            id: chunk.chunk.toolCall.id,
+            name: chunk.chunk.toolCall.name,
+            args: chunk.chunk.toolCall.arguments,
+          };
+          webview.postMessage(response);
+          break;
+        }
+
+        case 'toolResult': {
+          const response: HostToChatMessage = {
+            type: 'toolResult',
+            callId: chunk.chunk.toolResult.toolCallId,
+            name: chunk.chunk.toolResult.name,
+            content: chunk.chunk.toolResult.content,
+            isError: chunk.chunk.toolResult.isError,
+          };
+          webview.postMessage(response);
+          break;
+        }
+
+        case 'prompt': {
+          const promptId = chunk.chunk.prompt.toolCallId;
+          const approvalMsg: HostToChatMessage = {
+            type: 'toolApprovalRequest',
+            requestId: promptId,
+            toolName: chunk.chunk.prompt.toolName,
+            promptText: chunk.chunk.prompt.promptText,
+          };
+          webview.postMessage(approvalMsg);
+
+          const decision = await new Promise<'allow' | 'deny' | 'abort'>((resolve) => {
+            pendingApprovals.set(promptId, { resolve });
+          });
+
+          logger.info('[ChatHandler] Approval resolved:', promptId, decision);
+          break;
+        }
+
+        case 'error': {
+          const response: HostToChatMessage = {
+            type: 'error',
+            message: chunk.chunk.error.message,
+            context: 'stream',
+          };
+          webview.postMessage(response);
+          break;
+        }
+
+        case 'done': {
+          const response: HostToChatMessage = {
+            type: 'streamDone',
+            finishReason: chunk.chunk.done.finishReason,
+          };
+          webview.postMessage(response);
+          break;
+        }
+
+        case 'usage':
+          // Log token usage but don't send to UI for now
+          logger.debug('[ChatHandler] Token usage:', chunk.chunk.usage);
+          break;
+
+        default:
+          logger.warn('[ChatHandler] Unknown chunk type:', (chunk.chunk as { $case: string }).$case);
+      }
+    }
+  } catch (error) {
+    if (!aborted) {
+      logger.error('[ChatHandler] Stream error:', error);
+      const response: HostToChatMessage = {
+        type: 'error',
+        message: error instanceof Error ? error.message : String(error),
+        context: 'stream',
+      };
+      webview.postMessage(response);
+    }
+  } finally {
+    activeStreamAbort = null;
+  }
+}
+
+/**
+ * Convert proto Timestamp to ISO string.
+ */
+function timestampToISO(timestamp: proto.Timestamp | undefined): string | undefined {
+  if (!timestamp) {
+    return undefined;
+  }
+  // Timestamp has seconds as Long
+  const seconds = typeof timestamp.seconds === 'number'
+    ? timestamp.seconds
+    : timestamp.seconds.toNumber();
+  return new Date(seconds * 1000).toISOString();
+}
+
+/**
+ * Convert proto Role enum to string.
+ */
+function roleToString(role: proto.Role): string {
+  switch (role) {
+    case proto.Role.ROLE_SYSTEM:
+      return 'system';
+    case proto.Role.ROLE_USER:
+      return 'user';
+    case proto.Role.ROLE_ASSISTANT:
+      return 'assistant';
+    case proto.Role.ROLE_TOOL:
+      return 'tool';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Map proto Message to view MessageInfo.
+ */
+function mapMessageToView(message: proto.Message): MessageInfo {
+  const toolCalls: ToolCallInfo[] | undefined = message.toolCalls.length > 0
+    ? message.toolCalls.map(tc => ({
+        id: tc.id,
+        name: tc.name,
+        arguments: tc.arguments,
+      }))
+    : undefined;
+
+  return {
+    role: roleToString(message.role),
+    content: message.content,
+    toolCalls,
+    toolCallId: message.toolCallId || undefined,
+  };
+}

--- a/packages/vscode/src/webviews/chat/chatHandler.ts
+++ b/packages/vscode/src/webviews/chat/chatHandler.ts
@@ -30,11 +30,17 @@ const pendingApprovals = new Map<string, {
  * Cancel the currently active stream.
  */
 export function cancelActiveStream(): void {
+  // Resolve any pending approval promises before clearing, otherwise the
+  // awaiting handleSendMessage will never continue and the stream handler leaks.
+  for (const pending of pendingApprovals.values()) {
+    pending.resolve('abort');
+  }
+  pendingApprovals.clear();
+
   if (activeStreamAbort) {
     activeStreamAbort();
     activeStreamAbort = null;
   }
-  pendingApprovals.clear();
 }
 
 /**

--- a/packages/vscode/src/webviews/provider/ProviderPanel.ts
+++ b/packages/vscode/src/webviews/provider/ProviderPanel.ts
@@ -1,0 +1,112 @@
+import * as vscode from 'vscode';
+import { DaemonClient } from '../../daemon/client';
+import { getWebviewContent } from '../shared/getWebviewContent';
+import { getLogger } from '../../utils/logger';
+import { handleProviderMessage } from './providerHandler';
+
+/**
+ * Singleton webview panel for provider configuration
+ */
+export class ProviderPanel {
+  public static currentPanel: ProviderPanel | undefined;
+  private static readonly viewType = 'abbenayProviderConfig';
+
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionUri: vscode.Uri;
+  private readonly _client: DaemonClient;
+  private _disposables: vscode.Disposable[] = [];
+
+  /**
+   * Create or show the provider configuration panel
+   */
+  public static createOrShow(extensionUri: vscode.Uri, client: DaemonClient): void {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined;
+
+    // If panel already exists, reveal it
+    if (ProviderPanel.currentPanel) {
+      ProviderPanel.currentPanel._panel.reveal(column);
+      ProviderPanel.currentPanel.update();
+      return;
+    }
+
+    // Create new panel
+    const panel = vscode.window.createWebviewPanel(
+      ProviderPanel.viewType,
+      'Abbenay: Providers',
+      column || vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(extensionUri, 'out'),
+          vscode.Uri.joinPath(extensionUri, 'media'),
+        ],
+      },
+    );
+
+    ProviderPanel.currentPanel = new ProviderPanel(panel, extensionUri, client);
+  }
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, client: DaemonClient) {
+    this._panel = panel;
+    this._extensionUri = extensionUri;
+    this._client = client;
+
+    // Set HTML content
+    this.update();
+
+    // Listen for when the panel is disposed
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    // Handle messages from the webview
+    this._panel.webview.onDidReceiveMessage(
+      async (message) => {
+        try {
+          await handleProviderMessage(message, this._panel.webview, this._client);
+        } catch (error) {
+          const logger = getLogger();
+          logger.error('[ProviderPanel] Error handling message:', error);
+          this._panel.webview.postMessage({
+            type: 'error',
+            message: error instanceof Error ? error.message : String(error),
+            context: 'message-handler',
+          });
+        }
+      },
+      null,
+      this._disposables,
+    );
+  }
+
+  /**
+   * Update the webview content
+   */
+  public update(): void {
+    const webview = this._panel.webview;
+    this._panel.webview.html = getWebviewContent(
+      webview,
+      this._extensionUri,
+      'provider',
+      'Abbenay: Providers',
+    );
+  }
+
+  /**
+   * Clean up resources
+   */
+  public dispose(): void {
+    ProviderPanel.currentPanel = undefined;
+
+    // Clean up our resources
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const disposable = this._disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
+    }
+  }
+}

--- a/packages/vscode/src/webviews/provider/providerHandler.ts
+++ b/packages/vscode/src/webviews/provider/providerHandler.ts
@@ -358,6 +358,8 @@ async function handleDiscoverModels(
 ): Promise<void> {
   const models = await client.discoverModels(message.engineId, {
     providerId: message.providerId,
+    apiKey: message.apiKey,
+    baseUrl: message.baseUrl,
   });
 
   const modelInfo: ModelInfo[] = models.map((m) => ({

--- a/packages/vscode/src/webviews/provider/providerHandler.ts
+++ b/packages/vscode/src/webviews/provider/providerHandler.ts
@@ -1,0 +1,412 @@
+import * as vscode from 'vscode';
+import { DaemonClient } from '../../daemon/client';
+import * as proto from '../../proto/abbenay/v1/service';
+import {
+  ProviderToHostMessage,
+  ProviderInfo,
+  ProviderTemplateInfo,
+  EngineInfo,
+  SecretInfoView,
+  ModelInfo,
+} from '../shared/types';
+import { getLogger } from '../../utils/logger';
+
+/**
+ * Handle messages from the provider configuration webview
+ */
+export async function handleProviderMessage(
+  message: ProviderToHostMessage,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const logger = getLogger();
+  logger.debug('[ProviderHandler] Received message:', message.type);
+
+  try {
+    switch (message.type) {
+      case 'ready':
+        await handleReady(webview, client);
+        break;
+
+      case 'getProviders':
+        await handleGetProviders(webview, client);
+        break;
+
+      case 'getProviderTemplates':
+        await handleGetProviderTemplates(webview, client);
+        break;
+
+      case 'getEngines':
+        await handleGetEngines(webview, client);
+        break;
+
+      case 'configureProvider':
+        await handleConfigureProvider(message, webview, client);
+        break;
+
+      case 'removeProvider':
+        await handleRemoveProvider(message, webview, client);
+        break;
+
+      case 'setSecret':
+        await handleSetSecret(message, webview, client);
+        break;
+
+      case 'deleteSecret':
+        await handleDeleteSecret(message, webview, client);
+        break;
+
+      case 'listSecrets':
+        await handleListSecrets(webview, client);
+        break;
+
+      case 'getKeyStatus':
+        await handleGetKeyStatus(message, webview, client);
+        break;
+
+      case 'discoverModels':
+        await handleDiscoverModels(message, webview, client);
+        break;
+
+      case 'getConfig':
+        await handleGetConfig(message, webview, client);
+        break;
+
+      case 'updateConfig':
+        await handleUpdateConfig(message, webview, client);
+        break;
+
+      default:
+        logger.warn('[ProviderHandler] Unknown message type:', (message as { type: string }).type);
+    }
+  } catch (error) {
+    logger.error('[ProviderHandler] Error handling message:', error);
+    webview.postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error),
+      context: message.type,
+    });
+  }
+}
+
+/**
+ * Handle ready event - load initial data
+ */
+async function handleReady(webview: vscode.Webview, client: DaemonClient): Promise<void> {
+  await Promise.all([
+    handleGetProviders(webview, client),
+    handleGetProviderTemplates(webview, client),
+    handleGetEngines(webview, client),
+    handleListSecrets(webview, client),
+  ]);
+}
+
+/**
+ * Get list of configured providers
+ */
+async function handleGetProviders(webview: vscode.Webview, client: DaemonClient): Promise<void> {
+  const [providers, models] = await Promise.all([
+    client.listProviders(),
+    client.listModels(),
+  ]);
+
+  const modelCountByProvider = new Map<string, number>();
+  for (const m of models) {
+    const count = modelCountByProvider.get(m.provider) ?? 0;
+    modelCountByProvider.set(m.provider, count + 1);
+  }
+
+  const providerInfo: ProviderInfo[] = providers.map((p) => ({
+    id: p.id,
+    engine: p.engine,
+    configured: p.configured,
+    healthy: p.healthy,
+    requiresKey: p.requiresKey,
+    baseUrl: p.baseUrl,
+    modelCount: modelCountByProvider.get(p.id) ?? 0,
+  }));
+
+  webview.postMessage({
+    type: 'providers',
+    providers: providerInfo,
+  });
+}
+
+/**
+ * Get provider templates
+ */
+async function handleGetProviderTemplates(webview: vscode.Webview, client: DaemonClient): Promise<void> {
+  const templates = await client.getProviderTemplates();
+
+  const templateInfo: ProviderTemplateInfo[] = templates.map((t) => ({
+    id: t.suggestedName,
+    displayName: t.suggestedName,
+    engine: t.engine,
+    requiresKey: t.requiresKey,
+    defaultBaseUrl: t.defaultBaseUrl,
+  }));
+
+  webview.postMessage({
+    type: 'templates',
+    templates: templateInfo,
+  });
+}
+
+/**
+ * Get available engines
+ */
+async function handleGetEngines(webview: vscode.Webview, client: DaemonClient): Promise<void> {
+  const engines = await client.listEngines();
+
+  const engineInfo: EngineInfo[] = engines.map((e) => ({
+    id: e.id,
+    requiresKey: e.requiresKey,
+    defaultBaseUrl: e.defaultBaseUrl,
+    defaultEnvVar: e.defaultEnvVar,
+  }));
+
+  webview.postMessage({
+    type: 'engines',
+    engines: engineInfo,
+  });
+}
+
+/**
+ * Configure a provider
+ */
+async function handleConfigureProvider(
+  message: Extract<ProviderToHostMessage, { type: 'configureProvider' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    const workspacePath = workspaceFolders && workspaceFolders.length > 0
+      ? workspaceFolders[0].uri.fsPath
+      : undefined;
+
+    // Step 1: Configure provider credentials via gRPC
+    await client.configureProvider({
+      providerId: message.providerId,
+      engine: message.engine,
+      apiKey: message.apiKey,
+      envVarName: message.envVarName,
+      baseUrl: message.baseUrl,
+      target: message.target,
+      workspacePath,
+    });
+
+    // Step 2: Save selected models into the config file (same approach as dashboard)
+    if (message.models && message.models.length > 0) {
+      const location = (message.target === 'workspace' && workspacePath) ? workspacePath : 'user';
+      const configResponse = await client.getConfig(location);
+      const config = (configResponse.config ?? {}) as Record<string, unknown>;
+      const providers = ((config as Record<string, unknown>).providers ?? {}) as Record<string, Record<string, unknown>>;
+
+      if (!providers[message.providerId]) {
+        providers[message.providerId] = {};
+      }
+
+      const models: Record<string, { model_id: string }> = {};
+      for (const modelId of message.models) {
+        models[modelId] = { model_id: modelId };
+      }
+      providers[message.providerId].models = models;
+      (config as Record<string, unknown>).providers = providers;
+
+      await client.updateConfig(config as unknown as proto.Config, location);
+    }
+
+    logger.info('[ProviderHandler] Provider configured:', message.providerId);
+
+    webview.postMessage({
+      type: 'configureResult',
+      success: true,
+      providerId: message.providerId,
+    });
+
+    await handleGetProviders(webview, client);
+  } catch (error) {
+    logger.error('[ProviderHandler] Failed to configure provider:', error);
+    webview.postMessage({
+      type: 'configureResult',
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+      providerId: message.providerId,
+    });
+  }
+}
+
+/**
+ * Remove a provider
+ */
+async function handleRemoveProvider(
+  message: Extract<ProviderToHostMessage, { type: 'removeProvider' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const logger = getLogger();
+
+  const answer = await vscode.window.showWarningMessage(
+    `Remove provider "${message.providerId}"?`,
+    { modal: true },
+    'Remove',
+  );
+  if (answer !== 'Remove') {return;}
+
+  try {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    const workspacePath = workspaceFolders && workspaceFolders.length > 0
+      ? workspaceFolders[0].uri.fsPath
+      : undefined;
+
+    await client.removeProvider(message.providerId, message.target, workspacePath);
+    logger.info('[ProviderHandler] Provider removed:', message.providerId);
+
+    await handleGetProviders(webview, client);
+  } catch (error) {
+    logger.error('[ProviderHandler] Failed to remove provider:', error);
+    throw error;
+  }
+}
+
+/**
+ * Set a secret
+ */
+async function handleSetSecret(
+  message: Extract<ProviderToHostMessage, { type: 'setSecret' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    await client.setSecret(message.key, message.value);
+    logger.info('[ProviderHandler] Secret set:', message.key);
+
+    // Refresh secrets list
+    await handleListSecrets(webview, client);
+  } catch (error) {
+    logger.error('[ProviderHandler] Failed to set secret:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete a secret
+ */
+async function handleDeleteSecret(
+  message: Extract<ProviderToHostMessage, { type: 'deleteSecret' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    await client.deleteSecret(message.key);
+    logger.info('[ProviderHandler] Secret deleted:', message.key);
+
+    // Refresh secrets list
+    await handleListSecrets(webview, client);
+  } catch (error) {
+    logger.error('[ProviderHandler] Failed to delete secret:', error);
+    throw error;
+  }
+}
+
+/**
+ * List secrets
+ */
+async function handleListSecrets(webview: vscode.Webview, client: DaemonClient): Promise<void> {
+  const secrets = await client.listSecrets();
+
+  const secretInfo: SecretInfoView[] = secrets.map((s) => ({
+    key: s.key,
+    store: String(s.store),
+    hasValue: s.hasValue,
+  }));
+
+  webview.postMessage({
+    type: 'secrets',
+    secrets: secretInfo,
+  });
+}
+
+/**
+ * Get key status
+ */
+async function handleGetKeyStatus(
+  message: Extract<ProviderToHostMessage, { type: 'getKeyStatus' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const exists = await client.getKeyStatus(message.source, message.name);
+
+  webview.postMessage({
+    type: 'keyStatus',
+    source: message.source,
+    name: message.name,
+    exists,
+  });
+}
+
+/**
+ * Discover models
+ */
+async function handleDiscoverModels(
+  message: Extract<ProviderToHostMessage, { type: 'discoverModels' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const models = await client.discoverModels(message.engineId, {
+    providerId: message.providerId,
+  });
+
+  const modelInfo: ModelInfo[] = models.map((m) => ({
+    id: m.id,
+    provider: m.provider,
+    name: m.name,
+    engine: m.engine,
+  }));
+
+  webview.postMessage({
+    type: 'discoveredModels',
+    models: modelInfo,
+  });
+}
+
+/**
+ * Get configuration
+ */
+async function handleGetConfig(
+  message: Extract<ProviderToHostMessage, { type: 'getConfig' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const response = await client.getConfig(message.location);
+
+  webview.postMessage({
+    type: 'config',
+    config: response.config,
+    path: response.path,
+  });
+}
+
+/**
+ * Update configuration
+ */
+async function handleUpdateConfig(
+  message: Extract<ProviderToHostMessage, { type: 'updateConfig' }>,
+  webview: vscode.Webview,
+  client: DaemonClient,
+): Promise<void> {
+  const response = await client.updateConfig(message.config as unknown as proto.Config, message.location);
+
+  webview.postMessage({
+    type: 'config',
+    config: response.config,
+    path: response.path,
+  });
+}

--- a/packages/vscode/src/webviews/provider/providerHandler.ts
+++ b/packages/vscode/src/webviews/provider/providerHandler.ts
@@ -199,7 +199,7 @@ async function handleConfigureProvider(
     });
 
     // Step 2: Save selected models into the config file (same approach as dashboard)
-    if (message.models && Object.keys(message.models).length > 0) {
+    if (message.models !== undefined) {
       const location = (message.target === 'workspace' && workspacePath) ? workspacePath : 'user';
       const configResponse = await client.getConfig(location);
       const config = (configResponse.config ?? {}) as Record<string, unknown>;

--- a/packages/vscode/src/webviews/provider/providerHandler.ts
+++ b/packages/vscode/src/webviews/provider/providerHandler.ts
@@ -199,7 +199,7 @@ async function handleConfigureProvider(
     });
 
     // Step 2: Save selected models into the config file (same approach as dashboard)
-    if (message.models && message.models.length > 0) {
+    if (message.models && Object.keys(message.models).length > 0) {
       const location = (message.target === 'workspace' && workspacePath) ? workspacePath : 'user';
       const configResponse = await client.getConfig(location);
       const config = (configResponse.config ?? {}) as Record<string, unknown>;
@@ -209,11 +209,7 @@ async function handleConfigureProvider(
         providers[message.providerId] = {};
       }
 
-      const models: Record<string, { model_id: string }> = {};
-      for (const modelId of message.models) {
-        models[modelId] = { model_id: modelId };
-      }
-      providers[message.providerId].models = models;
+      providers[message.providerId].models = message.models;
       (config as Record<string, unknown>).providers = providers;
 
       await client.updateConfig(config as unknown as proto.Config, location);

--- a/packages/vscode/src/webviews/shared/getNonce.ts
+++ b/packages/vscode/src/webviews/shared/getNonce.ts
@@ -1,0 +1,5 @@
+import * as crypto from 'crypto';
+
+export function getNonce(): string {
+  return crypto.randomBytes(16).toString('hex');
+}

--- a/packages/vscode/src/webviews/shared/getWebviewContent.ts
+++ b/packages/vscode/src/webviews/shared/getWebviewContent.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { getNonce } from './getNonce';
+
+export function getWebviewContent(
+  webview: vscode.Webview,
+  extensionUri: vscode.Uri,
+  panelName: string,
+  title: string,
+): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, 'out', 'webview-ui', panelName, 'main.js'),
+  );
+  const styleUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, 'media', `${panelName}.css`),
+  );
+  const nonce = getNonce();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
+  <link rel="stylesheet" href="${styleUri}">
+  <title>${title}</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+}

--- a/packages/vscode/src/webviews/shared/types.ts
+++ b/packages/vscode/src/webviews/shared/types.ts
@@ -9,7 +9,7 @@ export type ProviderToHostMessage =
   | { type: 'getProviderTemplates' }
   | { type: 'getEngines' }
   | { type: 'getConfig'; location?: string }
-  | { type: 'configureProvider'; providerId: string; engine?: string; apiKey?: string; envVarName?: string; baseUrl?: string; target?: string; models?: string[] }
+  | { type: 'configureProvider'; providerId: string; engine?: string; apiKey?: string; envVarName?: string; baseUrl?: string; target?: string; models?: Record<string, { model_id: string }> }
   | { type: 'removeProvider'; providerId: string; target?: string }
   | { type: 'setSecret'; key: string; value: string }
   | { type: 'deleteSecret'; key: string }

--- a/packages/vscode/src/webviews/shared/types.ts
+++ b/packages/vscode/src/webviews/shared/types.ts
@@ -15,7 +15,7 @@ export type ProviderToHostMessage =
   | { type: 'deleteSecret'; key: string }
   | { type: 'listSecrets' }
   | { type: 'getKeyStatus'; source: string; name: string }
-  | { type: 'discoverModels'; engineId: string; providerId?: string }
+  | { type: 'discoverModels'; engineId: string; providerId?: string; apiKey?: string; baseUrl?: string }
   | { type: 'updateConfig'; config: unknown; location?: string };
 
 export type HostToProviderMessage =

--- a/packages/vscode/src/webviews/shared/types.ts
+++ b/packages/vscode/src/webviews/shared/types.ts
@@ -1,0 +1,122 @@
+// Message protocol types between webview and extension host.
+// All messages use a discriminated union on the `type` field.
+
+// ─── Provider Panel Messages ────────────────────────────────────────
+
+export type ProviderToHostMessage =
+  | { type: 'ready' }
+  | { type: 'getProviders' }
+  | { type: 'getProviderTemplates' }
+  | { type: 'getEngines' }
+  | { type: 'getConfig'; location?: string }
+  | { type: 'configureProvider'; providerId: string; engine?: string; apiKey?: string; envVarName?: string; baseUrl?: string; target?: string; models?: string[] }
+  | { type: 'removeProvider'; providerId: string; target?: string }
+  | { type: 'setSecret'; key: string; value: string }
+  | { type: 'deleteSecret'; key: string }
+  | { type: 'listSecrets' }
+  | { type: 'getKeyStatus'; source: string; name: string }
+  | { type: 'discoverModels'; engineId: string; providerId?: string }
+  | { type: 'updateConfig'; config: unknown; location?: string };
+
+export type HostToProviderMessage =
+  | { type: 'providers'; providers: ProviderInfo[] }
+  | { type: 'templates'; templates: ProviderTemplateInfo[] }
+  | { type: 'engines'; engines: EngineInfo[] }
+  | { type: 'config'; config: unknown; path: string }
+  | { type: 'configureResult'; success: boolean; error?: string; providerId: string }
+  | { type: 'secrets'; secrets: SecretInfoView[] }
+  | { type: 'keyStatus'; source: string; name: string; exists: boolean }
+  | { type: 'discoveredModels'; models: ModelInfo[] }
+  | { type: 'error'; message: string; context?: string };
+
+// ─── Chat Panel Messages ────────────────────────────────────────────
+
+export type ChatToHostMessage =
+  | { type: 'ready' }
+  | { type: 'listModels' }
+  | { type: 'listSessions' }
+  | { type: 'createSession'; model: string; topic?: string }
+  | { type: 'deleteSession'; sessionId: string }
+  | { type: 'getSession'; sessionId: string }
+  | { type: 'sendMessage'; sessionId: string; content: string; model?: string }
+  | { type: 'cancelStream' }
+  | { type: 'approveToolCall'; requestId: string; decision: 'allow' | 'deny' | 'abort' };
+
+export type HostToChatMessage =
+  | { type: 'models'; models: ModelInfo[] }
+  | { type: 'sessions'; sessions: SessionInfo[] }
+  | { type: 'sessionCreated'; session: SessionDetail }
+  | { type: 'sessionLoaded'; session: SessionDetail }
+  | { type: 'streamChunk'; text: string }
+  | { type: 'streamDone'; finishReason: string }
+  | { type: 'toolCall'; id: string; name: string; args: string }
+  | { type: 'toolResult'; callId: string; name: string; content: string; isError: boolean }
+  | { type: 'toolApprovalRequest'; requestId: string; toolName: string; promptText: string }
+  | { type: 'error'; message: string; context?: string };
+
+// ─── Shared view types (serializable subsets of proto types) ────────
+
+export interface ProviderInfo {
+  id: string;
+  engine: string;
+  configured: boolean;
+  healthy: boolean;
+  requiresKey: boolean;
+  baseUrl?: string;
+  modelCount: number;
+}
+
+export interface ProviderTemplateInfo {
+  id: string;
+  displayName: string;
+  engine: string;
+  requiresKey: boolean;
+  defaultBaseUrl?: string;
+  defaultEnvVar?: string;
+}
+
+export interface EngineInfo {
+  id: string;
+  requiresKey: boolean;
+  defaultBaseUrl?: string;
+  defaultEnvVar?: string;
+}
+
+export interface SecretInfoView {
+  key: string;
+  store: string;
+  hasValue: boolean;
+}
+
+export interface ModelInfo {
+  id: string;
+  provider: string;
+  name: string;
+  engine: string;
+}
+
+export interface SessionInfo {
+  id: string;
+  model: string;
+  topic: string;
+  messageCount: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SessionDetail extends SessionInfo {
+  messages: MessageInfo[];
+}
+
+export interface MessageInfo {
+  role: string;
+  content: string;
+  toolCalls?: ToolCallInfo[];
+  toolCallId?: string;
+}
+
+export interface ToolCallInfo {
+  id: string;
+  name: string;
+  arguments: string;
+}

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -16,5 +16,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "out", ".vscode-test", "**/__tests__/**"]
+  "exclude": ["node_modules", "out", ".vscode-test", "**/__tests__/**", "src/webview-ui/**"]
 }


### PR DESCRIPTION
## Summary

Add two native webviews to the VS Code extension for managing LLM providers and chatting with models, built with `@vscode-elements/elements` web components for native VS Code look and feel.

- **Provider Configuration Panel** — accordion-style form for engine selection, credentials, and model discovery with a dual-list (Available / Enabled) selector
- **Chat Sidebar** — Copilot-style chat with streaming markdown, syntax-highlighted code blocks, collapsible tool call cards, and tool approval gates (Allow/Deny/Abort)

### Design approach

- **Native webviews** using VS Code's webview API — no iframes, no embedded dashboards
- **Minimal capabilities** — webviews are thin UI shells; all business logic runs in the extension host via gRPC to the daemon
- **`@vscode-elements/elements`** for form controls (buttons, text fields, dropdowns, radio groups, badges, progress rings) — auto-inherits VS Code theming
- **Custom accordion** for collapsible sections (vscode-collapsible forces uppercase headings via shadow DOM)

## Changes

### Provider Panel
- Accordion form: Provider Setup (engine, name, base URL, API key via keychain or env var) and Select Models (discovery, search, dual-list selector)
- Provider list cards with status dots, engine badges, model counts, edit/delete actions
- Model discovery passes credentials from the form so new providers can discover models before saving
- Delete confirmation via VS Code native modal dialog

### Chat Sidebar
- Copilot-style message bubbles (user right-aligned, assistant left-aligned)
- Full markdown via `marked` with `highlight.js` syntax highlighting (8 languages)
- Tool call cards with Running/Used states, collapsible arguments/results
- Tool approval gates that block the stream until user responds
- Smart auto-scroll that pauses when user scrolls up
- Cancel button for active streams

### Infrastructure
- `esbuild.js`: Webview build context (IIFE format, browser platform)
- `tsconfig.json`: Excluded `src/webview-ui/` from tsc (esbuild handles bundling)
- `extension.ts`: Wired `ChatViewProvider` and `ProviderPanel` to commands; removed duplicate `openChat` command
- `client.ts`: Added `listEngines`, `setSecret`, `discoverModels` with credential passthrough

### Tests
- Unit tests for `getNonce`, `getWebviewContent`, `providerHandler`, `chatHandler` with mock helpers
- Updated smoke test to verify chat view registration
- Mock helpers: `mockDaemonClient.ts`, `mockWebview.ts`

### Documentation
- `docs/WEBVIEWS.md`: Design rationale, architecture, feature descriptions, message protocol
- `docs/TESTING.md`: VS Code extension test section with structure and mock patterns
- `docs/DEVELOPMENT.md`: Webview architecture and build commands

### Copilot Review Fixes
- Fix DOM selector in `addToolCard` and `createApprovalGate` to target `.msg-content` inside `.streaming`, preventing tool cards and approval gates from being appended outside the message layout
- Resolve pending approval promises with `abort` in `cancelActiveStream` before clearing the map, preventing a deadlock where `handleSendMessage` awaits a promise that never resolves
- Escape raw HTML blocks in marked renderer to prevent style injection from LLM output (defense-in-depth)
- Allow empty model selection to persist by checking `message.models !== undefined` instead of requiring non-empty keys
- Use correct field name `msg.promptText` for tool approval requests

## Test plan

- [x] `npm run lint` — passes clean
- [x] `npx tsc --noEmit` — no type errors
- [x] `node esbuild.js` — builds extension host + both webview bundles
- [ ] `npm test` — all unit and smoke tests pass
- [ ] Launch Extension Development Host (F5), open "Abbenay: Configure Providers" — verify accordion form, engine dropdown, model discovery with credentials
- [ ] Click Abbenay icon in activity bar — verify chat sidebar renders with welcome screen, model selector, input area
- [ ] Send a message in chat — verify streaming, markdown rendering, code blocks with syntax highlighting
- [ ] Test tool approval flow — verify Allow/Deny/Abort gates work correctly

Assisted-by: Claude Code/Cursor