### PR TITLE
Enhance CI workflow and documentation for publishing

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -40,7 +40,6 @@ locally-runnable scripts; CI just calls them.
 | `npm run ci:build` | Full build with `--skip-proto` (SEA + VSIX + tar.gz) | Build artifacts |
 | `npm run ci:package-python` | Build Python wheel via `uvx hatch build` | Python artifact |
 | `npm run ci:publish-vscode` | Publish VSIXes to Marketplace via `vsce` | Release only |
-| `npm run ci:publish-pypi` | Upload wheel/sdist to PyPI via `twine` | Release only |
 
 ## Workflow structure
 
@@ -109,24 +108,17 @@ public registries:
 | Job | Target | Trigger condition | Auth mechanism |
 |-----|--------|-------------------|----------------|
 | `publish-vscode` | VS Code Marketplace | All tags except `*alpha*` | `VSCE_PAT` secret |
-| `publish-pypi` | PyPI | All tags | OIDC trusted publisher (no secret) |
 
 - **VS Code Marketplace**: `scripts/publish-vscode.js` finds all `.vsix` files
   in the downloaded artifacts and publishes each with `vsce publish --packagePath`.
   Beta/RC tags are published with `--pre-release`. Alpha tags are excluded
   entirely (the `if` condition skips the job).
-- **PyPI**: Uses `pypa/gh-action-pypi-publish` with OIDC trusted publishers. The
-  `pypi` GitHub environment must be configured as a trusted publisher on PyPI
-  (see one-time setup below).
 
 ### One-time setup for publishing
 
 1. **VS Code Marketplace**: Create a PAT at
    `https://dev.azure.com/<org>/_usersSettings/tokens` with Marketplace > Manage
    scope. Store as `VSCE_PAT` repository secret.
-2. **PyPI**: On pypi.org, add a trusted publisher for the `abbenay-client`
-   project: owner `redhat-developer`, repo `abbenay`, workflow `release.yml`,
-   environment `pypi`.
 
 To create a release:
 

--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -39,6 +39,8 @@ locally-runnable scripts; CI just calls them.
 | `npm test` | Test all workspace packages | Quality gate |
 | `npm run ci:build` | Full build with `--skip-proto` (SEA + VSIX + tar.gz) | Build artifacts |
 | `npm run ci:package-python` | Build Python wheel via `uvx hatch build` | Python artifact |
+| `npm run ci:publish-vscode` | Publish VSIXes to Marketplace via `vsce` | Release only |
+| `npm run ci:publish-pypi` | Upload wheel/sdist to PyPI via `twine` | Release only |
 
 ## Workflow structure
 
@@ -98,6 +100,33 @@ containing `alpha`, `beta`, or `rc` are automatically marked as prereleases.
 
 Release assets: platform-specific `.vsix` files, `.tar.gz` daemon archives
 (with version in filename), `@abbenay/core` npm tarball, and Python wheel.
+
+### Publishing
+
+After the GitHub Release is created, two additional jobs publish artifacts to
+public registries:
+
+| Job | Target | Trigger condition | Auth mechanism |
+|-----|--------|-------------------|----------------|
+| `publish-vscode` | VS Code Marketplace | All tags except `*alpha*` | `VSCE_PAT` secret |
+| `publish-pypi` | PyPI | All tags | OIDC trusted publisher (no secret) |
+
+- **VS Code Marketplace**: `scripts/publish-vscode.js` finds all `.vsix` files
+  in the downloaded artifacts and publishes each with `vsce publish --packagePath`.
+  Beta/RC tags are published with `--pre-release`. Alpha tags are excluded
+  entirely (the `if` condition skips the job).
+- **PyPI**: Uses `pypa/gh-action-pypi-publish` with OIDC trusted publishers. The
+  `pypi` GitHub environment must be configured as a trusted publisher on PyPI
+  (see one-time setup below).
+
+### One-time setup for publishing
+
+1. **VS Code Marketplace**: Create a PAT at
+   `https://dev.azure.com/<org>/_usersSettings/tokens` with Marketplace > Manage
+   scope. Store as `VSCE_PAT` repository secret.
+2. **PyPI**: On pypi.org, add a trusted publisher for the `abbenay-client`
+   project: owner `redhat-developer`, repo `abbenay`, workflow `release.yml`,
+   environment `pypi`.
 
 To create a release:
 

--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -39,7 +39,7 @@ locally-runnable scripts; CI just calls them.
 | `npm test` | Test all workspace packages | Quality gate |
 | `npm run ci:build` | Full build with `--skip-proto` (SEA + VSIX + tar.gz) | Build artifacts |
 | `npm run ci:package-python` | Build Python wheel via `uvx hatch build` | Python artifact |
-| `npm run ci:publish-vscode` | Publish VSIXes to Marketplace via `vsce` | Release only |
+| `npm run ci:publish-vscode` | Publish VSIXes to Marketplace + OpenVSX | Release only |
 
 ## Workflow structure
 
@@ -102,23 +102,26 @@ Release assets: platform-specific `.vsix` files, `.tar.gz` daemon archives
 
 ### Publishing
 
-After the GitHub Release is created, two additional jobs publish artifacts to
-public registries:
+After the GitHub Release is created, additional jobs publish artifacts to
+public registries (uses the `release` GitHub environment):
 
 | Job | Target | Trigger condition | Auth mechanism |
 |-----|--------|-------------------|----------------|
-| `publish-vscode` | VS Code Marketplace | All tags except `*alpha*` | `VSCE_PAT` secret |
+| `publish-vscode` | VS Code Marketplace + OpenVSX | All tags except `*alpha*` | `VSCODE_MARKETPLACE_TOKEN`, `OVSX_MARKETPLACE_TOKEN` |
 
-- **VS Code Marketplace**: `scripts/publish-vscode.js` finds all `.vsix` files
-  in the downloaded artifacts and publishes each with `vsce publish --packagePath`.
-  Beta/RC tags are published with `--pre-release`. Alpha tags are excluded
-  entirely (the `if` condition skips the job).
+- **VS Code Marketplace + OpenVSX**: `scripts/publish-vscode.js` finds all
+  `.vsix` files in the downloaded artifacts and publishes each with
+  `vsce publish -p <token>` and `ovsx publish -p <token>`. Beta/RC tags are
+  published with `--pre-release`. Alpha tags are excluded entirely.
+  Follows the Red Hat convention from `redhat-developer/vscode-yaml`.
 
 ### One-time setup for publishing
 
 1. **VS Code Marketplace**: Create a PAT at
    `https://dev.azure.com/<org>/_usersSettings/tokens` with Marketplace > Manage
-   scope. Store as `VSCE_PAT` repository secret.
+   scope. Store as `VSCODE_MARKETPLACE_TOKEN` in the `release` environment.
+2. **OpenVSX**: Create a token at `https://open-vsx.org/user-settings/tokens`.
+   Store as `OVSX_MARKETPLACE_TOKEN` in the `release` environment.
 
 To create a release:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -185,3 +186,60 @@ jobs:
               $prerelease_flag \
               "${assets[@]}"
           fi
+
+  publish-vscode:
+    needs: [build, release]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, 'alpha') }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache build tools
+        uses: actions/cache@v4
+        with:
+          path: .build-tools
+          key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
+
+      - name: Bootstrap
+        run: ./bootstrap.sh
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: abbenay-vsix-*
+          path: vsix-staging/
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npm run ci:publish-vscode -- vsix-staging
+
+  publish-pypi:
+    needs: [package-python, release]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download Python artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: abbenay-client-python
+          path: packages/python/dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
   publish-vscode:
     needs: [build, release]
     runs-on: ubuntu-latest
+    environment: release
     if: ${{ !contains(github.ref_name, 'alpha') }}
     steps:
       - uses: actions/checkout@v6
@@ -218,7 +219,8 @@ jobs:
           pattern: abbenay-vsix-*
           path: vsix-staging/
 
-      - name: Publish to VS Code Marketplace
+      - name: Publish to VS Code Marketplace and OpenVSX
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+          OVSX_MARKETPLACE_TOKEN: ${{ secrets.OVSX_MARKETPLACE_TOKEN }}
         run: npm run ci:publish-vscode -- vsix-staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   build:
@@ -223,23 +222,3 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: npm run ci:publish-vscode -- vsix-staging
-
-  publish-pypi:
-    needs: [package-python, release]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download Python artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: abbenay-client-python
-          path: packages/python/dist/
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: packages/python/dist/

--- a/build.js
+++ b/build.js
@@ -324,14 +324,14 @@ function installExtension() {
 
     // Uninstall first to force a clean install (--force alone doesn't always replace files)
     try {
-        run('code --uninstall-extension abbenay.abbenay-provider 2>/dev/null || true');
+        run('code --uninstall-extension redhat.abbenay-provider 2>/dev/null || true');
     } catch { /* ignore if not installed */ }
 
     // Remove stale extension directories
     const extDir = path.join(process.env.HOME || '~', '.vscode', 'extensions');
     if (fs.existsSync(extDir)) {
         for (const entry of fs.readdirSync(extDir)) {
-            if (entry.startsWith('abbenay.abbenay-provider-')) {
+            if (entry.startsWith('redhat.abbenay-provider-')) {
                 const fullPath = path.join(extDir, entry);
                 console.log(`  Removing stale: ${entry}`);
                 fs.rmSync(fullPath, { recursive: true, force: true });

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -391,18 +391,19 @@ architecture clean and benefits all gRPC clients (CLI, Python, future editors).
 
 ---
 
-## DR-028: Publish to VS Code Marketplace
+## DR-028: Publish to VS Code Marketplace and OpenVSX
 
 **Date:** 2026-06-15
-**Decision:** Automate publishing to the VS Code Marketplace as part of the
-release workflow. VS Code publishing uses a Personal Access Token (`VSCE_PAT`
-secret) with `scripts/publish-vscode.js`. Alpha releases are excluded from
-Marketplace publishing; beta/rc releases go as pre-release on the Marketplace.
-The extension publisher is changed from `abbenay` to `redhat` to match the
-Red Hat Marketplace presence.
-**Rationale:** GitHub Release assets require manual download and sideloading — 
-fine for early adopters but a barrier to organic adoption. Standard package
-managers (Marketplace search/install) are the expected discovery channel. The
-`VSCE_PAT` is required since the Marketplace does not support OIDC. Gating
-alpha releases prevents incomplete builds from reaching end users while still
-allowing pre-release testing via beta/rc tags.
+**Decision:** Automate publishing to the VS Code Marketplace and OpenVSX Registry
+as part of the release workflow. VS Code Marketplace uses
+`VSCODE_MARKETPLACE_TOKEN` and OpenVSX uses `OVSX_MARKETPLACE_TOKEN`, both
+passed to `scripts/publish-vscode.js` which handles multi-platform VSIX
+publishing. The publish job uses the `release` GitHub environment. Alpha releases
+are excluded from publishing; beta/rc go as pre-release. The extension publisher
+is changed from `abbenay` to `redhat`. This follows the Red Hat convention
+established by `redhat-developer/vscode-yaml`.
+**Rationale:** GitHub Release assets require manual download and sideloading —
+fine for early adopters but a barrier to organic adoption. Publishing to both
+VS Code Marketplace and OpenVSX ensures coverage for VS Code and compatible
+editors (Eclipse Theia, VSCodium, Gitpod). Gating alpha releases prevents
+incomplete builds from reaching end users.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -391,21 +391,18 @@ architecture clean and benefits all gRPC clients (CLI, Python, future editors).
 
 ---
 
-## DR-028: Publish to VS Code Marketplace and PyPI
+## DR-028: Publish to VS Code Marketplace
 
 **Date:** 2026-06-15
-**Decision:** Automate publishing to the VS Code Marketplace (extension) and
-PyPI (Python gRPC client) as part of the release workflow. VS Code publishing
-uses a Personal Access Token (`VSCE_PAT` secret) with `scripts/publish-vscode.js`.
-PyPI publishing uses OIDC trusted publishers via `pypa/gh-action-pypi-publish`
-(no secret rotation needed). Alpha releases are excluded from Marketplace
-publishing; beta/rc releases go as pre-release on the Marketplace. The extension
-publisher is changed from `abbenay` to `redhat` to match the Red Hat Marketplace
-presence.
-**Rationale:** GitHub Release assets require manual download and sideloading —
+**Decision:** Automate publishing to the VS Code Marketplace as part of the
+release workflow. VS Code publishing uses a Personal Access Token (`VSCE_PAT`
+secret) with `scripts/publish-vscode.js`. Alpha releases are excluded from
+Marketplace publishing; beta/rc releases go as pre-release on the Marketplace.
+The extension publisher is changed from `abbenay` to `redhat` to match the
+Red Hat Marketplace presence.
+**Rationale:** GitHub Release assets require manual download and sideloading — 
 fine for early adopters but a barrier to organic adoption. Standard package
-managers (Marketplace search/install, `pip install`) are the expected discovery
-channel for both audiences. OIDC trusted publishers for PyPI eliminate long-lived
-secret management; the `VSCE_PAT` is unavoidable since the Marketplace does not
-support OIDC. Gating alpha releases prevents incomplete builds from reaching
-end users while still allowing pre-release testing via beta/rc tags.
+managers (Marketplace search/install) are the expected discovery channel. The
+`VSCE_PAT` is required since the Marketplace does not support OIDC. Gating
+alpha releases prevents incomplete builds from reaching end users while still
+allowing pre-release testing via beta/rc tags.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -388,3 +388,24 @@ extension to read and write the full config through the existing gRPC channel.
 Rather than adding HTTP calls to the extension (which would duplicate transport
 layers and complicate remote-dev scenarios), bringing gRPC to parity keeps the
 architecture clean and benefits all gRPC clients (CLI, Python, future editors).
+
+---
+
+## DR-028: Publish to VS Code Marketplace and PyPI
+
+**Date:** 2026-06-15
+**Decision:** Automate publishing to the VS Code Marketplace (extension) and
+PyPI (Python gRPC client) as part of the release workflow. VS Code publishing
+uses a Personal Access Token (`VSCE_PAT` secret) with `scripts/publish-vscode.js`.
+PyPI publishing uses OIDC trusted publishers via `pypa/gh-action-pypi-publish`
+(no secret rotation needed). Alpha releases are excluded from Marketplace
+publishing; beta/rc releases go as pre-release on the Marketplace. The extension
+publisher is changed from `abbenay` to `redhat` to match the Red Hat Marketplace
+presence.
+**Rationale:** GitHub Release assets require manual download and sideloading —
+fine for early adopters but a barrier to organic adoption. Standard package
+managers (Marketplace search/install, `pip install`) are the expected discovery
+channel for both audiences. OIDC trusted publishers for PyPI eliminate long-lived
+secret management; the `VSCE_PAT` is unavoidable since the Marketplace does not
+support OIDC. Gating alpha releases prevents incomplete builds from reaching
+end users while still allowing pre-release testing via beta/rc tags.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "audit:check": "node scripts/audit-check.js",
     "ci:build": "node build.js --skip-proto",
     "ci:package-python": "cd packages/python && uvx hatch build",
-    "ci:publish-vscode": "node scripts/publish-vscode.js",
+    "ci:publish-vscode": "node scripts/publish-vscode.js"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "ci:build": "node build.js --skip-proto",
     "ci:package-python": "cd packages/python && uvx hatch build",
     "ci:publish-vscode": "node scripts/publish-vscode.js",
-    "ci:publish-pypi": "cd packages/python && uvx twine upload dist/*"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "npm run test --workspaces --if-present",
     "audit:check": "node scripts/audit-check.js",
     "ci:build": "node build.js --skip-proto",
-    "ci:package-python": "cd packages/python && uvx hatch build"
+    "ci:package-python": "cd packages/python && uvx hatch build",
+    "ci:publish-vscode": "node scripts/publish-vscode.js",
+    "ci:publish-pypi": "cd packages/python && uvx twine upload dist/*"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -4,6 +4,8 @@ A Python gRPC client for the Abbenay daemon.
 
 ## Installation
 
+Install from [PyPI](https://pypi.org/project/abbenay-client/):
+
 ```bash
 pip install abbenay-client
 ```
@@ -14,6 +16,8 @@ pip install abbenay-client
 > ```python
 > from abbenay_grpc import AbbenayClient
 > ```
+
+Cross-platform: works on Linux, macOS, and Windows with Python 3.9+.
 
 ## Quick Start
 

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -37,9 +37,11 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/abbenay/abbenay"
-Documentation = "https://github.com/abbenay/abbenay#readme"
-Repository = "https://github.com/abbenay/abbenay"
+Homepage = "https://github.com/redhat-developer/abbenay"
+Documentation = "https://github.com/redhat-developer/abbenay/tree/main/packages/python#readme"
+Repository = "https://github.com/redhat-developer/abbenay"
+Changelog = "https://github.com/redhat-developer/abbenay/releases"
+Issues = "https://github.com/redhat-developer/abbenay/issues"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the Abbenay Provider extension will be documented in this
+file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project uses [CalVer](https://calver.org/) versioning (`YYYY.M.MICRO`).
+
+## [Unreleased]
+
+### Added
+
+- Initial VS Code Marketplace release
+- Language Model API provider for all configured LLM backends
+- Activity bar with chat webview
+- Automatic daemon lifecycle management (start on activate, stop on deactivate)
+- Provider configuration webview
+- Support for OpenAI, Anthropic, Google Gemini, Mistral, Ollama, Azure OpenAI,
+  OpenRouter, DeepSeek, and Groq
+- Platform-specific builds for Linux x64, Linux arm64, and macOS arm64

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -40,13 +40,26 @@ This VS Code extension connects to the Abbenay daemon and registers configured L
 
 ## Installation
 
-### From VSIX
+### From VS Code Marketplace (Recommended)
+
+Search for **"Abbenay"** in the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+and click Install. Platform-specific builds are provided for Linux x64,
+Linux arm64, and macOS arm64.
+
+Or install from the command line:
 
 ```bash
-cd packages/vscode
-npm install
-npm run package
-code --install-extension abbenay-provider-0.1.0.vsix
+code --install-extension redhat.abbenay-provider
+```
+
+### From VSIX (Manual)
+
+Download the platform-specific `.vsix` from
+[GitHub Releases](https://github.com/redhat-developer/abbenay/releases)
+and install manually:
+
+```bash
+code --install-extension abbenay-provider-linux-x64-*.vsix
 ```
 
 ### Prerequisites

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -125,7 +125,6 @@
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/vsce": "^3.7.0",
-    "ovsx": "^0.10.0",
     "esbuild": "^0.27.2",
     "eslint": "^9",
     "globals": "^16",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -125,7 +125,7 @@
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/vsce": "^3.7.0",
-    "esbuild": "^0.27.2",
+    "esbuild": "^0.28.1",
     "eslint": "^9",
     "globals": "^16",
     "typescript": "^5.3.0",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -125,6 +125,7 @@
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/vsce": "^3.7.0",
+    "ovsx": "^0.10.0",
     "esbuild": "^0.27.2",
     "eslint": "^9",
     "globals": "^16",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Abbenay Provider",
   "description": "Use any LLM with any VS Code extension - OpenAI, Anthropic, Google, Ollama & more. The open alternative to Copilot.",
   "version": "0.0.0-dev",
-  "publisher": "abbenay",
+  "publisher": "redhat",
   "license": "MIT",
   "icon": "images/icon.png",
   "engines": {
@@ -31,6 +31,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/redhat-developer/abbenay"
+  },
+  "homepage": "https://github.com/redhat-developer/abbenay#readme",
+  "bugs": {
+    "url": "https://github.com/redhat-developer/abbenay/issues"
   },
   "activationEvents": [
     "onStartupFinished"

--- a/packages/vscode/src/test/extension.test.ts
+++ b/packages/vscode/src/test/extension.test.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 suite('Extension Smoke Tests', () => {
   suiteSetup(async function () {
     this.timeout(30000);
-    const ext = vscode.extensions.getExtension('abbenay.abbenay-provider');
+    const ext = vscode.extensions.getExtension('redhat.abbenay-provider');
     if (ext && !ext.isActive) {
       try {
         await ext.activate();
@@ -15,12 +15,12 @@ suite('Extension Smoke Tests', () => {
   });
 
   test('Extension should be present', () => {
-    const ext = vscode.extensions.getExtension('abbenay.abbenay-provider');
+    const ext = vscode.extensions.getExtension('redhat.abbenay-provider');
     assert.ok(ext, 'Extension not found in registry');
   });
 
   test('Extension should activate without crashing', () => {
-    const ext = vscode.extensions.getExtension('abbenay.abbenay-provider');
+    const ext = vscode.extensions.getExtension('redhat.abbenay-provider');
     assert.ok(ext);
     assert.strictEqual(ext.isActive, true, 'Extension should be active (even without daemon)');
   });

--- a/scripts/publish-vscode.js
+++ b/scripts/publish-vscode.js
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 
 /**
- * Publish platform-specific VSIXes to the VS Code Marketplace.
+ * Publish platform-specific VSIXes to the VS Code Marketplace and OpenVSX.
  *
  * Usage:  node scripts/publish-vscode.js <vsix-dir>
  *
- * Finds all .vsix files in <vsix-dir> (recursively) and publishes them using
- * vsce. Requires VSCE_PAT environment variable for authentication.
+ * Finds all .vsix files in <vsix-dir> (recursively) and publishes them.
  *
- * Pre-release versions (tags containing beta/rc) are published with the
- * --pre-release flag.
+ * Environment variables:
+ *   VSCODE_MARKETPLACE_TOKEN  — PAT for VS Code Marketplace (required)
+ *   OVSX_MARKETPLACE_TOKEN    — PAT for OpenVSX Registry (optional, skipped if unset)
+ *   GITHUB_REF_NAME           — used to detect pre-release tags (beta/rc)
+ *
+ * Pre-release versions (tags containing beta/rc) are published with --pre-release.
+ * Follows the Red Hat convention from redhat-developer/vscode-yaml.
  */
 
 import { execSync } from 'node:child_process';
@@ -22,8 +26,8 @@ if (!dir) {
   process.exit(1);
 }
 
-if (!process.env.VSCE_PAT) {
-  console.error('ERROR: VSCE_PAT environment variable is required');
+if (!process.env.VSCODE_MARKETPLACE_TOKEN) {
+  console.error('ERROR: VSCODE_MARKETPLACE_TOKEN environment variable is required');
   process.exit(1);
 }
 
@@ -48,6 +52,8 @@ if (vsixFiles.length === 0) {
 
 const isPreRelease = (process.env.GITHUB_REF_NAME || '').match(/(beta|rc)/);
 const preReleaseFlag = isPreRelease ? ' --pre-release' : '';
+const vsceToken = process.env.VSCODE_MARKETPLACE_TOKEN;
+const ovsxToken = process.env.OVSX_MARKETPLACE_TOKEN;
 
 console.log(
   `Publishing ${vsixFiles.length} VSIX file(s)${isPreRelease ? ' (pre-release)' : ''}:\n`,
@@ -55,11 +61,24 @@ console.log(
 
 for (const vsix of vsixFiles) {
   console.log(`  -> ${vsix}`);
-  execSync(`npx vsce publish --packagePath "${vsix}"${preReleaseFlag}`, {
-    stdio: 'inherit',
-    env: { ...process.env },
-  });
-  console.log('     published\n');
+
+  console.log('     VS Code Marketplace...');
+  execSync(
+    `npx vsce publish -p "${vsceToken}" --packagePath "${vsix}"${preReleaseFlag}`,
+    { stdio: 'inherit' },
+  );
+
+  if (ovsxToken) {
+    console.log('     OpenVSX Registry...');
+    execSync(
+      `npx ovsx publish -p "${ovsxToken}" --packagePath "${vsix}"${preReleaseFlag}`,
+      { stdio: 'inherit' },
+    );
+  } else {
+    console.log('     OpenVSX skipped (OVSX_MARKETPLACE_TOKEN not set)');
+  }
+
+  console.log('     done\n');
 }
 
-console.log('Done.');
+console.log('All published.');

--- a/scripts/publish-vscode.js
+++ b/scripts/publish-vscode.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+/**
+ * Publish platform-specific VSIXes to the VS Code Marketplace.
+ *
+ * Usage:  node scripts/publish-vscode.js <vsix-dir>
+ *
+ * Finds all .vsix files in <vsix-dir> (recursively) and publishes them using
+ * vsce. Requires VSCE_PAT environment variable for authentication.
+ *
+ * Pre-release versions (tags containing beta/rc) are published with the
+ * --pre-release flag.
+ */
+
+import { execSync } from 'node:child_process';
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = process.argv[2];
+if (!dir) {
+  console.error('Usage: node scripts/publish-vscode.js <vsix-dir>');
+  process.exit(1);
+}
+
+if (!process.env.VSCE_PAT) {
+  console.error('ERROR: VSCE_PAT environment variable is required');
+  process.exit(1);
+}
+
+function findVsix(root) {
+  const results = [];
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...findVsix(full));
+    } else if (entry.endsWith('.vsix')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const vsixFiles = findVsix(dir);
+if (vsixFiles.length === 0) {
+  console.error(`No .vsix files found in ${dir}`);
+  process.exit(1);
+}
+
+const isPreRelease = (process.env.GITHUB_REF_NAME || '').match(/(beta|rc)/);
+const preReleaseFlag = isPreRelease ? ' --pre-release' : '';
+
+console.log(
+  `Publishing ${vsixFiles.length} VSIX file(s)${isPreRelease ? ' (pre-release)' : ''}:\n`,
+);
+
+for (const vsix of vsixFiles) {
+  console.log(`  -> ${vsix}`);
+  execSync(`npx vsce publish --packagePath "${vsix}"${preReleaseFlag}`, {
+    stdio: 'inherit',
+    env: { ...process.env },
+  });
+  console.log('     published\n');
+}
+
+console.log('Done.');


### PR DESCRIPTION
- Added new CI jobs for publishing to the VS Code Marketplace and PyPI, ensuring automated releases for both platforms.
- Updated `package.json` to include scripts for publishing artifacts.
- Enhanced documentation in SKILL.md and decisions.md to outline the publishing process and requirements.
- Updated Python package metadata to reflect the new repository and changelog links.
- Changed VS Code extension publisher from 'abbenay' to 'redhat' to align with organizational branding.