### PR TITLE
fix(daemon): implement manual tool loop for Vertex AI multi-step calls

### DIFF
--- a/packages/daemon/src/core/engines.test.ts
+++ b/packages/daemon/src/core/engines.test.ts
@@ -60,7 +60,7 @@ describe('PROVIDER_LOADERS coverage', () => {
 });
 
 describe('sanitizeVertexRequestBody', () => {
-  it('should strip stream_options and stream fields', () => {
+  it('should strip stream_options but preserve stream field', () => {
     const input = JSON.stringify({
       messages: [{ role: 'user', content: 'hi' }],
       stream: true,
@@ -69,9 +69,9 @@ describe('sanitizeVertexRequestBody', () => {
     });
     const result = sanitizeVertexRequestBody(input);
     expect(result).not.toBeNull();
-    expect(result!.removed).toEqual(['stream_options', 'stream']);
+    expect(result!.removed).toEqual(['stream_options']);
     const parsed = JSON.parse(result!.body);
-    expect(parsed).not.toHaveProperty('stream');
+    expect(parsed).toHaveProperty('stream', true);
     expect(parsed).not.toHaveProperty('stream_options');
     expect(parsed).toHaveProperty('messages');
     expect(parsed).toHaveProperty('anthropic_version');
@@ -86,11 +86,10 @@ describe('sanitizeVertexRequestBody', () => {
     expect(sanitizeVertexRequestBody('not json')).toBeNull();
   });
 
-  it('should strip only stream when stream_options is absent', () => {
+  it('should return null when only stream is present (nothing to strip)', () => {
     const input = JSON.stringify({ messages: [], stream: true });
     const result = sanitizeVertexRequestBody(input);
-    expect(result).not.toBeNull();
-    expect(result!.removed).toEqual(['stream']);
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -161,7 +161,6 @@ export function sanitizeVertexRequestBody(bodyStr: string): { body: string; remo
   }
   const removed: string[] = [];
   if ('stream_options' in body) { delete body.stream_options; removed.push('stream_options'); }
-  if ('stream' in body) { delete body.stream; removed.push('stream'); }
 
   // Filter empty/whitespace text content blocks from messages — Vertex Anthropic rejects them.
   // This handles both string content (e.g. content: ' ') and array content
@@ -930,10 +929,7 @@ export async function* streamChat(
       aiTools = toolRecord;
     }
 
-    const streamOptions = {
-      model,
-      messages: aiMessages,
-      ...(aiTools ? { tools: aiTools, maxSteps } : {}),
+    const baseParams = {
       ...(params?.temperature != null ? { temperature: params.temperature } : {}),
       ...(params?.maxTokens != null ? { maxTokens: params.maxTokens } : {}),
       ...(params?.top_p != null ? { topP: params.top_p } : {}),
@@ -942,58 +938,105 @@ export async function* streamChat(
       ...(jsonMode ? { responseFormat: { type: 'json' as const } } : {}),
     };
 
-    const result = streamText(streamOptions);
+    let currentMessages = aiMessages;
+    let stepsRemaining = maxSteps;
 
-    // Iterate over the full stream and yield our ChatChunk format
-    let gotContent = false;
-    for await (const part of result.fullStream) {
-      switch (part.type) {
-        case 'text-delta':
-          if (part.text) {
-            yield { type: 'text', text: part.text };
-            gotContent = true;
+    while (stepsRemaining > 0) {
+      stepsRemaining--;
+      debug(`[Adapter] streamChat step: messages=${currentMessages.length}, stepsRemaining=${stepsRemaining}`);
+
+      const result = streamText({
+        model,
+        messages: currentMessages,
+        ...(aiTools ? { tools: aiTools } : {}),
+        ...baseParams,
+      });
+
+      let finishReason = '';
+      const pendingToolCalls: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; result: unknown }> = [];
+
+      for await (const part of result.fullStream) {
+        switch (part.type) {
+          case 'text-delta':
+            if (part.text) {
+              yield { type: 'text', text: part.text };
+            }
+            break;
+
+          case 'tool-call':
+            yield {
+              type: 'tool',
+              name: part.toolName,
+              state: 'running',
+              call: { params: part.input, result: undefined },
+              done: false,
+            };
+            break;
+
+          case 'tool-result':
+            pendingToolCalls.push({
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              args: part.input as Record<string, unknown>,
+              result: part.output,
+            });
+            yield {
+              type: 'tool',
+              name: part.toolName,
+              state: 'completed',
+              call: { params: part.input, result: part.output },
+              done: true,
+            };
+            break;
+
+          case 'error': {
+            console.error(`[Adapter] Stream error for ${engineId}/${engineModelId}:`, part.error);
+            const errMsg = part.error instanceof Error ? part.error.message
+              : typeof part.error === 'string' ? part.error
+              : JSON.stringify(part.error);
+            yield { type: 'error', error: errMsg };
+            break;
           }
-          break;
 
-        case 'tool-call':
-          yield {
-            type: 'tool',
-            name: part.toolName,
-            state: 'running',
-            call: { params: part.input, result: undefined },
-            done: false,
-          };
-          break;
-
-        case 'tool-result':
-          yield {
-            type: 'tool',
-            name: part.toolName,
-            state: 'completed',
-            call: { params: part.input, result: part.output },
-            done: true,
-          };
-          break;
-
-        case 'error': {
-          console.error(`[Adapter] Stream error for ${engineId}/${engineModelId}:`, part.error);
-          const errMsg = part.error instanceof Error ? part.error.message
-            : typeof part.error === 'string' ? part.error
-            : JSON.stringify(part.error);
-          yield { type: 'error', error: errMsg };
-          break;
+          case 'finish':
+            finishReason = part.finishReason || 'stop';
+            break;
         }
-
-        case 'finish':
-          yield { type: 'done', finishReason: part.finishReason || 'stop' };
-          return;
       }
+
+      if (finishReason !== 'tool-calls' || pendingToolCalls.length === 0) {
+        yield { type: 'done', finishReason: finishReason || 'stop' };
+        return;
+      }
+
+      debug(`[Adapter] tool-calls complete (${pendingToolCalls.length} calls), continuing to next step`);
+
+      // Build updated messages with assistant tool_calls and tool results for next round
+      currentMessages = [
+        ...currentMessages,
+        {
+          role: 'assistant' as const,
+          content: pendingToolCalls.map(tc => ({
+            type: 'tool-call' as const,
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+            input: tc.args,
+          })),
+        },
+        ...pendingToolCalls.map(tc => ({
+          role: 'tool' as const,
+          content: [{
+            type: 'tool-result' as const,
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+            output: { type: 'text' as const, value: typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result ?? '') },
+          }],
+        })),
+      ] as ModelMessage[];
     }
 
-    // If we got content but no explicit finish event, emit done
-    if (gotContent) {
-      yield { type: 'done', finishReason: 'stop' };
-    }
+    // Exhausted maxSteps
+    yield { type: 'done', finishReason: 'stop' };
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`[Adapter] Chat error for ${engineId}/${engineModelId}:`, errorMessage);

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -12,7 +12,7 @@
  * the built-in step loop (stopWhen). No wrapper classes required.
  */
 
-import { streamText, jsonSchema, tool } from 'ai';
+import { streamText, jsonSchema, tool, stepCountIs } from 'ai';
 import type { AssistantModelMessage, JSONSchema7, LanguageModel, ModelMessage, ToolSet } from 'ai';
 
 import { mockStreamChat, getMockModels } from './mock.js';
@@ -929,114 +929,61 @@ export async function* streamChat(
       aiTools = toolRecord;
     }
 
-    const baseParams = {
+    const result = streamText({
+      model,
+      messages: aiMessages,
+      ...(aiTools ? { tools: aiTools } : {}),
+      ...(maxSteps > 1 ? { stopWhen: stepCountIs(maxSteps) } : {}),
       ...(params?.temperature != null ? { temperature: params.temperature } : {}),
       ...(params?.maxTokens != null ? { maxTokens: params.maxTokens } : {}),
       ...(params?.top_p != null ? { topP: params.top_p } : {}),
       ...(params?.top_k != null ? { topK: params.top_k } : {}),
       ...(params?.timeout != null ? { timeout: params.timeout } : {}),
       ...(jsonMode ? { responseFormat: { type: 'json' as const } } : {}),
-    };
+    });
 
-    let currentMessages = aiMessages;
-    let stepsRemaining = maxSteps;
-
-    while (stepsRemaining > 0) {
-      stepsRemaining--;
-      debug(`[Adapter] streamChat step: messages=${currentMessages.length}, stepsRemaining=${stepsRemaining}`);
-
-      const result = streamText({
-        model,
-        messages: currentMessages,
-        ...(aiTools ? { tools: aiTools } : {}),
-        ...baseParams,
-      });
-
-      let finishReason = '';
-      const pendingToolCalls: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; result: unknown }> = [];
-
-      for await (const part of result.fullStream) {
-        switch (part.type) {
-          case 'text-delta':
-            if (part.text) {
-              yield { type: 'text', text: part.text };
-            }
-            break;
-
-          case 'tool-call':
-            yield {
-              type: 'tool',
-              name: part.toolName,
-              state: 'running',
-              call: { params: part.input, result: undefined },
-              done: false,
-            };
-            break;
-
-          case 'tool-result':
-            pendingToolCalls.push({
-              toolCallId: part.toolCallId,
-              toolName: part.toolName,
-              args: part.input as Record<string, unknown>,
-              result: part.output,
-            });
-            yield {
-              type: 'tool',
-              name: part.toolName,
-              state: 'completed',
-              call: { params: part.input, result: part.output },
-              done: true,
-            };
-            break;
-
-          case 'error': {
-            console.error(`[Adapter] Stream error for ${engineId}/${engineModelId}:`, part.error);
-            const errMsg = part.error instanceof Error ? part.error.message
-              : typeof part.error === 'string' ? part.error
-              : JSON.stringify(part.error);
-            yield { type: 'error', error: errMsg };
-            break;
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case 'text-delta':
+          if (part.text) {
+            yield { type: 'text', text: part.text };
           }
+          break;
 
-          case 'finish':
-            finishReason = part.finishReason || 'stop';
-            break;
+        case 'tool-call':
+          yield {
+            type: 'tool',
+            name: part.toolName,
+            state: 'running',
+            call: { params: part.input, result: undefined },
+            done: false,
+          };
+          break;
+
+        case 'tool-result':
+          yield {
+            type: 'tool',
+            name: part.toolName,
+            state: 'completed',
+            call: { params: part.input, result: part.output },
+            done: true,
+          };
+          break;
+
+        case 'error': {
+          console.error(`[Adapter] Stream error for ${engineId}/${engineModelId}:`, part.error);
+          const errMsg = part.error instanceof Error ? part.error.message
+            : typeof part.error === 'string' ? part.error
+            : JSON.stringify(part.error);
+          yield { type: 'error', error: errMsg };
+          break;
         }
+
+        case 'finish':
+          yield { type: 'done', finishReason: part.finishReason || 'stop' };
+          break;
       }
-
-      if (finishReason !== 'tool-calls' || pendingToolCalls.length === 0) {
-        yield { type: 'done', finishReason: finishReason || 'stop' };
-        return;
-      }
-
-      debug(`[Adapter] tool-calls complete (${pendingToolCalls.length} calls), continuing to next step`);
-
-      // Build updated messages with assistant tool_calls and tool results for next round
-      currentMessages = [
-        ...currentMessages,
-        {
-          role: 'assistant' as const,
-          content: pendingToolCalls.map(tc => ({
-            type: 'tool-call' as const,
-            toolCallId: tc.toolCallId,
-            toolName: tc.toolName,
-            input: tc.args,
-          })),
-        },
-        ...pendingToolCalls.map(tc => ({
-          role: 'tool' as const,
-          content: [{
-            type: 'tool-result' as const,
-            toolCallId: tc.toolCallId,
-            toolName: tc.toolName,
-            output: { type: 'text' as const, value: typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result ?? '') },
-          }],
-        })),
-      ] as ModelMessage[];
     }
-
-    // Exhausted maxSteps
-    yield { type: 'done', finishReason: 'stop' };
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`[Adapter] Chat error for ${engineId}/${engineModelId}:`, errorMessage);


### PR DESCRIPTION
## Summary

- Fix Vertex AI multi-step tool calling by enabling the AI SDK's native `stopWhen: stepCountIs(maxSteps)` for tool loop continuation. Previously, `streamText` defaulted to a single step (`stepCountIs(1)`), causing it to terminate after the first tool call without feeding results back to the model.
- Stop stripping the `stream` field from Vertex AI request bodies in `sanitizeVertexRequestBody`. Removing it caused Vertex to return `application/json` instead of `text/event-stream`, breaking the SDK's streaming parser entirely.
- Update tests to reflect the corrected sanitization behavior.

## Background

Two issues combined to break Vertex AI tool calling:

1. **Missing `stopWhen` configuration** — The AI SDK v6 defaults to `stepCountIs(1)`, meaning `streamText` only performs one step. When the model returned `finishReason: "tool-calls"`, the SDK correctly executed the tools but then stopped without making a second LLM call. Passing `stopWhen: stepCountIs(maxSteps)` enables the SDK's built-in multi-step loop.

2. **`stream` field stripped from request body** — `sanitizeVertexRequestBody` was removing `stream: true`, causing Vertex AI's `streamRawPredict` endpoint to return JSON instead of SSE. The SDK's `EventSourceParserStream` then produced no events, resulting in silent failures.

## Commits

- `fix(daemon): implement manual tool loop for Vertex AI multi-step calls` -- initial fix with stream field preservation
- `refactor(daemon): use SDK native stopWhen for multi-step tool loops` -- simplify by leveraging the SDK's built-in multi-step support

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test -w packages/daemon` passes locally (432/432 tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Manual validation: Vertex AI tool calls complete multi-step interactions successfully
- [ ] CI validation on upstream