### PR TITLE
fix(deps): bump @grpc/grpc-js to 1.14.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1805,9 +1805,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",


### PR DESCRIPTION
## Summary

- Bump @grpc/grpc-js from 1.14.3 to 1.14.4 (lockfile-only, all workspace ranges already cover it)
- Resolves Dependabot alerts #71 and #72
  - GHSA-99f4-grh7-6pcq (CVE-2026-48069): malformed compressed message crashes client/server
  - GHSA-5375-pq7m-f5r2 (CVE-2026-48068): malformed request crashes server
- Alert severity: **high** (both)

## Commits

- `fix(deps): bump @grpc/grpc-js to 1.14.4` -- resolves two high-severity gRPC crash vulnerabilities

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test` passes locally (434 daemon + 24 vscode tests)
- [x] `npm run ci:build` passes locally (SEA + VSIX)
- [ ] CI passes on PR