### PR TITLE
feat: add `abbenay.chat.send` command for programmatic prompt injection

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -58,6 +58,11 @@
         "title": "Configure Providers",
         "category": "Abbenay",
         "icon": "$(gear)"
+      },
+      {
+        "command": "abbenay.chat.send",
+        "title": "Send Message to Chat",
+        "category": "Abbenay"
       }
     ],
     "viewsContainers": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -17,6 +17,7 @@ const DASHBOARD_URL = 'http://localhost:8787';
 let daemonConnected = false;
 let languageModelProvider: AbbenayLanguageModelProvider | null = null;
 let backchannelHandler: BackchannelHandler | null = null;
+let chatViewProvider: ChatViewProvider | null = null;
 
 export async function activate(context: vscode.ExtensionContext) {
   console.log('[Abbenay] activate() called');
@@ -81,13 +82,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register chat sidebar webview
   const client = getDaemonClient();
-  const chatViewProvider = new ChatViewProvider(context.extensionUri, client);
+  chatViewProvider = new ChatViewProvider(context.extensionUri, client);
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(ChatViewProvider.viewType, chatViewProvider),
   );
 
   // Register commands
-  registerCommands(context);
+  registerCommands(context, chatViewProvider);
 
   // Create status bar item
   const statusBarItem = vscode.window.createStatusBarItem(
@@ -142,7 +143,7 @@ export async function deactivate() {
   disposeLogger();
 }
 
-function registerCommands(context: vscode.ExtensionContext): void {
+function registerCommands(context: vscode.ExtensionContext, chat: ChatViewProvider): void {
   // Daemon status command
   context.subscriptions.push(
     vscode.commands.registerCommand('abbenay.daemonStatus', async () => {
@@ -223,6 +224,17 @@ function registerCommands(context: vscode.ExtensionContext): void {
       console.log('[Abbenay] configureProvider command');
       const client = getDaemonClient();
       ProviderPanel.createOrShow(context.extensionUri, client);
+    })
+  );
+
+  // Chat send command — allows other extensions to inject a prompt
+  context.subscriptions.push(
+    vscode.commands.registerCommand('abbenay.chat.send', async (args: { message: string }) => {
+      if (!args?.message) {
+        vscode.window.showWarningMessage('abbenay.chat.send requires a { message } argument.');
+        return;
+      }
+      await chat.injectPrompt(args.message);
     })
   );
 

--- a/packages/vscode/src/test/extension.test.ts
+++ b/packages/vscode/src/test/extension.test.ts
@@ -32,6 +32,7 @@ suite('Extension Smoke Tests', () => {
       'abbenay.daemonStatus',
       'abbenay.openDashboard',
       'abbenay.configureProvider',
+      'abbenay.chat.send',
     ];
 
     for (const cmd of expected) {

--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -259,6 +259,38 @@ function handleCancel(): void {
   removeThinkingIndicator();
 }
 
+// Handle a prompt injected by the extension host.
+function handleInjectPrompt(message: string): void {
+  if (state.isStreaming || state.approvalWaiting) {
+    $textarea.value = message;
+    autoResize();
+    $textarea.focus();
+    return;
+  }
+
+  if (!state.currentSessionId) {
+    const model = state.currentModel || state.models[0]?.id;
+    if (!model) {
+      $textarea.value = message;
+      autoResize();
+      $textarea.focus();
+      return;
+    }
+    $modelSelect.value = model;
+    state.currentModel = model;
+
+    pendingInjectedPrompt = message;
+    api.postMessage({ type: 'createSession', model, topic: 'New Chat' });
+    return;
+  }
+
+  $textarea.value = message;
+  autoResize();
+  handleSend();
+}
+
+let pendingInjectedPrompt: string | null = null;
+
 function handleTextareaKeydown(e: KeyboardEvent): void {
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();
@@ -297,7 +329,16 @@ function onMessage(event: MessageEvent): void {
       state.approvalWaiting = false;
       renderMessages();
       updateInputState();
-      $textarea.focus();
+
+      if (pendingInjectedPrompt) {
+        const prompt = pendingInjectedPrompt;
+        pendingInjectedPrompt = null;
+        $textarea.value = prompt;
+        autoResize();
+        handleSend();
+      } else {
+        $textarea.focus();
+      }
       break;
 
     case 'sessionLoaded':
@@ -343,6 +384,10 @@ function onMessage(event: MessageEvent): void {
       updateInputState();
       state.userScrolledUp = false;
       scrollToBottom();
+      break;
+
+    case 'injectPrompt':
+      handleInjectPrompt(msg.message);
       break;
 
     case 'error':

--- a/packages/vscode/src/webviews/chat/ChatViewProvider.ts
+++ b/packages/vscode/src/webviews/chat/ChatViewProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { DaemonClient } from '../../daemon/client';
 import { getWebviewContent } from '../shared/getWebviewContent';
-import { ChatToHostMessage } from '../shared/types';
+import { ChatToHostMessage, HostToChatMessage } from '../shared/types';
 import { handleChatMessage, cancelActiveStream } from './chatHandler';
 import { getLogger } from '../../utils/logger';
 
@@ -73,5 +73,23 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     if (this._view) {
       this._view.show(true);
     }
+  }
+
+  // Inject a prompt into the chat panel.
+  public async injectPrompt(message: string): Promise<void> {
+    if (!this._view) {
+      this._logger.info('[ChatView] View not resolved yet — focusing to trigger resolve');
+      await vscode.commands.executeCommand('abbenay.chatView.focus');
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    if (!this._view) {
+      this._logger.warn('[ChatView] Cannot inject prompt — view still not resolved after focus');
+      return;
+    }
+
+    this._view.show(true);
+    const msg: HostToChatMessage = { type: 'injectPrompt', message };
+    this._view.webview.postMessage(msg);
   }
 }

--- a/packages/vscode/src/webviews/shared/types.ts
+++ b/packages/vscode/src/webviews/shared/types.ts
@@ -52,6 +52,7 @@ export type HostToChatMessage =
   | { type: 'toolCall'; id: string; name: string; args: string }
   | { type: 'toolResult'; callId: string; name: string; content: string; isError: boolean }
   | { type: 'toolApprovalRequest'; requestId: string; toolName: string; promptText: string }
+  | { type: 'injectPrompt'; message: string }
   | { type: 'error'; message: string; context?: string };
 
 // ─── Shared view types (serializable subsets of proto types) ────────


### PR DESCRIPTION
## Summary - ([AAP-82703](https://redhat.atlassian.net/browse/AAP-82703))

- Registers a new `abbenay.chat.send` VS Code command that accepts `{ message: string }` and injects the prompt directly into the Abbenay chat sidebar
- If the chat panel hasn't been opened yet, focuses it to trigger webview resolution before posting the message
- If no active session exists and models are available, creates a session and submits the prompt; otherwise populates the textarea for manual send
- Adds `injectPrompt` to the `HostToChatMessage` protocol and handles it in the webview UI

## Background

Consuming extensions like [vscode-ansible](https://github.com/ansible/vscode-ansible) need to programmatically send prompts to the Abbenay chat (e.g., "AI Summary" sparkle buttons). Without `abbenay.chat.send`, the only option was `abbenay.chatView.focus` + clipboard copy, requiring users to manually paste — a UX regression compared to the VS Code Copilot and IBM Bob integrations which support zero-click prompt delivery.

## Changed files

| File | Change |
|---|---|
| `packages/vscode/package.json` | Declare `abbenay.chat.send` command |
| `packages/vscode/src/extension.ts` | Hoist `chatViewProvider` to module scope, register the command |
| `packages/vscode/src/webviews/shared/types.ts` | Add `injectPrompt` to `HostToChatMessage` |
| `packages/vscode/src/webviews/chat/ChatViewProvider.ts` | Add `injectPrompt()` with auto-focus for unresolved views |
| `packages/vscode/src/webview-ui/chat/main.ts` | Handle `injectPrompt` — populate textarea, create session if needed, submit |
| `packages/vscode/src/test/extension.test.ts` | Add `abbenay.chat.send` to expected commands |

## Test plan

- [x] `npm run lint` passes (0 errors)
- [ ] Verify `abbenay.chat.send` is registered via Developer Tools console
- [ ] Invoke with daemon running and models configured — prompt populates and sends
- [ ] Invoke without prior sidebar open — view resolves before message is posted
- [ ] Invoke without models configured — prompt populates textarea for manual send
- [ ] Invoke while streaming — prompt populates textarea without interrupting active stream

---

Assisted-by: Cursor