### PR TITLE
fix(deps): bump uuid to 11.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10872,16 +10872,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -11909,7 +11909,7 @@
         "express": "^4.21.0",
         "js-yaml": "^4.1.0",
         "keytar": "^7.9.0",
-        "uuid": "^10.0.0",
+        "uuid": "^11.1.1",
         "zod": "^3.25.0"
       },
       "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -45,7 +45,7 @@
     "express": "^4.21.0",
     "js-yaml": "^4.1.0",
     "keytar": "^7.9.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.1",
     "zod": "^3.25.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bump uuid from ^10.0.0 to ^11.1.1 in packages/daemon (major version)
- Resolves: GHSA-wmmm-f939-6g9c, GHSA-458j-xx4x-4375 (medium)
- Only `v4` is used via ESM `import { v4 as uuidv4 }` -- no breaking API changes apply

## Commits

- `fix(deps): bump uuid to 11.1.1` -- resolve 2 medium buffer bounds advisories

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test` passes locally (434 daemon + 24 vscode tests)
- [x] `npm run ci:build` passes locally
- [ ] CI passes on PR