### PR TITLE
feat: implement interactive model picker for CLI chat

### DIFF
--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -1,8 +1,10 @@
 /**
- * Interactive CLI chat — `aby chat -m <model>`
+ * Interactive CLI chat — `aby chat`
  *
  * Starts the daemon in-process if not already running, then enters a
  * readline-based REPL that streams responses to stdout.
+ *
+ * When --model is omitted, an interactive model picker is displayed.
  *
  * All tool calls require approval by default (secure-by-default, DR-019).
  * Users can choose "allow always" to session-approve a tool for the
@@ -287,5 +289,49 @@ function promptApproval(rl: readline.Interface): Promise<'allow' | 'allow-always
     };
 
     rl.once('line', handler);
+  });
+}
+
+// ── Model picker ──────────────────────────────────────────────────────
+
+export interface PickerModel {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+export function parseModelPickerInput(raw: string, count: number): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return 1;
+  const num = Number(trimmed);
+  if (!Number.isInteger(num) || num < 1 || num > count) return null;
+  return num;
+}
+
+export function promptModelPicker(
+  models: PickerModel[],
+  rl: readline.Interface,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    process.stderr.write(`\n${BOLD}Available models:${RESET}\n`);
+    for (let i = 0; i < models.length; i++) {
+      const marker = i === 0 ? ` ${DIM}(default)${RESET}` : '';
+      process.stderr.write(`  ${CYAN}[${i + 1}]${RESET} ${models[i].id}${marker}\n`);
+    }
+    process.stderr.write(`\n${YELLOW}Select a model [1]:${RESET} `);
+
+    const handler = (line: string) => {
+      const choice = parseModelPickerInput(line, models.length);
+      if (choice !== null) {
+        resolve(models[choice - 1].id);
+      } else {
+        process.stderr.write(`${RED}Invalid choice. Enter 1–${models.length}.${RESET}\n`);
+        process.stderr.write(`${YELLOW}Select a model [1]:${RESET} `);
+        rl.once('line', handler);
+      }
+    };
+
+    rl.once('line', handler);
+    rl.once('close', () => resolve(null));
   });
 }

--- a/packages/daemon/src/daemon/chat.ts
+++ b/packages/daemon/src/daemon/chat.ts
@@ -19,13 +19,15 @@ import { SessionStore } from '../core/session-store.js';
 import { maybeSummarize } from '../core/session-summarizer.js';
 import type { ChatToolOptions } from '../core/state.js';
 
-interface ChatOptions {
+export interface ChatOptions {
   model?: string;
   session?: string;
   system?: string;
   policy?: string;
   tools?: boolean;
   json?: boolean;
+  /** Pre-initialized state from model picker — avoids a second daemon startup. */
+  state?: import('./state.js').DaemonState;
 }
 
 const RESET  = '\x1b[0m';
@@ -39,7 +41,9 @@ const RED    = '\x1b[31m';
 export async function runInteractiveChat(options: ChatOptions): Promise<void> {
   let state: DaemonState;
 
-  if (isDaemonRunningSync()) {
+  if (options.state) {
+    state = options.state;
+  } else if (isDaemonRunningSync()) {
     console.error(`${DIM}Daemon already running — using in-process state...${RESET}`);
     state = new DaemonState();
   } else {

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -286,9 +286,10 @@ program
   .action(async (options) => {
     if (!options.model && !options.session) {
       const { selectModel } = await import('./model-picker.js');
-      const picked = await selectModel();
-      if (!picked) process.exit(1);
-      options.model = picked;
+      const result = await selectModel();
+      if (!result) process.exit(1);
+      options.model = result.model;
+      options.state = result.state;
     }
     const { runInteractiveChat } = await import('./chat.js');
     await runInteractiveChat(options);

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -285,8 +285,10 @@ program
   .option('--json', 'Output raw JSON chunks (for piping)')
   .action(async (options) => {
     if (!options.model && !options.session) {
-      console.error('Either --model or --session is required');
-      process.exit(1);
+      const { selectModel } = await import('./model-picker.js');
+      const picked = await selectModel();
+      if (!picked) process.exit(1);
+      options.model = picked;
     }
     const { runInteractiveChat } = await import('./chat.js');
     await runInteractiveChat(options);

--- a/packages/daemon/src/daemon/model-picker.test.ts
+++ b/packages/daemon/src/daemon/model-picker.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  parseModelPickerInput,
+  promptModelPicker,
+  type PickerModel,
+} from './chat.js';
+
+// ── parseModelPickerInput ─────────────────────────────────────────────
+
+describe('parseModelPickerInput', () => {
+  it('empty input selects default (1)', () => {
+    expect(parseModelPickerInput('', 3)).toBe(1);
+    expect(parseModelPickerInput('  ', 3)).toBe(1);
+  });
+
+  it('valid number in range', () => {
+    expect(parseModelPickerInput('2', 3)).toBe(2);
+    expect(parseModelPickerInput(' 3 ', 3)).toBe(3);
+  });
+
+  it('out of range returns null', () => {
+    expect(parseModelPickerInput('0', 3)).toBeNull();
+    expect(parseModelPickerInput('4', 3)).toBeNull();
+    expect(parseModelPickerInput('-1', 3)).toBeNull();
+  });
+
+  it('non-numeric returns null', () => {
+    expect(parseModelPickerInput('abc', 3)).toBeNull();
+    expect(parseModelPickerInput('1.5', 3)).toBeNull();
+  });
+
+  it('single model — only 1 is valid', () => {
+    expect(parseModelPickerInput('1', 1)).toBe(1);
+    expect(parseModelPickerInput('', 1)).toBe(1);
+    expect(parseModelPickerInput('2', 1)).toBeNull();
+  });
+});
+
+// ── promptModelPicker ─────────────────────────────────────────────────
+
+function makeModels(...ids: string[]): PickerModel[] {
+  return ids.map((id) => {
+    const [provider, ...rest] = id.split('/');
+    return { id, name: rest.join('/'), provider };
+  });
+}
+
+function fakeRl(): EventEmitter & { once: ReturnType<typeof vi.fn> } {
+  return new EventEmitter() as EventEmitter & { once: ReturnType<typeof vi.fn> };
+}
+
+describe('promptModelPicker', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  it('selects model by number', async () => {
+    const rl = fakeRl();
+    const models = makeModels('openai/gpt-4o', 'anthropic/claude-sonnet');
+    const promise = promptModelPicker(models, rl as never);
+
+    rl.emit('line', '2');
+    const result = await promise;
+    expect(result).toBe('anthropic/claude-sonnet');
+  });
+
+  it('selects default on empty input', async () => {
+    const rl = fakeRl();
+    const models = makeModels('openai/gpt-4o', 'anthropic/claude-sonnet');
+    const promise = promptModelPicker(models, rl as never);
+
+    rl.emit('line', '');
+    const result = await promise;
+    expect(result).toBe('openai/gpt-4o');
+  });
+
+  it('re-prompts on invalid input then accepts valid', async () => {
+    const rl = fakeRl();
+    const models = makeModels('openai/gpt-4o', 'anthropic/claude-sonnet');
+    const promise = promptModelPicker(models, rl as never);
+
+    rl.emit('line', '9');
+    // After invalid input, it re-registers a handler
+    await new Promise((r) => setTimeout(r, 10));
+    rl.emit('line', '1');
+    const result = await promise;
+    expect(result).toBe('openai/gpt-4o');
+  });
+
+  it('returns null on close (cancellation)', async () => {
+    const rl = fakeRl();
+    const models = makeModels('openai/gpt-4o');
+    const promise = promptModelPicker(models, rl as never);
+
+    rl.emit('close');
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+
+  it('displays all model IDs in picker output', async () => {
+    const rl = fakeRl();
+    const models = makeModels('openai/gpt-4o', 'anthropic/claude-sonnet', 'ollama/llama3');
+    const promise = promptModelPicker(models, rl as never);
+
+    rl.emit('line', '');
+    await promise;
+
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toContain('openai/gpt-4o');
+    expect(output).toContain('anthropic/claude-sonnet');
+    expect(output).toContain('ollama/llama3');
+    expect(output).toContain('(default)');
+  });
+
+  it('single model — Enter selects it', async () => {
+    const rl = fakeRl();
+    const models = makeModels('mock/echo');
+    const promise = promptModelPicker(models, rl as never);
+
+    rl.emit('line', '');
+    const result = await promise;
+    expect(result).toBe('mock/echo');
+  });
+});
+

--- a/packages/daemon/src/daemon/model-picker.ts
+++ b/packages/daemon/src/daemon/model-picker.ts
@@ -8,7 +8,16 @@ const RESET = '\x1b[0m';
 const DIM = '\x1b[2m';
 const YELLOW = '\x1b[33m';
 
-export async function selectModel(): Promise<string | null> {
+export interface ModelPickerResult {
+  model: string;
+  state: DaemonState;
+}
+
+/**
+ * Interactive model picker. Returns the chosen model AND the DaemonState
+ * so callers can reuse it without a second startup.
+ */
+export async function selectModel(): Promise<ModelPickerResult | null> {
   let state: DaemonState;
   if (isDaemonRunningSync()) {
     state = new DaemonState();
@@ -31,7 +40,9 @@ export async function selectModel(): Promise<string | null> {
   });
 
   try {
-    return await promptModelPicker(models, rl);
+    const model = await promptModelPicker(models, rl);
+    if (!model) return null;
+    return { model, state };
   } finally {
     rl.close();
   }

--- a/packages/daemon/src/daemon/model-picker.ts
+++ b/packages/daemon/src/daemon/model-picker.ts
@@ -1,0 +1,38 @@
+import * as readline from 'node:readline';
+import { startDaemon } from './daemon.js';
+import { isDaemonRunningSync } from './transport.js';
+import { DaemonState } from './state.js';
+import { promptModelPicker } from './chat.js';
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+const YELLOW = '\x1b[33m';
+
+export async function selectModel(): Promise<string | null> {
+  let state: DaemonState;
+  if (isDaemonRunningSync()) {
+    state = new DaemonState();
+  } else {
+    state = await startDaemon({ keepAlive: false });
+  }
+
+  const models = await state.listModels();
+  if (models.length === 0) {
+    console.error(
+      `${YELLOW}No models configured.${RESET} Run: ${DIM}aby start${RESET} -> open the web UI to add a provider.`,
+    );
+    return null;
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+    terminal: process.stdin.isTTY !== undefined,
+  });
+
+  try {
+    return await promptModelPicker(models, rl);
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/daemon/src/daemon/select-model.test.ts
+++ b/packages/daemon/src/daemon/select-model.test.ts
@@ -32,9 +32,9 @@ describe('selectModel', () => {
 
   it('returns null and prints guidance when no models are configured', async () => {
     const { DaemonState } = await import('./state.js');
-    vi.mocked(DaemonState).mockImplementation(() => ({
-      listModels: vi.fn().mockResolvedValue([]),
-    }) as any);
+    vi.mocked(DaemonState).mockImplementation(function () {
+      return { listModels: vi.fn().mockResolvedValue([]) } as any;
+    });
 
     const { selectModel } = await import('./model-picker.js');
     const result = await selectModel();
@@ -52,9 +52,9 @@ describe('selectModel', () => {
       { id: 'anthropic/claude-sonnet', name: 'claude-sonnet', provider: 'anthropic' },
     ];
     const { DaemonState } = await import('./state.js');
-    vi.mocked(DaemonState).mockImplementation(() => ({
-      listModels: vi.fn().mockResolvedValue(models),
-    }) as any);
+    vi.mocked(DaemonState).mockImplementation(function () {
+      return { listModels: vi.fn().mockResolvedValue(models) } as any;
+    });
 
     const { promptModelPicker } = await import('./chat.js');
     vi.mocked(promptModelPicker).mockResolvedValue('anthropic/claude-sonnet');
@@ -71,9 +71,9 @@ describe('selectModel', () => {
       { id: 'openai/gpt-4o', name: 'gpt-4o', provider: 'openai' },
     ];
     const { DaemonState } = await import('./state.js');
-    vi.mocked(DaemonState).mockImplementation(() => ({
-      listModels: vi.fn().mockResolvedValue(models),
-    }) as any);
+    vi.mocked(DaemonState).mockImplementation(function () {
+      return { listModels: vi.fn().mockResolvedValue(models) } as any;
+    });
 
     const { promptModelPicker } = await import('./chat.js');
     vi.mocked(promptModelPicker).mockResolvedValue(null);
@@ -103,9 +103,9 @@ describe('selectModel', () => {
     vi.mocked(isDaemonRunningSync).mockReturnValue(true);
 
     const { DaemonState } = await import('./state.js');
-    vi.mocked(DaemonState).mockImplementation(() => ({
-      listModels: vi.fn().mockResolvedValue([]),
-    }) as any);
+    vi.mocked(DaemonState).mockImplementation(function () {
+      return { listModels: vi.fn().mockResolvedValue([]) } as any;
+    });
 
     const { startDaemon } = await import('./daemon.js');
 

--- a/packages/daemon/src/daemon/select-model.test.ts
+++ b/packages/daemon/src/daemon/select-model.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./transport.js', () => ({
+  isDaemonRunningSync: vi.fn(() => true),
+}));
+
+vi.mock('./state.js', () => ({
+  DaemonState: vi.fn(),
+}));
+
+vi.mock('./daemon.js', () => ({
+  startDaemon: vi.fn(),
+}));
+
+vi.mock('./chat.js', () => ({
+  promptModelPicker: vi.fn(),
+}));
+
+// ── selectModel ──────────────────────────────────────────────────────
+
+describe('selectModel', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+  });
+
+  it('returns null and prints guidance when no models are configured', async () => {
+    const { DaemonState } = await import('./state.js');
+    vi.mocked(DaemonState).mockImplementation(() => ({
+      listModels: vi.fn().mockResolvedValue([]),
+    }) as any);
+
+    const { selectModel } = await import('./model-picker.js');
+    const result = await selectModel();
+
+    expect(result).toBeNull();
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toContain('No models configured');
+    expect(output).toContain('aby start');
+    expect(output).toContain('web UI');
+  });
+
+  it('returns selected model via picker when models exist', async () => {
+    const models = [
+      { id: 'openai/gpt-4o', name: 'gpt-4o', provider: 'openai' },
+      { id: 'anthropic/claude-sonnet', name: 'claude-sonnet', provider: 'anthropic' },
+    ];
+    const { DaemonState } = await import('./state.js');
+    vi.mocked(DaemonState).mockImplementation(() => ({
+      listModels: vi.fn().mockResolvedValue(models),
+    }) as any);
+
+    const { promptModelPicker } = await import('./chat.js');
+    vi.mocked(promptModelPicker).mockResolvedValue('anthropic/claude-sonnet');
+
+    const { selectModel } = await import('./model-picker.js');
+    const result = await selectModel();
+
+    expect(result).toBe('anthropic/claude-sonnet');
+    expect(promptModelPicker).toHaveBeenCalledWith(models, expect.anything());
+  });
+
+  it('returns null when user cancels the picker (Ctrl+C)', async () => {
+    const models = [
+      { id: 'openai/gpt-4o', name: 'gpt-4o', provider: 'openai' },
+    ];
+    const { DaemonState } = await import('./state.js');
+    vi.mocked(DaemonState).mockImplementation(() => ({
+      listModels: vi.fn().mockResolvedValue(models),
+    }) as any);
+
+    const { promptModelPicker } = await import('./chat.js');
+    vi.mocked(promptModelPicker).mockResolvedValue(null);
+
+    const { selectModel } = await import('./model-picker.js');
+    const result = await selectModel();
+
+    expect(result).toBeNull();
+  });
+
+  it('starts daemon if not already running', async () => {
+    const { isDaemonRunningSync } = await import('./transport.js');
+    vi.mocked(isDaemonRunningSync).mockReturnValue(false);
+
+    const { startDaemon } = await import('./daemon.js');
+    const fakeState = { listModels: vi.fn().mockResolvedValue([]) };
+    vi.mocked(startDaemon).mockResolvedValue(fakeState as any);
+
+    const { selectModel } = await import('./model-picker.js');
+    await selectModel();
+
+    expect(startDaemon).toHaveBeenCalledWith({ keepAlive: false });
+  });
+
+  it('uses existing DaemonState when daemon is already running', async () => {
+    const { isDaemonRunningSync } = await import('./transport.js');
+    vi.mocked(isDaemonRunningSync).mockReturnValue(true);
+
+    const { DaemonState } = await import('./state.js');
+    vi.mocked(DaemonState).mockImplementation(() => ({
+      listModels: vi.fn().mockResolvedValue([]),
+    }) as any);
+
+    const { startDaemon } = await import('./daemon.js');
+
+    const { selectModel } = await import('./model-picker.js');
+    await selectModel();
+
+    expect(DaemonState).toHaveBeenCalled();
+    expect(startDaemon).not.toHaveBeenCalled();
+  });
+});
+
+// ── --model flag bypass (chat action guard) ──────────────────────────
+
+describe('chat command --model bypass', () => {
+  it('skips picker when --model is provided', () => {
+    const options = { model: 'openai/gpt-4o', session: undefined };
+    const shouldPickModel = !options.model && !options.session;
+    expect(shouldPickModel).toBe(false);
+  });
+
+  it('skips picker when --session is provided', () => {
+    const options = { model: undefined, session: 'abc123' };
+    const shouldPickModel = !options.model && !options.session;
+    expect(shouldPickModel).toBe(false);
+  });
+
+  it('triggers picker when neither --model nor --session is provided', () => {
+    const options = { model: undefined, session: undefined };
+    const shouldPickModel = !options.model && !options.session;
+    expect(shouldPickModel).toBe(true);
+  });
+});

--- a/packages/daemon/src/daemon/select-model.test.ts
+++ b/packages/daemon/src/daemon/select-model.test.ts
@@ -46,7 +46,7 @@ describe('selectModel', () => {
     expect(output).toContain('web UI');
   });
 
-  it('returns selected model via picker when models exist', async () => {
+  it('returns model and state via picker when models exist', async () => {
     const models = [
       { id: 'openai/gpt-4o', name: 'gpt-4o', provider: 'openai' },
       { id: 'anthropic/claude-sonnet', name: 'claude-sonnet', provider: 'anthropic' },
@@ -62,7 +62,10 @@ describe('selectModel', () => {
     const { selectModel } = await import('./model-picker.js');
     const result = await selectModel();
 
-    expect(result).toBe('anthropic/claude-sonnet');
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('anthropic/claude-sonnet');
+    expect(result!.state).toBeDefined();
+    expect(result!.state.listModels).toBeDefined();
     expect(promptModelPicker).toHaveBeenCalledWith(models, expect.anything());
   });
 


### PR DESCRIPTION
- Updated the CLI chat command to allow model selection via an interactive picker when the --model option is omitted.
- Added `selectModel` function to manage model selection and daemon state.
- Introduced `promptModelPicker` for displaying available models and handling user input.
- Created tests for model selection and input parsing to ensure functionality and error handling.
- Updated documentation to reflect changes in command usage.

Ref : [https://redhat.atlassian.net/browse/AAP-79615](url)