### PR TITLE
fix: remove Abbenay status bar icon to avoid conflict with Ansible extension

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,7 +129,7 @@ The extension acts as a **thin gRPC client** to the daemon:
 4. Opens web dashboard on command
 
 **Key files:**
-- `extension.ts` - Activation, commands, status bar
+- `extension.ts` - Activation, commands
 - `daemon/client.ts` - gRPC client wrapper
 - `daemon/backchannel.ts` - Bidirectional stream handler
 - `providers/AbbenayLanguageModelProvider.ts` - VS Code LM API integration

--- a/docs/PRODUCT_OVERVIEW.md
+++ b/docs/PRODUCT_OVERVIEW.md
@@ -248,7 +248,6 @@ providers:
 | Criterion | Status | Notes |
 |-----------|--------|-------|
 | VS Code Language Model API | ✅ Complete | `vscode.lm.selectChatModels({ vendor: 'abbenay' })` |
-| Connection status | ✅ Complete | Status bar item + status panel |
 | Web-based configuration | ✅ Complete | Dashboard at localhost:8787 |
 
 ---

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -174,7 +174,7 @@ The extension is a thin gRPC client with these responsibilities:
 | **Daemon Client** | Connects to the Abbenay daemon via Unix socket |
 | **Backchannel** | Provides workspace path to daemon for workspace-level config |
 | **LM Provider** | Implements `LanguageModelChatProvider` to register models with VS Code |
-| **Status Bar** | Shows connection status |
+| **Chat Sidebar** | Provides chat view in the activity bar |
 
 The extension does **not**:
 - Store secrets (secrets are in system keychain)

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -14,7 +14,6 @@ import { ProviderPanel } from './webviews/provider/ProviderPanel';
 // Default dashboard URL - daemon serves web UI here
 const DASHBOARD_URL = 'http://localhost:8787';
 
-let daemonConnected = false;
 let languageModelProvider: AbbenayLanguageModelProvider | null = null;
 let backchannelHandler: BackchannelHandler | null = null;
 
@@ -32,7 +31,6 @@ export async function activate(context: vscode.ExtensionContext) {
     logger.info('[Daemon] Connecting to Abbenay daemon...');
     await initializeDaemon();
     logger.info('[Daemon] Connected and registered');
-    daemonConnected = true;
     
     // Check daemon health
     const client = getDaemonClient();
@@ -88,19 +86,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register commands
   registerCommands(context);
-
-  // Create status bar item
-  const statusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right,
-    100
-  );
-  statusBarItem.text = daemonConnected ? '$(sparkle) Abbenay' : '$(warning) Abbenay';
-  statusBarItem.tooltip = daemonConnected 
-    ? 'Abbenay Daemon Connected - Click to open dashboard' 
-    : 'Abbenay Daemon Not Connected';
-  statusBarItem.command = 'abbenay.openDashboard';
-  statusBarItem.show();
-  context.subscriptions.push(statusBarItem);
 
   // Watch for configuration changes
   context.subscriptions.push(


### PR DESCRIPTION
## Summary 

JIRA: [AAP-82362](https://redhat.atlassian.net/browse/AAP-82362)

The Abbenay extension's status bar icon conflicts with the Ansible extension's status bar icon, which already provides access to Abbenay LLM provider functionality. This PR removes the redundant status bar item while keeping the `openDashboard` command available from the command palette.

### Status bar view before this change -

<img width="445" height="27" alt="Screenshot 2026-07-09 at 12 53 43 PM" src="https://github.com/user-attachments/assets/c3bb1d44-8461-444f-923e-c89c4fa5f865" />