### PR TITLE
feat: add PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,24 @@ jobs:
           name: abbenay-client-python
           path: packages/python/dist/
 
+  publish-python:
+    needs: [package-python]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download Python artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: abbenay-client-python
+          path: dist/
+
+      - name: Publish to pypi.org
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
   release:
     needs: [build, package-python]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `publish-python` job to `release.yml` using OIDC Trusted Publishing via `pypa/gh-action-pypi-publish`
- Fix project URLs in `pyproject.toml` (pointed to wrong repo)

## Prerequisites
- `pypi` environment created in GitHub repo settings
- Trusted Publisher configured on pypi.org for this repo

Resolves: AAP-78603