### PR TITLE
fix(daemon): enforce MCP tool policy and connection consent (C3/A2)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,7 +79,8 @@ Full application layer. Extends core with transport, UI, and CLI.
 | `daemon/transport.ts` | Unix socket and PID file management |
 | `daemon/tool-router.ts` | Tool execution routing (VS Code, MCP, local) |
 | `daemon/mcp-client-pool.ts` | MCP server connection pool |
-| `daemon/mcp-server.ts` | Embedded MCP server (exposes daemon as MCP) |
+| `daemon/mcp-server.ts` | Embedded MCP server (connection consent + tool_policy) |
+| `core/tool-approval.ts` | Shared tool validator (chat + MCP HTTP) |
 | `daemon/index.ts` | CLI entry point (Commander) |
 | `daemon/server/abbenay-service.ts` | gRPC service handlers |
 | `daemon/web/server.ts` | Express web server + REST API |
@@ -300,13 +301,16 @@ The `ToolRegistry` collects tools from multiple sources and namespaces them to p
 | MCP server | `mcp:` | `mcp:github/searchCode` |
 | Local (agent-registered) | `local:` | `local:myAgent/search` |
 
-**Tool policy** controls which tools the LLM sees:
+**Tool policy** controls which tools the LLM sees **and** which tools may
+execute via chat or the embedded MCP HTTP endpoint (`/mcp`). Both surfaces
+use the shared `createToolValidator` helper (DR-033):
 
 | Tier | Config field | Behavior |
 |------|-------------|----------|
 | Auto-approve | `auto_approve` | Execute without confirmation |
-| Require approval | `require_approval` | Pause and ask user |
-| Disabled | `disabled_tools` | Never sent to LLM |
+| Require approval | `require_approval` | Pause and ask user (chat SSE or `POST /api/mcp/approvals`) |
+| Disabled | `disabled_tools` | Never sent to LLM; MCP `tools/call` rejected |
+| Default (no match) | — | Ask (secure-by-default, DR-019) |
 
 Patterns support glob matching (e.g., `mcp:filesystem/*`).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -85,7 +85,9 @@ gRPC, or MCP paths instead of `/v1`.
 ### HTTP API security (`server`)
 
 The web dashboard, REST API (`/api/*`), OpenAI-compatible API (`/v1/*`), and
-MCP endpoint (`/mcp`) require authentication by default.
+MCP endpoint (`/mcp`) require authentication by default. MCP tool calls also
+honor `tool_policy` (same approval path as chat — see [Tool policy](#tool-policy)
+below).
 
 | Setting / env | Purpose | Default |
 |---------------|---------|---------|
@@ -117,6 +119,48 @@ have set a strong token.
 > with `--host 0.0.0.0` (or any non-loopback bind) fails closed — the HTTP
 > server refuses to start. Prefer keeping auth enabled and using a local
 > token instead.
+
+### Tool policy
+
+`tool_policy` in `config.yaml` applies to **chat** and to tools invoked through
+Abbenay's MCP HTTP endpoint (`POST /mcp`). Both use the same validator
+(`createToolValidator` — DR-033).
+
+```yaml
+tool_policy:
+  disabled_tools: ['mcp:dangerous/*']   # Rejected; never listed for chat
+  auto_approve: ['local:agent/echo']    # Runs without prompting
+  require_approval: ['local:agent/danger']  # Blocks until user approves
+```
+
+| Outcome | Chat | MCP HTTP (`/mcp`) |
+|---------|------|-------------------|
+| `disabled_tools` | Tool omitted from LLM | `tools/call` returns error; executor not run |
+| `auto_approve` | Runs immediately | Runs immediately |
+| `require_approval` / default ask | SSE `approval_request`; `POST /api/chat/:chatId/approve` | Request blocks; dashboard / `GET|POST /api/mcp/approvals` |
+| Denied / abort | Tool skipped or loop aborted | `tools/call` returns `isError` |
+
+Unauthenticated `POST/GET/DELETE /mcp` is rejected with `401` (DR-030).
+
+### MCP client connection consent
+
+Bearer auth alone is not enough to open an MCP session. On `initialize`, Abbenay
+creates a pending connection consent (DR-034). The dashboard (or
+`GET/POST /api/mcp/connections`) must allow the client before a
+`Mcp-Session-Id` is issued. Subsequent `tools/call` requests without that
+session header are rejected with `403`.
+
+| Action | API |
+|--------|-----|
+| List pending + active sessions | `GET /api/mcp/connections` |
+| Allow / deny (optional `remember: true`) | `POST /api/mcp/connections/:requestId` |
+| Revoke session | `DELETE /api/mcp/connections/sessions/:sessionId` |
+
+`remember: true` is a DX shortcut keyed on `clientInfo.name` for the daemon
+lifetime. Empty names and the placeholder `unknown-client` are never
+remembered. Remember is not strong client identity — any API-token holder can
+present a remembered name, and the same token can both call `/mcp` and approve
+via `/api/mcp/connections`.
 
 ### Session ownership
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -152,15 +152,18 @@ session header are rejected with `403`.
 
 | Action | API |
 |--------|-----|
-| List pending + active sessions | `GET /api/mcp/connections` |
+| List pending + active sessions + remembered | `GET /api/mcp/connections` |
 | Allow / deny (optional `remember: true`) | `POST /api/mcp/connections/:requestId` |
 | Revoke session | `DELETE /api/mcp/connections/sessions/:sessionId` |
+| Forget remembered client | `DELETE /api/mcp/connections/remembered/:clientName` |
 
 `remember: true` is a DX shortcut keyed on `clientInfo.name` for the daemon
 lifetime. Empty names and the placeholder `unknown-client` are never
 remembered. Remember is not strong client identity — any API-token holder can
 present a remembered name, and the same token can both call `/mcp` and approve
-via `/api/mcp/connections`.
+via `/api/mcp/connections`. Pending connection consents and tool approvals
+auto-deny after **5 minutes** if the user never responds, so abandoned
+`initialize` / `tools/call` requests cannot leak entries in the pending maps.
 
 ### Session ownership
 

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -37,7 +37,7 @@ The `start` command runs all services:
 | Web dashboard | `http://localhost:8787` |
 | REST API | `http://localhost:8787/api/*` |
 | OpenAI-compatible API | `http://localhost:8787/v1/chat/completions` |
-| MCP server | `http://localhost:8787/mcp` (when `--mcp` is passed) |
+| MCP server | `http://localhost:8787/mcp` (when `--mcp` is passed; requires Bearer auth; tools honor `tool_policy`) |
 | gRPC (TCP) | `localhost:50051` (for Python/programmatic clients) |
 
 ### What's different from bare-metal

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -382,14 +382,22 @@ for await (const chunk of core.chat('my-openai/gpt-4o', messages, undefined, { t
 
 ### Tool policy
 
-Control tool visibility and approval via `ToolPolicyConfig`:
+Control tool visibility and approval via `ToolPolicyConfig`. Chat and the
+daemon MCP HTTP server share `createToolValidator` / `authorizeToolExecution`
+from `tool-approval.ts` (DR-033):
 
 ```typescript
+import { createToolValidator, authorizeToolExecution } from '@abbenay/core';
+
 const tools = registry.listForChat({
   disabled_tools: ['mcp:filesystem/*'],   // Never send to LLM
   auto_approve: ['local:*/*'],            // Execute without confirmation
   require_approval: ['ws:*/*'],           // Pause and ask user
 });
+
+// Same precedence for any execution surface:
+// disabled → deny; require_approval → ask; auto_approve → allow; default → ask
+const validator = createToolValidator(registry, policy, onApprovalNeeded);
 ```
 
 ## Relationship to @abbenay/daemon

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -328,6 +328,26 @@ Tools from connected MCP servers are automatically available in chat.
 Tool approval policies control which tools can execute without
 confirmation.
 
+### Expose Abbenay as an MCP server
+
+With `--mcp`, Abbenay also serves aggregated tools at `POST /mcp` for
+external MCP clients. That endpoint requires:
+
+1. The same Bearer token as other HTTP routes
+2. **Explicit connection consent** on `initialize` (dashboard → Pending MCP
+   client connections, or `POST /api/mcp/connections/:id`)
+3. `tool_policy` on every `tools/call` (same approval path as chat)
+
+After you allow a connection, use the `Mcp-Session-Id` from the initialize
+response on later requests. Tools that need consent appear under
+**Pending MCP tool approvals**.
+
+```bash
+aby start --mcp -p 8787
+# Client: Authorization: Bearer $ABBENAY_API_TOKEN → http://127.0.0.1:8787/mcp
+# Approve the client in the dashboard, then send Mcp-Session-Id on tools/call
+```
+
 ---
 
 ## 9. VS Code integration

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,6 +61,7 @@ All three tiers are enforced. The default for tools matching no tier is
 - **M2**: CLI `aby chat` with interactive approval — **done**
 - **M3**: VS Code backchannel approval flow
 - **M4**: `max_tool_iterations` enforcement — **done**
+- **M5**: MCP HTTP (`/mcp`) uses the same tool_policy path as chat (DR-033) — **done**
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -69,7 +69,8 @@ Pure unit tests with no I/O, no network, no processes.
 | `src/core/mock.test.ts` | Mock engine: echo, fixed, error, empty, slow modes |
 | `src/core/config.test.ts` | Config loading, merging, validation |
 | `src/core/tool-registry.test.ts` | Glob matching, tool registration, resolution, policy filtering |
-| `src/core/tool-approval.test.ts` | 3-tier approval precedence (auto_approve, require_approval, default) |
+| `src/core/tool-approval.test.ts` | Shared validator: disabled / auto_approve / require_approval / default ask |
+| `src/daemon/mcp-server.test.ts` | MCP authorizeAndExecute honors tool_policy (no bypass) |
 | `src/state.test.ts` | DaemonState: provider listing, model listing, chat flow |
 | `src/daemon/chat-prompt.test.ts` | `parseApprovalInput` case-sensitive routing |
 | `src/daemon/web/openai-compat.test.ts` | OpenAI format mapping: models, finish reasons, stream chunks, complete responses |
@@ -88,6 +89,7 @@ Tests that start real servers, make real HTTP/gRPC calls.
 | `tests/integration/web-sse.test.ts` | Web API endpoints + SSE chat streaming + errors + disconnect |
 | `tests/integration/openai-compat.test.ts` | OpenAI-compatible API: /v1/models, streaming, non-streaming, errors, tool calls |
 | `tests/integration/sessions.test.ts` | Session REST API: CRUD endpoints, session chat SSE streaming + persistence |
+| `tests/integration/mcp-http-policy.test.ts` | `/mcp` auth + connection consent + tool_policy E2E |
 
 ### Mock Engine
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -527,8 +527,12 @@ Non-initialize requests without an approved `Mcp-Session-Id` are rejected with
 keeps a **non-empty** `clientInfo.name` for the daemon lifetime (the default
 placeholder `unknown-client` is never remembered — remember is a DX shortcut,
 not strong client identity; any token bearer can present a remembered name).
+Remembered names can be cleared via
+`DELETE /api/mcp/connections/remembered/:clientName` (dashboard Forget).
 Sessions can be revoked via
-`DELETE /api/mcp/connections/sessions/:sessionId`.
+`DELETE /api/mcp/connections/sessions/:sessionId`. Pending connection consents
+and MCP tool approvals auto-deny after a 5-minute TTL so abandoned clients
+cannot leak pending map entries.
 **Rationale:** Bearer auth alone (DR-030) proves possession of the API token but
 does not express user intent to let a specific MCP client attach. Connection
 consent closes the remaining C3 recommendation and stops token-bearing callers

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -492,3 +492,46 @@ Forcing tools off forever breaks those clients; enabling Abbenay-side execution
 on `/v1` without an approval UI would weaken DR-019. Passthrough preserves the
 secure default while unblocking client-executed tools for explicitly opted-in
 models.
+
+---
+
+## DR-033: MCP HTTP uses the same tool approval policy as chat
+
+**Date:** 2026-07-17
+**Decision:** Every tool invocation on the embedded MCP HTTP endpoint (`/mcp`)
+goes through the shared `createToolValidator` / `authorizeToolExecution` helper
+used by chat. Precedence is `disabled_tools` → deny, `require_approval` → ask,
+`auto_approve` → allow, default → ask (DR-019). Pending MCP approvals block the
+MCP `tools/call` until the user resolves them via
+`GET/POST /api/mcp/approvals` (dashboard consent UX). `/mcp` remains behind the
+DR-030 Bearer/cookie auth gate. There is no executor path that bypasses
+`tool_policy`. After connection consent (DR-034), the daemon keeps a
+sessionful Streamable HTTP transport per approved `Mcp-Session-Id`
+(`enableJsonResponse: true`); non-initialize requests without an approved
+session are rejected.
+**Rationale:** Finding C3/A2 — `registerTools()` previously invoked executors
+directly, so an authenticated (or, before DR-030, open) MCP client could run
+tools while skipping approval tiers. Sharing one validator with chat closes
+that bypass and keeps policy configuration consistent across surfaces.
+
+---
+
+## DR-034: Explicit consent for MCP client connections
+
+**Date:** 2026-07-17
+**Decision:** Before an MCP client may establish a Streamable HTTP session on
+`/mcp`, the user must explicitly allow the connection (dashboard /
+`POST /api/mcp/connections/:requestId`). `initialize` blocks until allow/deny.
+Non-initialize requests without an approved `Mcp-Session-Id` are rejected with
+403 so `tools/call` cannot skip connection consent. Optional "Allow & Remember"
+keeps a **non-empty** `clientInfo.name` for the daemon lifetime (the default
+placeholder `unknown-client` is never remembered — remember is a DX shortcut,
+not strong client identity; any token bearer can present a remembered name).
+Sessions can be revoked via
+`DELETE /api/mcp/connections/sessions/:sessionId`.
+**Rationale:** Bearer auth alone (DR-030) proves possession of the API token but
+does not express user intent to let a specific MCP client attach. Connection
+consent closes the remaining C3 recommendation and stops token-bearing callers
+from silently opening an MCP session. API-token holders can both call `/mcp`
+and approve via `/api/mcp/connections`, so consent is interactive friction, not
+a second principal against a stolen/shared token.

--- a/packages/daemon/src/core/index.ts
+++ b/packages/daemon/src/core/index.ts
@@ -104,6 +104,18 @@ export type {
 /** Tool policy pattern matching */
 export { matchesAnyPattern } from './tool-registry.js';
 
+/** Shared tool approval validator (chat + MCP HTTP) */
+export {
+  createToolValidator,
+  authorizeToolExecution,
+  classifyToolPolicy,
+} from './tool-approval.js';
+export type {
+  ApprovalDecision,
+  OnToolApprovalNeeded,
+  ToolPolicyTier,
+} from './tool-approval.js';
+
 // ─── Engine Listing ─────────────────────────────────────────────────────
 
 /** Get all available engines (the fixed set of LLM API implementations) */

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -35,7 +35,8 @@ import {
   type ToolExecutor,
   type ToolValidationCallback,
 } from './engines.js';
-import { matchesAnyPattern, type ToolRegistry } from './tool-registry.js';
+import type { ToolRegistry } from './tool-registry.js';
+import { createToolValidator } from './tool-approval.js';
 import { VERSION } from '../version.js';
 
 // ── Virtual provider info (runtime, for API responses) ─────────────────
@@ -641,32 +642,17 @@ export class CoreState {
 
     // ── Build tool validator from policy + caller's approval callback ──
     // Secure-by-default: all tools require approval unless explicitly
-    // listed in auto_approve.  See DR-019.
-    // Precedence: require_approval > auto_approve > default (ask).
+    // listed in auto_approve.  See DR-019 / DR-033.
+    // Same createToolValidator() path as MCP HTTP (/mcp) — no bypass.
     let toolValidator: ToolValidationCallback | undefined;
     if (toolOptions?.onToolApprovalNeeded && this.toolRegistry) {
       const registry = this.toolRegistry;
-      const requirePatterns = toolPolicy?.require_approval;
-      const autoPatterns = toolPolicy?.auto_approve;
-
-      toolValidator = async (toolName: string, args: unknown): Promise<'allow' | 'deny' | 'abort'> => {
-        const resolved = registry.resolve(toolName);
-        const nsName = resolved?.namespacedName || toolName;
-
-        if (matchesAnyPattern(requirePatterns, nsName)) {
-          const requestId = crypto.randomUUID();
-          debug(`[State] Tool "${toolName}" (${nsName}) requires approval (explicit) — requestId=${requestId}`);
-          return toolOptions.onToolApprovalNeeded!(requestId, toolName, args, nsName);
-        }
-
-        if (matchesAnyPattern(autoPatterns, nsName)) {
-          return 'allow';
-        }
-
-        const requestId = crypto.randomUUID();
-        debug(`[State] Tool "${toolName}" (${nsName}) requires approval (default) — requestId=${requestId}`);
-        return toolOptions.onToolApprovalNeeded!(requestId, toolName, args, nsName);
-      };
+      const onApproval = toolOptions.onToolApprovalNeeded;
+      const inner = createToolValidator(registry, toolPolicy, async (requestId, toolName, args, nsName) => {
+        debug(`[State] Tool "${toolName}" (${nsName || toolName}) requires approval — requestId=${requestId}`);
+        return onApproval(requestId, toolName, args, nsName);
+      });
+      toolValidator = inner;
     }
 
     // ── Resolve maxSteps for tool loop ──

--- a/packages/daemon/src/core/tool-approval.test.ts
+++ b/packages/daemon/src/core/tool-approval.test.ts
@@ -1,44 +1,17 @@
 /**
  * Tool approval validator unit tests
  *
- * Tests the 3-tier precedence logic (require_approval > auto_approve > default ask)
- * that is built inside CoreState.chat(). Exercises the validator construction
- * directly against ToolRegistry + matchesAnyPattern to verify tier ordering,
- * namespacedName passthrough, and backward compatibility.
+ * Tests the shared 3-tier precedence logic (disabled > require_approval >
+ * auto_approve > default ask) used by both chat and MCP HTTP.
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { matchesAnyPattern, ToolRegistry, type ToolPolicyConfig } from './tool-registry.js';
-
-type ApprovalDecision = 'allow' | 'deny' | 'abort';
-
-/**
- * Build a tool validator using the same logic as state.ts.
- * This is extracted here to test in isolation without mocking the full chat flow.
- */
-function buildValidator(
-  registry: ToolRegistry,
-  policy: ToolPolicyConfig | undefined,
-  onApprovalNeeded: (requestId: string, toolName: string, args: unknown, namespacedName?: string) => Promise<ApprovalDecision>,
-) {
-  const requirePatterns = policy?.require_approval;
-  const autoPatterns = policy?.auto_approve;
-
-  return async (toolName: string, args: unknown): Promise<ApprovalDecision> => {
-    const resolved = registry.resolve(toolName);
-    const nsName = resolved?.namespacedName || toolName;
-
-    if (matchesAnyPattern(requirePatterns, nsName)) {
-      return onApprovalNeeded('req-id', toolName, args, nsName);
-    }
-
-    if (matchesAnyPattern(autoPatterns, nsName)) {
-      return 'allow';
-    }
-
-    return onApprovalNeeded('req-id', toolName, args, nsName);
-  };
-}
+import { ToolRegistry, type ToolPolicyConfig } from './tool-registry.js';
+import {
+  authorizeToolExecution,
+  classifyToolPolicy,
+  createToolValidator,
+} from './tool-approval.js';
 
 function makeRegistry(): ToolRegistry {
   const reg = new ToolRegistry();
@@ -60,7 +33,7 @@ describe('Tool approval validator', () => {
     it('asks for all tools when no policy is configured', async () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
-      const validator = buildValidator(reg, undefined, onApproval);
+      const validator = createToolValidator(reg, undefined, onApproval);
 
       await validator('search', {});
       await validator('read', {});
@@ -72,10 +45,42 @@ describe('Tool approval validator', () => {
     it('asks for all tools with empty policy', async () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
-      const validator = buildValidator(reg, {}, onApproval);
+      const validator = createToolValidator(reg, {}, onApproval);
 
       await validator('search', {});
       expect(onApproval).toHaveBeenCalledTimes(1);
+    });
+
+    it('denies ask-tier tools when no approval callback (fail-closed)', async () => {
+      const reg = makeRegistry();
+      const validator = createToolValidator(reg, undefined);
+      expect(await validator('search', {})).toBe('deny');
+    });
+  });
+
+  describe('disabled_tools tier', () => {
+    it('denies tools matching disabled_tools without asking', async () => {
+      const reg = makeRegistry();
+      const onApproval = vi.fn().mockResolvedValue('allow');
+      const policy: ToolPolicyConfig = { disabled_tools: ['mcp:github/delete_repo'] };
+      const validator = createToolValidator(reg, policy, onApproval);
+
+      expect(await validator('delete_repo', {})).toBe('deny');
+      expect(onApproval).not.toHaveBeenCalled();
+    });
+
+    it('disabled_tools overrides auto_approve', async () => {
+      const reg = makeRegistry();
+      const onApproval = vi.fn().mockResolvedValue('allow');
+      const policy: ToolPolicyConfig = {
+        auto_approve: ['mcp:*/*'],
+        disabled_tools: ['mcp:github/delete_repo'],
+      };
+      const validator = createToolValidator(reg, policy, onApproval);
+
+      expect(await validator('delete_repo', {})).toBe('deny');
+      expect(await validator('search', {})).toBe('allow');
+      expect(onApproval).not.toHaveBeenCalled();
     });
   });
 
@@ -84,7 +89,7 @@ describe('Tool approval validator', () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
       const policy: ToolPolicyConfig = { auto_approve: ['mcp:safe/*'] };
-      const validator = buildValidator(reg, policy, onApproval);
+      const validator = createToolValidator(reg, policy, onApproval);
 
       const decision = await validator('read', {});
       expect(decision).toBe('allow');
@@ -95,7 +100,7 @@ describe('Tool approval validator', () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
       const policy: ToolPolicyConfig = { auto_approve: ['mcp:safe/*'] };
-      const validator = buildValidator(reg, policy, onApproval);
+      const validator = createToolValidator(reg, policy, onApproval);
 
       await validator('search', {});
       expect(onApproval).toHaveBeenCalledTimes(1);
@@ -110,7 +115,7 @@ describe('Tool approval validator', () => {
         auto_approve: ['mcp:*/*'],
         require_approval: ['mcp:github/delete_repo'],
       };
-      const validator = buildValidator(reg, policy, onApproval);
+      const validator = createToolValidator(reg, policy, onApproval);
 
       const decision = await validator('delete_repo', {});
       expect(decision).toBe('deny');
@@ -124,7 +129,7 @@ describe('Tool approval validator', () => {
         auto_approve: ['mcp:*/*'],
         require_approval: ['mcp:github/delete_repo'],
       };
-      const validator = buildValidator(reg, policy, onApproval);
+      const validator = createToolValidator(reg, policy, onApproval);
 
       const decision = await validator('search', {});
       expect(decision).toBe('allow');
@@ -137,7 +142,7 @@ describe('Tool approval validator', () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
       const policy: ToolPolicyConfig = { auto_approve: ['*:*/*'] };
-      const validator = buildValidator(reg, policy, onApproval);
+      const validator = createToolValidator(reg, policy, onApproval);
 
       expect(await validator('search', {})).toBe('allow');
       expect(await validator('read', {})).toBe('allow');
@@ -150,11 +155,11 @@ describe('Tool approval validator', () => {
     it('passes namespacedName to approval callback', async () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
-      const validator = buildValidator(reg, undefined, onApproval);
+      const validator = createToolValidator(reg, undefined, onApproval);
 
       await validator('search', { q: 'test' });
       expect(onApproval).toHaveBeenCalledWith(
-        'req-id',
+        expect.any(String),
         'search',
         { q: 'test' },
         'mcp:github/search',
@@ -165,11 +170,11 @@ describe('Tool approval validator', () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('allow');
       const policy: ToolPolicyConfig = { require_approval: ['mcp:github/*'] };
-      const validator = buildValidator(reg, policy, onApproval);
+      const validator = createToolValidator(reg, policy, onApproval);
 
       await validator('search', {});
       expect(onApproval).toHaveBeenCalledWith(
-        'req-id',
+        expect.any(String),
         'search',
         {},
         'mcp:github/search',
@@ -181,7 +186,7 @@ describe('Tool approval validator', () => {
     it('propagates deny from callback', async () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('deny');
-      const validator = buildValidator(reg, undefined, onApproval);
+      const validator = createToolValidator(reg, undefined, onApproval);
 
       expect(await validator('search', {})).toBe('deny');
     });
@@ -189,9 +194,49 @@ describe('Tool approval validator', () => {
     it('propagates abort from callback', async () => {
       const reg = makeRegistry();
       const onApproval = vi.fn().mockResolvedValue('abort');
-      const validator = buildValidator(reg, undefined, onApproval);
+      const validator = createToolValidator(reg, undefined, onApproval);
 
       expect(await validator('search', {})).toBe('abort');
+    });
+  });
+
+  describe('classifyToolPolicy', () => {
+    it('classifies each tier', () => {
+      const policy: ToolPolicyConfig = {
+        disabled_tools: ['mcp:github/delete_repo'],
+        require_approval: ['mcp:github/search'],
+        auto_approve: ['mcp:safe/*'],
+      };
+      expect(classifyToolPolicy('mcp:github/delete_repo', policy)).toBe('disabled');
+      expect(classifyToolPolicy('mcp:github/search', policy)).toBe('require_approval');
+      expect(classifyToolPolicy('mcp:safe/read', policy)).toBe('auto_approve');
+      expect(classifyToolPolicy('local:agent/calculate', policy)).toBe('default_ask');
+    });
+  });
+
+  describe('authorizeToolExecution', () => {
+    it('returns disabled message for disabled tools', async () => {
+      const reg = makeRegistry();
+      const result = await authorizeToolExecution(
+        reg,
+        { disabled_tools: ['mcp:github/search'] },
+        'search',
+        {},
+      );
+      expect(result.decision).toBe('deny');
+      expect(result.message).toMatch(/disabled/);
+    });
+
+    it('allows auto_approve tools', async () => {
+      const reg = makeRegistry();
+      const result = await authorizeToolExecution(
+        reg,
+        { auto_approve: ['mcp:safe/*'] },
+        'read',
+        {},
+      );
+      expect(result.decision).toBe('allow');
+      expect(result.message).toBeUndefined();
     });
   });
 });

--- a/packages/daemon/src/core/tool-approval.ts
+++ b/packages/daemon/src/core/tool-approval.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared tool approval policy — used by chat (streamChat) and MCP HTTP (/mcp).
+ *
+ * Precedence (secure-by-default, DR-019 / DR-033):
+ *   disabled_tools → deny
+ *   require_approval → ask (onApprovalNeeded)
+ *   auto_approve → allow
+ *   default → ask (onApprovalNeeded)
+ *
+ * Chat and MCP MUST use this helper so there is no execution path that
+ * bypasses policy.
+ */
+
+import * as crypto from 'node:crypto';
+import type { ToolValidationCallback } from './engines.js';
+import { matchesAnyPattern, type ToolPolicyConfig, type ToolRegistry } from './tool-registry.js';
+
+export type ApprovalDecision = 'allow' | 'deny' | 'abort';
+
+/**
+ * Transport-specific callback when a tool needs explicit user consent.
+ * Web chat/MCP block until REST approve; CLI prompts via readline.
+ */
+export type OnToolApprovalNeeded = (
+  requestId: string,
+  toolName: string,
+  args: unknown,
+  namespacedName?: string,
+) => Promise<ApprovalDecision>;
+
+/**
+ * Classify a tool against policy without prompting.
+ * Useful for list filtering and diagnostics.
+ */
+export type ToolPolicyTier = 'disabled' | 'require_approval' | 'auto_approve' | 'default_ask';
+
+export function classifyToolPolicy(
+  namespacedName: string,
+  policy: ToolPolicyConfig | undefined,
+): ToolPolicyTier {
+  if (matchesAnyPattern(policy?.disabled_tools, namespacedName)) {
+    return 'disabled';
+  }
+  if (matchesAnyPattern(policy?.require_approval, namespacedName)) {
+    return 'require_approval';
+  }
+  if (matchesAnyPattern(policy?.auto_approve, namespacedName)) {
+    return 'auto_approve';
+  }
+  return 'default_ask';
+}
+
+/**
+ * Build the shared tool validator used by chat engines and MCP HTTP.
+ *
+ * @param registry - Tool registry for namespaced name resolution
+ * @param policy - Current tool_policy from config (may be undefined)
+ * @param onApprovalNeeded - Required for ask tiers; if omitted, ask tiers deny (fail-closed)
+ */
+export function createToolValidator(
+  registry: ToolRegistry,
+  policy: ToolPolicyConfig | undefined,
+  onApprovalNeeded?: OnToolApprovalNeeded,
+): ToolValidationCallback {
+  const requirePatterns = policy?.require_approval;
+  const autoPatterns = policy?.auto_approve;
+  const disabledPatterns = policy?.disabled_tools;
+
+  return async (toolName: string, args: unknown): Promise<ApprovalDecision> => {
+    const resolved = registry.resolve(toolName);
+    const nsName = resolved?.namespacedName || toolName;
+
+    if (matchesAnyPattern(disabledPatterns, nsName)) {
+      return 'deny';
+    }
+
+    if (matchesAnyPattern(requirePatterns, nsName)) {
+      if (!onApprovalNeeded) return 'deny';
+      const requestId = crypto.randomUUID();
+      return onApprovalNeeded(requestId, toolName, args, nsName);
+    }
+
+    if (matchesAnyPattern(autoPatterns, nsName)) {
+      return 'allow';
+    }
+
+    // Default ask (DR-019)
+    if (!onApprovalNeeded) return 'deny';
+    const requestId = crypto.randomUUID();
+    return onApprovalNeeded(requestId, toolName, args, nsName);
+  };
+}
+
+/**
+ * Run the shared validator and map the decision to execute / skip / abort.
+ * Returns a human-readable denial message when not allowed.
+ */
+export async function authorizeToolExecution(
+  registry: ToolRegistry,
+  policy: ToolPolicyConfig | undefined,
+  toolName: string,
+  args: unknown,
+  onApprovalNeeded?: OnToolApprovalNeeded,
+): Promise<{ decision: ApprovalDecision; message?: string }> {
+  const validator = createToolValidator(registry, policy, onApprovalNeeded);
+  const decision = await validator(toolName, args);
+  if (decision === 'allow') {
+    return { decision };
+  }
+  if (decision === 'abort') {
+    return { decision, message: 'Tool execution aborted by policy' };
+  }
+  const resolved = registry.resolve(toolName);
+  const nsName = resolved?.namespacedName || toolName;
+  const tier = classifyToolPolicy(nsName, policy);
+  if (tier === 'disabled') {
+    return {
+      decision: 'deny',
+      message: `Tool "${nsName}" is disabled by tool_policy.disabled_tools`,
+    };
+  }
+  return {
+    decision: 'deny',
+    message: `Tool execution denied by policy (${nsName})`,
+  };
+}

--- a/packages/daemon/src/daemon/mcp-server.test.ts
+++ b/packages/daemon/src/daemon/mcp-server.test.ts
@@ -1,0 +1,149 @@
+/**
+ * AbbenayMcpServer unit tests — tool_policy enforcement on MCP execution.
+ *
+ * Verifies authorizeAndExecute uses the same createToolValidator path as chat:
+ * disabled → deny, require_approval → wait for consent, auto_approve → run.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToolRegistry } from '../core/tool-registry.js';
+import { ToolRouter } from './tool-router.js';
+import { AbbenayMcpServer } from './mcp-server.js';
+
+describe('AbbenayMcpServer authorizeAndExecute', () => {
+  let registry: ToolRegistry;
+  let router: ToolRouter;
+  let server: AbbenayMcpServer;
+  let executor: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+    executor = vi.fn().mockResolvedValue({ ok: true });
+    registry.register('agent', 'local', [
+      {
+        name: 'echo',
+        description: 'Echo tool',
+        inputSchema: JSON.stringify({ type: 'object', properties: {} }),
+        executor,
+      },
+      {
+        name: 'danger',
+        description: 'Dangerous tool',
+        inputSchema: JSON.stringify({ type: 'object', properties: {} }),
+        executor,
+      },
+    ]);
+    router = new ToolRouter();
+    server = new AbbenayMcpServer(registry, router);
+  });
+
+  function tool(name: string) {
+    const t = registry.resolve(name);
+    if (!t) throw new Error(`missing tool ${name}`);
+    return t;
+  }
+
+  it('rejects disabled_tools without executing', async () => {
+    server.configure({
+      getPolicy: () => ({ disabled_tools: ['local:agent/danger'] }),
+      onApprovalNeeded: vi.fn().mockResolvedValue('allow'),
+    });
+
+    const result = await server.authorizeAndExecute(tool('danger'), { x: 1 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/disabled/);
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it('runs auto_approve tools without asking', async () => {
+    const onApproval = vi.fn().mockResolvedValue('allow');
+    server.configure({
+      getPolicy: () => ({ auto_approve: ['local:agent/echo'] }),
+      onApprovalNeeded: onApproval,
+    });
+
+    const result = await server.authorizeAndExecute(tool('echo'), { msg: 'hi' });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('ok');
+    expect(onApproval).not.toHaveBeenCalled();
+    expect(executor).toHaveBeenCalledWith({ msg: 'hi' });
+  });
+
+  it('blocks require_approval until callback allows', async () => {
+    let resolveApproval!: (d: 'allow' | 'deny' | 'abort') => void;
+    const approvalPromise = new Promise<'allow' | 'deny' | 'abort'>((r) => {
+      resolveApproval = r;
+    });
+    const onApproval = vi.fn().mockReturnValue(approvalPromise);
+
+    server.configure({
+      getPolicy: () => ({
+        auto_approve: ['local:agent/*'],
+        require_approval: ['local:agent/danger'],
+      }),
+      onApprovalNeeded: onApproval,
+    });
+
+    const execPromise = server.authorizeAndExecute(tool('danger'), {});
+    // Not executed yet
+    await Promise.resolve();
+    expect(executor).not.toHaveBeenCalled();
+    expect(onApproval).toHaveBeenCalled();
+
+    resolveApproval('allow');
+    const result = await execPromise;
+    expect(result.isError).toBeUndefined();
+    expect(executor).toHaveBeenCalled();
+  });
+
+  it('does not run when require_approval is denied', async () => {
+    server.configure({
+      getPolicy: () => ({ require_approval: ['local:agent/echo'] }),
+      onApprovalNeeded: vi.fn().mockResolvedValue('deny'),
+    });
+
+    const result = await server.authorizeAndExecute(tool('echo'), {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/denied/);
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it('default-ask denies when no approval handler (fail-closed)', async () => {
+    server.configure({
+      getPolicy: () => ({}),
+    });
+
+    const result = await server.authorizeAndExecute(tool('echo'), {});
+    expect(result.isError).toBe(true);
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it('auto_approve only when policy allows — unmatched tools still ask', async () => {
+    const onApproval = vi.fn().mockResolvedValue('deny');
+    server.configure({
+      getPolicy: () => ({ auto_approve: ['local:agent/echo'] }),
+      onApprovalNeeded: onApproval,
+    });
+
+    const denied = await server.authorizeAndExecute(tool('danger'), {});
+    expect(denied.isError).toBe(true);
+    expect(onApproval).toHaveBeenCalled();
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  describe('connection consent helpers', () => {
+    it('rememberClient / forgetClient manage the allowlist', () => {
+      server.rememberClient('claude-desktop');
+      expect(server.listRememberedClients()).toContain('claude-desktop');
+      server.forgetClient('claude-desktop');
+      expect(server.listRememberedClients()).not.toContain('claude-desktop');
+    });
+
+    it('refuses to remember unknown-client or empty names', () => {
+      server.rememberClient('unknown-client');
+      server.rememberClient('');
+      server.rememberClient('   ');
+      expect(server.listRememberedClients()).toEqual([]);
+    });
+  });
+});

--- a/packages/daemon/src/daemon/mcp-server.ts
+++ b/packages/daemon/src/daemon/mcp-server.ts
@@ -7,51 +7,198 @@
  *
  * Uses @modelcontextprotocol/sdk with Streamable HTTP transport,
  * mounted on the daemon's Express web server at /mcp.
+ *
+ * Security (DR-033 / DR-034):
+ * - /mcp is authenticated by the Express auth middleware (DR-030).
+ * - New MCP clients must receive explicit connection consent before a session
+ *   is established (initialize blocks until allow/deny).
+ * - Non-initialize requests require an approved Mcp-Session-Id (no tools/call
+ *   bypass without consent).
+ * - Every tool invocation goes through createToolValidator / authorizeToolExecution
+ *   (same path as chat).
  */
 
+import * as crypto from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { Express, Request, Response } from 'express';
-import type { ToolRegistry } from '../core/tool-registry.js';
+import { z, type ZodRawShape, type ZodTypeAny } from 'zod';
+import { loadConfig } from '../core/config.js';
+import {
+  authorizeToolExecution,
+  classifyToolPolicy,
+  type OnToolApprovalNeeded,
+} from '../core/tool-approval.js';
+import type { RegisteredTool, ToolPolicyConfig, ToolRegistry } from '../core/tool-registry.js';
 import type { ToolRouter } from './tool-router.js';
 import { VERSION } from '../version.js';
 
+/** Placeholder used when clientInfo.name is missing — never eligible for "remember". */
+const UNKNOWN_CLIENT_NAME = 'unknown-client';
+
+/**
+ * Convert a JSON Schema object into a Zod raw shape for MCP registerTool().
+ * The MCP SDK's deprecated tool() overload treats plain objects as annotations,
+ * not inputSchema — which drops arguments (path becomes undefined).
+ */
+function jsonSchemaToZodRawShape(schema: Record<string, unknown>): ZodRawShape {
+  const props = (schema.properties && typeof schema.properties === 'object')
+    ? schema.properties as Record<string, Record<string, unknown>>
+    : {};
+  const required = new Set(
+    Array.isArray(schema.required) ? schema.required.filter((r): r is string => typeof r === 'string') : [],
+  );
+  const shape: ZodRawShape = {};
+
+  for (const [key, prop] of Object.entries(props)) {
+    const type = prop?.type;
+    let field: ZodTypeAny;
+    switch (type) {
+      case 'string':
+        field = z.string();
+        break;
+      case 'number':
+        field = z.number();
+        break;
+      case 'integer':
+        field = z.number().int();
+        break;
+      case 'boolean':
+        field = z.boolean();
+        break;
+      case 'array':
+        field = z.array(z.any());
+        break;
+      case 'object':
+        field = z.record(z.string(), z.any());
+        break;
+      default:
+        field = z.any();
+    }
+    if (!required.has(key)) {
+      field = field.optional();
+    }
+    shape[key] = field;
+  }
+  return shape;
+}
+
+export type ConnectionConsentDecision = 'allow' | 'deny';
+
+/**
+ * Called when an MCP client sends initialize and needs explicit user consent
+ * before a session is created.
+ */
+export type OnConnectionConsentNeeded = (
+  requestId: string,
+  clientName: string,
+  clientVersion: string,
+) => Promise<ConnectionConsentDecision>;
+
+export interface McpServerHooks {
+  /** Load current tool_policy (called per invocation so config changes apply). */
+  getPolicy?: () => ToolPolicyConfig | undefined;
+  /** Block until the user approves/denies a tool call (web REST / dashboard). */
+  onApprovalNeeded?: OnToolApprovalNeeded;
+  /** Block until the user approves/denies a new MCP client connection. */
+  onConnectionConsentNeeded?: OnConnectionConsentNeeded;
+}
+
+interface McpSession {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  clientName: string;
+  clientVersion: string;
+  connectedAt: number;
+}
+
+export interface McpSessionInfo {
+  sessionId: string;
+  clientName: string;
+  clientVersion: string;
+  connectedAt: number;
+}
+
 export class AbbenayMcpServer {
-  private mcpServer: McpServer;
-  private transport?: StreamableHTTPServerTransport;
   private running = false;
+  private hooks: McpServerHooks = {};
+  /** Approved MCP Streamable HTTP sessions (sessionId → session). */
+  private sessions = new Map<string, McpSession>();
+  /** Client names approved with "Allow & Remember" for this daemon lifetime. */
+  private rememberedClients = new Set<string>();
 
   constructor(
     private registry: ToolRegistry,
     private router: ToolRouter,
-  ) {
-    this.mcpServer = new McpServer({
-      name: 'abbenay',
-      version: VERSION,
-    });
+  ) {}
+
+  /**
+   * Configure policy loader and approval / connection-consent callbacks.
+   */
+  configure(hooks: McpServerHooks): void {
+    this.hooks = { ...this.hooks, ...hooks };
   }
 
   /**
-   * Register all tools from the registry with the MCP server
-   * and start serving on the given Express app at /mcp.
+   * Remember a client name so future initialize skips the consent prompt.
+   * Refuses empty names and the `unknown-client` placeholder — remember is a
+   * DX shortcut keyed on client-reported name, not strong identity.
+   */
+  rememberClient(clientName: string): void {
+    const name = clientName?.trim();
+    if (!name || name === UNKNOWN_CLIENT_NAME) return;
+    this.rememberedClients.add(name);
+  }
+
+  /** Forget a remembered client name. */
+  forgetClient(clientName: string): void {
+    this.rememberedClients.delete(clientName);
+  }
+
+  listRememberedClients(): string[] {
+    return [...this.rememberedClients].sort();
+  }
+
+  listSessions(): McpSessionInfo[] {
+    return [...this.sessions.entries()].map(([sessionId, s]) => ({
+      sessionId,
+      clientName: s.clientName,
+      clientVersion: s.clientVersion,
+      connectedAt: s.connectedAt,
+    }));
+  }
+
+  /** Revoke an approved session (client must re-consent on next initialize). */
+  async revokeSession(sessionId: string): Promise<boolean> {
+    const session = this.sessions.get(sessionId);
+    if (!session) return false;
+    this.sessions.delete(sessionId);
+    try {
+      await session.transport.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await session.server.close();
+    } catch {
+      /* ignore */
+    }
+    return true;
+  }
+
+  /**
+   * Mount /mcp routes on the Express app.
+   *
+   * Auth for /mcp is enforced by createWebApp()'s requireAuth middleware
+   * (mounted before these routes).
    */
   async start(app: Express): Promise<void> {
     if (this.running) return;
 
-    // Register tools from the registry
-    this.registerTools();
-
-    // Create stateless transport (no session management)
-    this.transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-    });
-
-    await this.mcpServer.connect(this.transport);
-
-    // Mount POST /mcp for MCP requests
-    app.post('/mcp', async (req: Request, res: Response) => {
+    const handle = async (req: Request, res: Response, withBody: boolean): Promise<void> => {
       try {
-        await this.transport!.handleRequest(req, res, req.body);
+        await this.handleHttpRequest(req, res, withBody);
       } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : String(error);
         console.error('[McpServer] Request error:', msg);
@@ -59,59 +206,39 @@ export class AbbenayMcpServer {
           res.status(500).json({ error: 'MCP request failed' });
         }
       }
-    });
+    };
 
-    // Mount GET /mcp for SSE stream (if client requests it)
-    app.get('/mcp', async (req: Request, res: Response) => {
-      try {
-        await this.transport!.handleRequest(req, res);
-      } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        console.error('[McpServer] SSE request error:', msg);
-        if (!res.headersSent) {
-          res.status(500).json({ error: 'MCP SSE request failed' });
-        }
-      }
-    });
-
-    // Mount DELETE /mcp for session cleanup
-    app.delete('/mcp', async (req: Request, res: Response) => {
-      try {
-        await this.transport!.handleRequest(req, res);
-      } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        console.error('[McpServer] Delete request error:', msg);
-        if (!res.headersSent) {
-          res.status(500).json({ error: 'MCP delete request failed' });
-        }
-      }
-    });
+    app.post('/mcp', (req, res) => { void handle(req, res, true); });
+    app.get('/mcp', (req, res) => { void handle(req, res, false); });
+    app.delete('/mcp', (req, res) => { void handle(req, res, false); });
 
     this.running = true;
-    console.log('[McpServer] MCP server started at /mcp');
+    console.log('[McpServer] MCP server started at /mcp (auth + connection consent + tool_policy)');
   }
 
   /**
-   * Refresh registered tools (call when registry changes).
+   * Notify clients that the tool list changed.
    */
   refreshTools(): void {
     if (!this.running) return;
-    // The MCP SDK registers tools at server creation time.
-    // For dynamic updates, notify clients that the tool list changed.
-    this.mcpServer.sendToolListChanged();
+    for (const session of this.sessions.values()) {
+      try {
+        session.server.sendToolListChanged();
+      } catch {
+        /* ignore per-session failures */
+      }
+    }
     console.log('[McpServer] Notified clients of tool list change');
   }
 
   /**
-   * Stop the MCP server.
+   * Stop the MCP server and tear down all sessions.
    */
   async stop(): Promise<void> {
     if (!this.running) return;
-    try {
-      await this.mcpServer.close();
-    } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : String(error);
-      console.warn('[McpServer] Error closing:', msg);
+    const ids = [...this.sessions.keys()];
+    for (const id of ids) {
+      await this.revokeSession(id);
     }
     this.running = false;
     console.log('[McpServer] MCP server stopped');
@@ -121,14 +248,185 @@ export class AbbenayMcpServer {
     return this.running;
   }
 
+  /**
+   * Authorize + execute a tool using the shared policy path.
+   * Exposed for unit/integration tests (same logic as MCP tool handlers).
+   */
+  async authorizeAndExecute(
+    tool: RegisteredTool,
+    args: Record<string, unknown>,
+  ): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+    const policy = this.resolvePolicy();
+    const auth = await authorizeToolExecution(
+      this.registry,
+      policy,
+      tool.originalName,
+      args,
+      this.hooks.onApprovalNeeded,
+    );
+
+    if (auth.decision !== 'allow') {
+      return {
+        content: [{ type: 'text', text: auth.message || 'Tool execution denied by policy' }],
+        isError: true,
+      };
+    }
+
+    try {
+      const fallbackExecutor = this.router.buildFallbackExecutor();
+      let result: unknown;
+      if (tool.executor) {
+        result = await tool.executor(args);
+      } else {
+        result = await fallbackExecutor(tool, args);
+      }
+
+      const text = typeof result === 'string' ? result : JSON.stringify(result);
+      return {
+        content: [{ type: 'text' as const, text }],
+      };
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: 'text' as const, text: msg }],
+        isError: true,
+      };
+    }
+  }
+
   // ── Internal ─────────────────────────────────────────────────────────
 
+  private resolvePolicy(): ToolPolicyConfig | undefined {
+    if (this.hooks.getPolicy) {
+      return this.hooks.getPolicy();
+    }
+    try {
+      return loadConfig().tool_policy;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private sessionIdFromRequest(req: Request): string | undefined {
+    const raw = req.headers['mcp-session-id'];
+    if (typeof raw === 'string' && raw.trim()) return raw.trim();
+    return undefined;
+  }
+
+  private extractClientInfo(body: unknown): { name: string; version: string } {
+    const params = (body as { params?: { clientInfo?: { name?: string; version?: string } } })?.params;
+    const name = params?.clientInfo?.name?.trim() || UNKNOWN_CLIENT_NAME;
+    const version = params?.clientInfo?.version?.trim() || '0.0.0';
+    return { name, version };
+  }
+
   /**
-   * Register all tools from the registry as MCP tools.
+   * Connection consent (DR-034). Remembered clients skip the prompt.
+   * Fail-closed when no consent handler is configured.
    */
-  private registerTools(): void {
-    const tools = this.registry.getAll();
-    const fallbackExecutor = this.router.buildFallbackExecutor();
+  private async requireConnectionConsent(
+    clientName: string,
+    clientVersion: string,
+  ): Promise<ConnectionConsentDecision> {
+    if (this.rememberedClients.has(clientName)) {
+      console.log(`[McpServer] Connection auto-allowed (remembered): ${clientName}`);
+      return 'allow';
+    }
+    if (!this.hooks.onConnectionConsentNeeded) {
+      console.warn('[McpServer] Connection denied: no onConnectionConsentNeeded handler');
+      return 'deny';
+    }
+    const requestId = crypto.randomUUID();
+    console.log(
+      `[McpServer] Connection consent required: ${clientName}@${clientVersion} (requestId=${requestId})`,
+    );
+    return this.hooks.onConnectionConsentNeeded(requestId, clientName, clientVersion);
+  }
+
+  private async handleHttpRequest(
+    req: Request,
+    res: Response,
+    withBody: boolean,
+  ): Promise<void> {
+    const sessionId = this.sessionIdFromRequest(req);
+
+    // Existing approved session — reuse its transport
+    if (sessionId && this.sessions.has(sessionId)) {
+      const session = this.sessions.get(sessionId)!;
+      if (withBody) {
+        await session.transport.handleRequest(req, res, req.body);
+      } else {
+        await session.transport.handleRequest(req, res);
+      }
+      return;
+    }
+
+    // New connection: only initialize may create a session, and only after consent
+    if (req.method === 'POST' && withBody && isInitializeRequest(req.body)) {
+      const client = this.extractClientInfo(req.body);
+      const decision = await this.requireConnectionConsent(client.name, client.version);
+      if (decision !== 'allow') {
+        res.status(403).json({
+          error: 'MCP client connection denied',
+          clientName: client.name,
+          clientVersion: client.version,
+        });
+        return;
+      }
+
+      const server = new McpServer({
+        name: 'abbenay',
+        version: VERSION,
+      });
+      this.registerToolsOn(server);
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+        enableJsonResponse: true,
+        onsessioninitialized: (id) => {
+          this.sessions.set(id, {
+            transport,
+            server,
+            clientName: client.name,
+            clientVersion: client.version,
+            connectedAt: Date.now(),
+          });
+          console.log(`[McpServer] Session established: ${id} (${client.name}@${client.version})`);
+        },
+      });
+
+      transport.onclose = () => {
+        const id = transport.sessionId;
+        if (id && this.sessions.has(id)) {
+          this.sessions.delete(id);
+          console.log(`[McpServer] Session closed: ${id}`);
+        }
+      };
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    // No session and not an initialize — refuse (closes tools/call bypass)
+    res.status(403).json({
+      error:
+        'MCP client consent required. Send initialize, obtain user approval, ' +
+        'then include the Mcp-Session-Id from the initialize response.',
+    });
+  }
+
+  /**
+   * Register tools from the registry onto an MCP server instance.
+   * Disabled tools are omitted from the list (same as listForChat).
+   * Execution still re-checks policy so a later disable cannot be bypassed.
+   */
+  private registerToolsOn(mcpServer: McpServer): void {
+    const policy = this.resolvePolicy();
+    const tools = this.registry.getAll().filter((tool) => {
+      const tier = classifyToolPolicy(tool.namespacedName, policy);
+      return tier !== 'disabled';
+    });
 
     for (const tool of tools) {
       let schema: Record<string, unknown>;
@@ -138,34 +436,18 @@ export class AbbenayMcpServer {
         schema = { type: 'object', properties: {} };
       }
 
-      this.mcpServer.tool(
+      const inputShape = jsonSchemaToZodRawShape(schema);
+      // registerTool (not deprecated tool()) so JSON-derived schemas become
+      // real inputSchema — otherwise args are dropped and the handler only
+      // receives the MCP request "extra" object.
+      mcpServer.registerTool(
         tool.originalName,
-        tool.description,
-        schema,
-        async (args: Record<string, unknown>) => {
-          try {
-            let result: unknown;
-            if (tool.executor) {
-              result = await tool.executor(args);
-            } else {
-              result = await fallbackExecutor(tool, args);
-            }
-
-            const text = typeof result === 'string' ? result : JSON.stringify(result);
-            return {
-              content: [{ type: 'text' as const, text }],
-            };
-          } catch (error: unknown) {
-            const msg = error instanceof Error ? error.message : String(error);
-            return {
-              content: [{ type: 'text' as const, text: msg }],
-              isError: true,
-            };
-          }
+        {
+          description: tool.description,
+          inputSchema: inputShape,
         },
+        async (args: Record<string, unknown>) => this.authorizeAndExecute(tool, args ?? {}),
       );
     }
-
-    console.log(`[McpServer] Registered ${tools.length} tools`);
   }
 }

--- a/packages/daemon/src/daemon/mcp-server.ts
+++ b/packages/daemon/src/daemon/mcp-server.ts
@@ -151,9 +151,11 @@ export class AbbenayMcpServer {
     this.rememberedClients.add(name);
   }
 
-  /** Forget a remembered client name. */
+  /** Forget a remembered client name (no-op if unknown). */
   forgetClient(clientName: string): void {
-    this.rememberedClients.delete(clientName);
+    const name = clientName?.trim();
+    if (!name) return;
+    this.rememberedClients.delete(name);
   }
 
   listRememberedClients(): string[] {

--- a/packages/daemon/src/daemon/web/http-security.ts
+++ b/packages/daemon/src/daemon/web/http-security.ts
@@ -385,7 +385,7 @@ export function createCorsMiddleware(allowlist: string[]) {
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
     res.setHeader(
       'Access-Control-Allow-Headers',
-      `Content-Type, Authorization, ${CSRF_HEADER}, ${SESSION_OWNER_HEADER}`,
+      `Content-Type, Authorization, ${CSRF_HEADER}, ${SESSION_OWNER_HEADER}, Mcp-Session-Id, MCP-Protocol-Version`,
     );
 
     if (req.method === 'OPTIONS') {

--- a/packages/daemon/src/daemon/web/http-security.ts
+++ b/packages/daemon/src/daemon/web/http-security.ts
@@ -59,6 +59,12 @@ export interface WebSecurityOptions {
   authEnabled?: boolean;
   /** Skip loading user config (tests). */
   skipConfig?: boolean;
+  /**
+   * TTL for pending MCP connection-consent and tool-approval promises (ms).
+   * Abandoned initialize/approvals are auto-denied and removed from the pending
+   * maps when the timer fires. Default: 5 minutes. Tests may pass a short value.
+   */
+  mcpPendingTtlMs?: number;
 }
 
 /** Env values that disable HTTP auth (local-dev escape hatch). */

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -250,6 +250,12 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   // ── MCP connection consent + tool approval (DR-033 / DR-034) ───────────
   // Connection: initialize blocks until POST /api/mcp/connections resolves.
   // Tools: authorizeAndExecute blocks until POST /api/mcp/approvals resolves.
+  // Abandoned pending entries auto-deny after mcpPendingTtlMs (default 5m).
+  const DEFAULT_MCP_PENDING_TTL_MS = 5 * 60 * 1000;
+  const mcpPendingTtlMs = options?.mcpPendingTtlMs != null && options.mcpPendingTtlMs > 0
+    ? options.mcpPendingTtlMs
+    : DEFAULT_MCP_PENDING_TTL_MS;
+
   const pendingMcpApprovals = new Map<string, {
     resolve: (decision: 'allow' | 'deny' | 'abort') => void;
     toolName: string;
@@ -279,8 +285,19 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
           `[Web] MCP tool approval required: ${namespacedName || toolName} (requestId=${requestId})`,
         );
         return new Promise<'allow' | 'deny' | 'abort'>((resolve) => {
+          const timer = setTimeout(() => {
+            if (!pendingMcpApprovals.has(requestId)) return;
+            pendingMcpApprovals.delete(requestId);
+            console.log(
+              `[Web] MCP tool approval expired → deny: ${namespacedName || toolName} (requestId=${requestId})`,
+            );
+            resolve('deny');
+          }, mcpPendingTtlMs);
           pendingMcpApprovals.set(requestId, {
-            resolve,
+            resolve: (decision) => {
+              clearTimeout(timer);
+              resolve(decision);
+            },
             toolName,
             namespacedName,
             args,
@@ -293,8 +310,19 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
           `[Web] MCP connection consent required: ${clientName}@${clientVersion} (requestId=${requestId})`,
         );
         return new Promise<'allow' | 'deny'>((resolve) => {
+          const timer = setTimeout(() => {
+            if (!pendingMcpConnections.has(requestId)) return;
+            pendingMcpConnections.delete(requestId);
+            console.log(
+              `[Web] MCP connection consent expired → deny: ${clientName}@${clientVersion} (requestId=${requestId})`,
+            );
+            resolve('deny');
+          }, mcpPendingTtlMs);
           pendingMcpConnections.set(requestId, {
-            resolve,
+            resolve: (decision) => {
+              clearTimeout(timer);
+              resolve(decision);
+            },
             clientName,
             clientVersion,
             createdAt: Date.now(),
@@ -371,6 +399,31 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
       const msg = err instanceof Error ? err.message : String(err);
       res.status(500).json({ error: msg });
     }
+  });
+
+  /**
+   * DELETE /api/mcp/connections/remembered/:clientName — forget a remembered client
+   */
+  app.delete('/api/mcp/connections/remembered/:clientName', (req, res) => {
+    const clientName = decodeURIComponent(req.params.clientName || '').trim();
+    if (!clientName) {
+      res.status(400).json({ error: 'clientName is required' });
+      return;
+    }
+    if (typeof state.mcpServer?.forgetClient !== 'function') {
+      res.status(404).json({ error: 'MCP server does not support forgetClient' });
+      return;
+    }
+    const before = typeof state.mcpServer.listRememberedClients === 'function'
+      ? state.mcpServer.listRememberedClients()
+      : [];
+    if (!before.includes(clientName)) {
+      res.status(404).json({ error: `No remembered MCP client "${clientName}"` });
+      return;
+    }
+    state.mcpServer.forgetClient(clientName);
+    console.log(`[Web] MCP remembered client forgotten: ${clientName}`);
+    res.json({ success: true, forgotten: clientName });
   });
 
   /**

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -247,6 +247,168 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   app.use('/v1', requireAuth);
   app.use('/mcp', requireAuth);
 
+  // ── MCP connection consent + tool approval (DR-033 / DR-034) ───────────
+  // Connection: initialize blocks until POST /api/mcp/connections resolves.
+  // Tools: authorizeAndExecute blocks until POST /api/mcp/approvals resolves.
+  const pendingMcpApprovals = new Map<string, {
+    resolve: (decision: 'allow' | 'deny' | 'abort') => void;
+    toolName: string;
+    namespacedName?: string;
+    args: unknown;
+    createdAt: number;
+  }>();
+
+  const pendingMcpConnections = new Map<string, {
+    resolve: (decision: 'allow' | 'deny') => void;
+    clientName: string;
+    clientVersion: string;
+    createdAt: number;
+  }>();
+
+  if (typeof state.mcpServer?.configure === 'function') {
+    state.mcpServer.configure({
+      getPolicy: () => {
+        try {
+          return loadConfig().tool_policy;
+        } catch {
+          return undefined;
+        }
+      },
+      onApprovalNeeded: async (requestId, toolName, args, namespacedName) => {
+        console.log(
+          `[Web] MCP tool approval required: ${namespacedName || toolName} (requestId=${requestId})`,
+        );
+        return new Promise<'allow' | 'deny' | 'abort'>((resolve) => {
+          pendingMcpApprovals.set(requestId, {
+            resolve,
+            toolName,
+            namespacedName,
+            args,
+            createdAt: Date.now(),
+          });
+        });
+      },
+      onConnectionConsentNeeded: async (requestId, clientName, clientVersion) => {
+        console.log(
+          `[Web] MCP connection consent required: ${clientName}@${clientVersion} (requestId=${requestId})`,
+        );
+        return new Promise<'allow' | 'deny'>((resolve) => {
+          pendingMcpConnections.set(requestId, {
+            resolve,
+            clientName,
+            clientVersion,
+            createdAt: Date.now(),
+          });
+        });
+      },
+    });
+  }
+
+  /**
+   * GET /api/mcp/connections — pending connection consents + active sessions
+   */
+  app.get('/api/mcp/connections', (_req, res) => {
+    const pending = [...pendingMcpConnections.entries()].map(([requestId, p]) => ({
+      requestId,
+      clientName: p.clientName,
+      clientVersion: p.clientVersion,
+      createdAt: p.createdAt,
+    }));
+    const sessions = typeof state.mcpServer?.listSessions === 'function'
+      ? state.mcpServer.listSessions()
+      : [];
+    const remembered = typeof state.mcpServer?.listRememberedClients === 'function'
+      ? state.mcpServer.listRememberedClients()
+      : [];
+    res.json({ pending, sessions, remembered });
+  });
+
+  /**
+   * POST /api/mcp/connections/:requestId — allow / deny a pending MCP client connection
+   * Body: { decision: 'allow' | 'deny', remember?: boolean }
+   */
+  app.post('/api/mcp/connections/:requestId', (req, res) => {
+    const { requestId } = req.params;
+    const { decision, remember } = req.body as { decision?: string; remember?: boolean };
+    if (!decision || !['allow', 'deny'].includes(decision)) {
+      res.status(400).json({ error: 'decision must be allow or deny' });
+      return;
+    }
+    const pending = pendingMcpConnections.get(requestId);
+    if (!pending) {
+      res.status(404).json({ error: `No pending MCP connection with requestId "${requestId}"` });
+      return;
+    }
+    console.log(
+      `[Web] MCP connection: ${pending.clientName}@${pending.clientVersion} → ${decision}` +
+        (remember && decision === 'allow' ? ' (remember)' : '') +
+        ` (requestId=${requestId})`,
+    );
+    if (decision === 'allow' && remember && typeof state.mcpServer?.rememberClient === 'function') {
+      state.mcpServer.rememberClient(pending.clientName);
+    }
+    pending.resolve(decision as 'allow' | 'deny');
+    pendingMcpConnections.delete(requestId);
+    res.json({ success: true });
+  });
+
+  /**
+   * DELETE /api/mcp/connections/sessions/:sessionId — revoke an approved session
+   */
+  app.delete('/api/mcp/connections/sessions/:sessionId', async (req, res) => {
+    try {
+      if (typeof state.mcpServer?.revokeSession !== 'function') {
+        res.status(404).json({ error: 'MCP server does not support session revoke' });
+        return;
+      }
+      const ok = await state.mcpServer.revokeSession(req.params.sessionId);
+      if (!ok) {
+        res.status(404).json({ error: `No MCP session "${req.params.sessionId}"` });
+        return;
+      }
+      res.json({ success: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  /**
+   * GET /api/mcp/approvals — list pending MCP tool approval requests
+   */
+  app.get('/api/mcp/approvals', (_req, res) => {
+    const pending = [...pendingMcpApprovals.entries()].map(([requestId, p]) => ({
+      requestId,
+      toolName: p.toolName,
+      namespacedName: p.namespacedName,
+      args: p.args,
+      createdAt: p.createdAt,
+    }));
+    res.json({ pending });
+  });
+
+  /**
+   * POST /api/mcp/approvals/:requestId — approve / deny / abort a pending MCP tool call
+   * Body: { decision: 'allow' | 'deny' | 'abort' }
+   */
+  app.post('/api/mcp/approvals/:requestId', (req, res) => {
+    const { requestId } = req.params;
+    const { decision } = req.body as { decision?: string };
+    if (!decision || !['allow', 'deny', 'abort'].includes(decision)) {
+      res.status(400).json({ error: 'decision must be allow, deny, or abort' });
+      return;
+    }
+    const pending = pendingMcpApprovals.get(requestId);
+    if (!pending) {
+      res.status(404).json({ error: `No pending MCP approval with requestId "${requestId}"` });
+      return;
+    }
+    console.log(`[Web] MCP tool approval: ${pending.namespacedName || pending.toolName} → ${decision} (requestId=${requestId})`);
+    pending.resolve(decision as 'allow' | 'deny' | 'abort');
+    pendingMcpApprovals.delete(requestId);
+    res.json({ success: true });
+  });
+
   // ─── API Routes ────────────────────────────────────────────────────────
 
   /**

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -621,6 +621,21 @@
             </div>
           </template>
 
+          <template x-if="mcpRemembered.length > 0">
+            <div style="margin-bottom: var(--rh-space-lg);">
+              <h3 style="margin: 0 0 0.5rem; font-size: 0.95rem;">Remembered MCP clients</h3>
+              <p style="margin: 0 0 0.5rem; font-size: 0.85rem; color: #6a6e73;">
+                These client names skip connection consent for this daemon lifetime. Forget to require approval again.
+              </p>
+              <template x-for="name in mcpRemembered" :key="name">
+                <div style="display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;">
+                  <strong x-text="name"></strong>
+                  <button class="btn btn-secondary btn-sm" @click="forgetMcpClient(name)">Forget</button>
+                </div>
+              </template>
+            </div>
+          </template>
+
           <template x-if="pendingMcpApprovals.length > 0">
             <div style="margin-bottom: var(--rh-space-lg); padding: 1rem; background: #fff3cd; border: 2px solid #e6a817; border-radius: 3px;">
               <h3 style="margin: 0 0 0.75rem; font-size: 1rem;">Pending MCP tool approvals</h3>
@@ -1412,6 +1427,7 @@ function dashboard() {
     pendingMcpApprovals: [],
     pendingMcpConnections: [],
     mcpSessions: [],
+    mcpRemembered: [],
     
     // Tools
     allTools: [],
@@ -1933,6 +1949,7 @@ function dashboard() {
         const data = await resp.json();
         this.pendingMcpConnections = data.pending || [];
         this.mcpSessions = data.sessions || [];
+        this.mcpRemembered = data.remembered || [];
       } catch (e) { /* ignore */ }
     },
 
@@ -1957,6 +1974,17 @@ function dashboard() {
         await this.loadMcpConnections();
       } catch (e) {
         console.error('Failed to revoke MCP session:', e);
+      }
+    },
+
+    async forgetMcpClient(clientName) {
+      try {
+        await apiFetch(`/api/mcp/connections/remembered/${encodeURIComponent(clientName)}`, {
+          method: 'DELETE',
+        });
+        await this.loadMcpConnections();
+      } catch (e) {
+        console.error('Failed to forget MCP client:', e);
       }
     },
 

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -582,9 +582,64 @@
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--rh-space-md);">
             <p style="margin: 0; color: #6a6e73; font-size: 0.85rem;">
               MCP servers provide tools to the LLM. Configure them in <code>~/.config/abbenay/config.yaml</code> under <code>mcp_servers</code>.
+              Tools invoked via Abbenay's <code>/mcp</code> endpoint use the same approval policy as chat.
             </p>
-            <button class="btn btn-secondary btn-sm" @click="loadMcpServers()">Refresh</button>
+            <button class="btn btn-secondary btn-sm" @click="loadMcpServers(); loadMcpApprovals(); loadMcpConnections()">Refresh</button>
           </div>
+
+          <template x-if="pendingMcpConnections.length > 0">
+            <div style="margin-bottom: var(--rh-space-lg); padding: 1rem; background: #fce7e7; border: 2px solid #c9190b; border-radius: 3px;">
+              <h3 style="margin: 0 0 0.75rem; font-size: 1rem;">Pending MCP client connections</h3>
+              <p style="margin: 0 0 0.75rem; font-size: 0.85rem; color: #6a6e73;">
+                An external MCP client is trying to connect to Abbenay. Approve only if you trust this client.
+              </p>
+              <template x-for="req in pendingMcpConnections" :key="req.requestId">
+                <div style="margin-bottom: 0.75rem; padding: 0.75rem; background: #fff; border-radius: 3px;">
+                  <div style="font-weight: 600;" x-text="req.clientName + ' v' + req.clientVersion"></div>
+                  <div style="display: flex; gap: 0.5rem; margin-top: 0.5rem; flex-wrap: wrap;">
+                    <button class="btn btn-primary btn-sm" @click="resolveMcpConnection(req.requestId, 'allow')">Allow once</button>
+                    <button class="btn btn-primary btn-sm" @click="resolveMcpConnection(req.requestId, 'allow', true)">Allow &amp; Remember</button>
+                    <button class="btn btn-secondary btn-sm" style="color: #c00;" @click="resolveMcpConnection(req.requestId, 'deny')">Deny</button>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <template x-if="mcpSessions.length > 0">
+            <div style="margin-bottom: var(--rh-space-lg);">
+              <h3 style="margin: 0 0 0.5rem; font-size: 0.95rem;">Active MCP client sessions</h3>
+              <template x-for="sess in mcpSessions" :key="sess.sessionId">
+                <div style="display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0;">
+                  <span>
+                    <strong x-text="sess.clientName"></strong>
+                    <span style="color: #6a6e73; font-size: 0.85rem;" x-text="' v' + sess.clientVersion"></span>
+                  </span>
+                  <button class="btn btn-secondary btn-sm" @click="revokeMcpSession(sess.sessionId)">Revoke</button>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <template x-if="pendingMcpApprovals.length > 0">
+            <div style="margin-bottom: var(--rh-space-lg); padding: 1rem; background: #fff3cd; border: 2px solid #e6a817; border-radius: 3px;">
+              <h3 style="margin: 0 0 0.75rem; font-size: 1rem;">Pending MCP tool approvals</h3>
+              <p style="margin: 0 0 0.75rem; font-size: 0.85rem; color: #6a6e73;">
+                An MCP client called a tool that requires your consent. Approve or deny to unblock the request.
+              </p>
+              <template x-for="req in pendingMcpApprovals" :key="req.requestId">
+                <div style="margin-bottom: 0.75rem; padding: 0.75rem; background: #fff; border-radius: 3px;">
+                  <div style="font-weight: 600;" x-text="req.namespacedName || req.toolName"></div>
+                  <pre style="font-size: 0.75rem; overflow: auto; max-height: 8rem; margin: 0.5rem 0;" x-text="JSON.stringify(req.args || {}, null, 2)"></pre>
+                  <div style="display: flex; gap: 0.5rem;">
+                    <button class="btn btn-primary btn-sm" @click="resolveMcpApproval(req.requestId, 'allow')">Allow</button>
+                    <button class="btn btn-secondary btn-sm" @click="resolveMcpApproval(req.requestId, 'deny')">Deny</button>
+                    <button class="btn btn-secondary btn-sm" style="color: #c00;" @click="resolveMcpApproval(req.requestId, 'abort')">Abort</button>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
 
           <template x-if="mcpServers.length === 0">
             <div class="empty-state">
@@ -1354,6 +1409,9 @@ function dashboard() {
     
     // MCP Servers
     mcpServers: [],
+    pendingMcpApprovals: [],
+    pendingMcpConnections: [],
+    mcpSessions: [],
     
     // Tools
     allTools: [],
@@ -1416,8 +1474,15 @@ function dashboard() {
       await this.refresh();
       // Load MCP servers, tools, and policies in background
       this.loadMcpServers();
+      this.loadMcpApprovals();
+      this.loadMcpConnections();
       this.loadTools();
       this.loadPolicies();
+      // Poll pending MCP connection consent + tool approvals
+      setInterval(() => {
+        this.loadMcpApprovals();
+        this.loadMcpConnections();
+      }, 2000);
     },
     
     // ── Config helpers ──
@@ -1850,6 +1915,62 @@ function dashboard() {
         const data = await resp.json();
         this.mcpServers = data.mcp_servers || [];
       } catch (e) { console.error('Failed to load MCP servers:', e); }
+    },
+
+    async loadMcpApprovals() {
+      try {
+        const resp = await apiFetch('/api/mcp/approvals');
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.pendingMcpApprovals = data.pending || [];
+      } catch (e) { /* ignore — MCP server may be stopped */ }
+    },
+
+    async loadMcpConnections() {
+      try {
+        const resp = await apiFetch('/api/mcp/connections');
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.pendingMcpConnections = data.pending || [];
+        this.mcpSessions = data.sessions || [];
+      } catch (e) { /* ignore */ }
+    },
+
+    async resolveMcpConnection(requestId, decision, remember = false) {
+      try {
+        await apiFetch(`/api/mcp/connections/${encodeURIComponent(requestId)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ decision, remember: !!remember }),
+        });
+        await this.loadMcpConnections();
+      } catch (e) {
+        console.error('Failed to resolve MCP connection:', e);
+      }
+    },
+
+    async revokeMcpSession(sessionId) {
+      try {
+        await apiFetch(`/api/mcp/connections/sessions/${encodeURIComponent(sessionId)}`, {
+          method: 'DELETE',
+        });
+        await this.loadMcpConnections();
+      } catch (e) {
+        console.error('Failed to revoke MCP session:', e);
+      }
+    },
+
+    async resolveMcpApproval(requestId, decision) {
+      try {
+        await apiFetch(`/api/mcp/approvals/${encodeURIComponent(requestId)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ decision }),
+        });
+        await this.loadMcpApprovals();
+      } catch (e) {
+        console.error('Failed to resolve MCP approval:', e);
+      }
     },
     
     async reconnectMcpServer(serverId) {

--- a/packages/daemon/tests/integration/http-security.test.ts
+++ b/packages/daemon/tests/integration/http-security.test.ts
@@ -165,6 +165,14 @@ describe('HTTP auth', () => {
     expect(res.statusCode).toBe(401);
   });
 
+  it('rejects unauthenticated POST /mcp', async () => {
+    const res = await httpRequest('POST', '/mcp', {
+      token: null,
+      body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
   it('allows authenticated GET /api/secrets', async () => {
     const res = await httpRequest('GET', '/api/secrets');
     expect(res.statusCode).toBe(200);

--- a/packages/daemon/tests/integration/mcp-http-policy.test.ts
+++ b/packages/daemon/tests/integration/mcp-http-policy.test.ts
@@ -421,6 +421,46 @@ describe('MCP connection consent (DR-034)', () => {
     const res = await initPromise;
     expect(res.statusCode).toBe(200);
   });
+
+  it('DELETE remembered client requires consent again', async () => {
+    const name = `forget-me-${++clientSeq}`;
+    await mcpConnect(name, true);
+
+    let list = await httpRequest('GET', '/api/mcp/connections');
+    expect(list.body.remembered).toContain(name);
+
+    const forgotten = await httpRequest(
+      'DELETE',
+      `/api/mcp/connections/remembered/${encodeURIComponent(name)}`,
+    );
+    expect(forgotten.statusCode).toBe(200);
+    expect(forgotten.body.forgotten).toBe(name);
+
+    list = await httpRequest('GET', '/api/mcp/connections');
+    expect(list.body.remembered).not.toContain(name);
+
+    // Next initialize needs consent again
+    const initPromise = httpRequest('POST', '/mcp', {
+      body: {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name, version: '0.0.4' },
+        },
+      },
+      headers: { 'MCP-Protocol-Version': '2024-11-05' },
+    });
+    const requestId = await waitForPendingConnection();
+    expect(requestId).toBeTruthy();
+    await httpRequest('POST', `/api/mcp/connections/${requestId}`, {
+      body: { decision: 'deny' },
+    });
+    const res = await initPromise;
+    expect(res.statusCode).toBe(403);
+  });
 });
 
 describe('MCP HTTP tool_policy', () => {
@@ -565,5 +605,182 @@ describe('MCP HTTP tool_policy', () => {
     expect(call.http.statusCode).toBe(200);
     expect(call.rpc?.result?.isError).not.toBe(true);
     expect(dangerExecutor).toHaveBeenCalled();
+  });
+});
+
+describe('MCP pending consent / approval TTL', () => {
+  let ttlHttpServer: http.Server;
+  let ttlBaseUrl: string;
+  let ttlMcpServer: AbbenayMcpServer;
+  let ttlRegistry: ToolRegistry;
+  let ttlSessionsDir: string;
+
+  function ttlRequest(
+    method: string,
+    urlPath: string,
+    opts?: { body?: unknown; headers?: Record<string, string> },
+  ): Promise<{ statusCode: number; body: any }> {
+    return new Promise((resolve, reject) => {
+      const urlObj = new URL(urlPath, ttlBaseUrl);
+      const headers: Record<string, string> = {
+        Connection: 'close',
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${TEST_TOKEN}`,
+        ...(opts?.headers || {}),
+      };
+      let bodyStr: string | undefined;
+      if (opts?.body !== undefined) {
+        bodyStr = JSON.stringify(opts.body);
+        headers['Content-Type'] = 'application/json';
+        headers['Content-Length'] = String(Buffer.byteLength(bodyStr));
+      }
+      const req = http.request(
+        {
+          hostname: urlObj.hostname,
+          port: urlObj.port,
+          path: urlObj.pathname,
+          method,
+          headers,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf-8');
+            let body: any = raw;
+            try { body = JSON.parse(raw); } catch { /* keep raw */ }
+            resolve({ statusCode: res.statusCode || 0, body });
+          });
+        },
+      );
+      req.on('error', reject);
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  }
+
+  beforeAll(async () => {
+    ttlSessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-mcp-ttl-'));
+    writePolicy({ auto_approve: ['local:agent/echo'] });
+
+    ttlRegistry = new ToolRegistry();
+    ttlRegistry.register('agent', 'local', [
+      {
+        name: 'echo',
+        description: 'Safe echo',
+        inputSchema: JSON.stringify({ type: 'object', properties: {} }),
+        executor: async () => ({ ok: true }),
+      },
+    ]);
+    const router = new ToolRouter();
+    ttlMcpServer = new AbbenayMcpServer(ttlRegistry, router);
+
+    const state = {
+      version: '0.1.0-test',
+      startedAt: new Date(),
+      secretStore: mockSecretStore,
+      sessionStore: new SessionStore(ttlSessionsDir),
+      toolRegistry: ttlRegistry,
+      mcpServer: ttlMcpServer,
+      async listProviders() { return []; },
+      async listModels() { return []; },
+      async discoverModels() { return []; },
+      async resolveProviderCredentials() { return {}; },
+      async chat() {
+        return (async function* () {
+          yield { type: 'done' as const, finishReason: 'stop' };
+        })();
+      },
+      getStatus() {
+        return { version: '0.1.0-test', uptime: 0, providers: 0, models: 0 };
+      },
+      getConnectedClients() { return []; },
+      mcpClientPool: {
+        getAllStatus() { return []; },
+        async reconnect() {},
+      },
+    } as unknown as DaemonState;
+
+    const app = createWebApp(state, {
+      apiToken: TEST_TOKEN,
+      skipConfig: false,
+      host: '127.0.0.1',
+      mcpPendingTtlMs: 80,
+    });
+    await ttlMcpServer.start(app);
+
+    const port = await new Promise<number>((resolve) => {
+      ttlHttpServer = app.listen(0, '127.0.0.1', () => {
+        const addr = ttlHttpServer.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : 0);
+      });
+    });
+    ttlBaseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await ttlMcpServer.stop();
+    if (ttlHttpServer) {
+      await new Promise<void>((resolve) => ttlHttpServer.close(() => resolve()));
+    }
+    fs.rmSync(ttlSessionsDir, { recursive: true, force: true });
+  });
+
+  it('auto-denies abandoned initialize after TTL and clears pending map', async () => {
+    const initPromise = ttlRequest('POST', '/mcp', {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'ttl-client', version: '0.0.1' },
+        },
+      },
+      headers: { 'MCP-Protocol-Version': '2024-11-05' },
+    });
+
+    let sawPending = false;
+    for (let i = 0; i < 40; i++) {
+      const list = await ttlRequest('GET', '/api/mcp/connections');
+      if (list.body.pending?.length > 0) {
+        sawPending = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(sawPending).toBe(true);
+
+    const res = await initPromise;
+    expect(res.statusCode).toBe(403);
+    expect(String(res.body.error || '')).toMatch(/denied/i);
+
+    const list = await ttlRequest('GET', '/api/mcp/connections');
+    expect(list.body.pending).toEqual([]);
+  });
+
+  it('auto-denies abandoned tool approval after TTL', async () => {
+    writePolicy({}); // default ask → approval required
+
+    const echo = ttlRegistry.resolve('echo')!;
+    const resultPromise = ttlMcpServer.authorizeAndExecute(echo, {});
+
+    let approvalId: string | undefined;
+    for (let i = 0; i < 40; i++) {
+      const list = await ttlRequest('GET', '/api/mcp/approvals');
+      if (list.body.pending?.length > 0) {
+        approvalId = list.body.pending[0].requestId;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(approvalId).toBeDefined();
+
+    const denied = await resultPromise;
+    expect(denied.isError).toBe(true);
+
+    const list = await ttlRequest('GET', '/api/mcp/approvals');
+    expect(list.body.pending).toEqual([]);
   });
 });

--- a/packages/daemon/tests/integration/mcp-http-policy.test.ts
+++ b/packages/daemon/tests/integration/mcp-http-policy.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Integration: MCP HTTP auth + connection consent + tool_policy (DR-033 / DR-034)
+ *
+ * Acceptance:
+ * - Unauthenticated POST /mcp → 401
+ * - tools/call without approved session → 403 (connection consent required)
+ * - initialize blocks until POST /api/mcp/connections allow/deny
+ * - disabled_tools / require_approval / auto_approve via authenticated session
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-mcp-policy-'));
+const configPath = path.join(tmpConfigDir, 'config.yaml');
+
+vi.mock('../../src/core/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/core/paths.js')>();
+  return {
+    ...actual,
+    getUserConfigPath: () => configPath,
+    getConfigDir: () => tmpConfigDir,
+  };
+});
+
+import { createWebApp } from '../../src/daemon/web/server.js';
+import { ToolRegistry } from '../../src/core/tool-registry.js';
+import { ToolRouter } from '../../src/daemon/tool-router.js';
+import { AbbenayMcpServer } from '../../src/daemon/mcp-server.js';
+import { SessionStore } from '../../src/core/session-store.js';
+import type { DaemonState } from '../../src/daemon/state.js';
+import type { SecretStore } from '../../src/core/secrets.js';
+import * as yaml from 'js-yaml';
+
+const TEST_TOKEN = 'test-mcp-policy-token';
+
+const mockSecretStore: SecretStore = {
+  async get() { return null; },
+  async set() {},
+  async delete() { return true; },
+  async has() { return false; },
+};
+
+let sessionsDir: string;
+let httpServer: http.Server;
+let baseUrl: string;
+let registry: ToolRegistry;
+let mcpServer: AbbenayMcpServer;
+let echoExecutor: ReturnType<typeof vi.fn>;
+let dangerExecutor: ReturnType<typeof vi.fn>;
+let clientSeq = 0;
+
+function writePolicy(tool_policy: Record<string, unknown> | undefined): void {
+  const cfg = tool_policy ? { tool_policy } : {};
+  fs.writeFileSync(configPath, yaml.dump(cfg), 'utf-8');
+}
+
+function createState(): DaemonState {
+  registry = new ToolRegistry();
+  echoExecutor = vi.fn().mockResolvedValue({ echoed: true });
+  dangerExecutor = vi.fn().mockResolvedValue({ danger: true });
+  registry.register('agent', 'local', [
+    {
+      name: 'echo',
+      description: 'Safe echo',
+      inputSchema: JSON.stringify({ type: 'object', properties: { msg: { type: 'string' } } }),
+      executor: echoExecutor,
+    },
+    {
+      name: 'danger',
+      description: 'Dangerous',
+      inputSchema: JSON.stringify({ type: 'object', properties: {} }),
+      executor: dangerExecutor,
+    },
+  ]);
+  const router = new ToolRouter();
+  mcpServer = new AbbenayMcpServer(registry, router);
+
+  return {
+    version: '0.1.0-test',
+    startedAt: new Date(),
+    secretStore: mockSecretStore,
+    sessionStore: new SessionStore(sessionsDir),
+    toolRegistry: registry,
+    mcpServer,
+    async listProviders() { return []; },
+    async listModels() { return []; },
+    async discoverModels() { return []; },
+    async resolveProviderCredentials() { return {}; },
+    async chat() {
+      return (async function* () {
+        yield { type: 'done' as const, finishReason: 'stop' };
+      })();
+    },
+    getStatus() {
+      return { version: '0.1.0-test', uptime: 0, providers: 0, models: 0 };
+    },
+    getConnectedClients() { return []; },
+    mcpClientPool: {
+      getAllStatus() { return []; },
+      async reconnect() {},
+    },
+  } as unknown as DaemonState;
+}
+
+function httpRequest(
+  method: string,
+  urlPath: string,
+  opts?: {
+    body?: unknown;
+    headers?: Record<string, string>;
+    token?: string | null;
+  },
+): Promise<{ statusCode: number; body: any; headers: http.IncomingHttpHeaders; raw: string }> {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(urlPath, baseUrl);
+    const headers: Record<string, string> = {
+      Connection: 'close',
+      Accept: 'application/json, text/event-stream',
+      ...(opts?.headers || {}),
+    };
+    if (opts?.token !== null) {
+      headers.Authorization = `Bearer ${opts?.token ?? TEST_TOKEN}`;
+    }
+    let bodyStr: string | undefined;
+    if (opts?.body !== undefined) {
+      bodyStr = JSON.stringify(opts.body);
+      headers['Content-Type'] = 'application/json';
+      headers['Content-Length'] = String(Buffer.byteLength(bodyStr));
+    }
+    const req = http.request(
+      {
+        hostname: urlObj.hostname,
+        port: urlObj.port,
+        path: urlObj.pathname + urlObj.search,
+        method,
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf-8');
+          let body: any = raw;
+          try {
+            body = JSON.parse(raw);
+          } catch {
+            // keep raw
+          }
+          resolve({ statusCode: res.statusCode || 0, body, headers: res.headers, raw });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (bodyStr) req.write(bodyStr);
+    req.end();
+  });
+}
+
+function extractMcpResult(res: { body: any; raw: string }): any {
+  if (res.body && typeof res.body === 'object' && (res.body.result || res.body.error)) {
+    return res.body;
+  }
+  const lines = res.raw.split('\n');
+  for (const line of lines) {
+    if (line.startsWith('data: ')) {
+      try {
+        return JSON.parse(line.slice(6));
+      } catch {
+        /* continue */
+      }
+    }
+  }
+  return res.body;
+}
+
+async function waitForPendingConnection(timeoutMs = 2000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const list = await httpRequest('GET', '/api/mcp/connections');
+    if (list.body.pending?.length > 0) {
+      return list.body.pending[0].requestId as string;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error('Timed out waiting for pending MCP connection consent');
+}
+
+/** Initialize + approve connection; returns Mcp-Session-Id. */
+async function mcpConnect(clientName?: string, remember = false): Promise<string> {
+  const name = clientName || `test-client-${++clientSeq}`;
+  const initPromise = httpRequest('POST', '/mcp', {
+    body: {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name, version: '0.0.1' },
+      },
+    },
+    headers: { 'MCP-Protocol-Version': '2024-11-05' },
+  });
+
+  const requestId = await waitForPendingConnection();
+  const approve = await httpRequest('POST', `/api/mcp/connections/${requestId}`, {
+    body: { decision: 'allow', remember },
+  });
+  expect(approve.statusCode).toBe(200);
+
+  const res = await initPromise;
+  expect(res.statusCode).toBe(200);
+  const sessionId = res.headers['mcp-session-id'];
+  expect(typeof sessionId).toBe('string');
+  expect(sessionId!.length).toBeGreaterThan(0);
+  return sessionId as string;
+}
+
+async function mcpJsonRpc(
+  method: string,
+  params: unknown | undefined,
+  opts: { id?: number; sessionId?: string } = {},
+): Promise<any> {
+  const headers: Record<string, string> = {
+    'MCP-Protocol-Version': '2024-11-05',
+  };
+  if (opts.sessionId) {
+    headers['Mcp-Session-Id'] = opts.sessionId;
+  }
+  const res = await httpRequest('POST', '/mcp', {
+    body: {
+      jsonrpc: '2.0',
+      id: opts.id ?? 1,
+      method,
+      ...(params !== undefined ? { params } : {}),
+    },
+    headers,
+  });
+  return { http: res, rpc: extractMcpResult(res) };
+}
+
+beforeAll(async () => {
+  sessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-mcp-sess-'));
+  writePolicy({ auto_approve: ['local:agent/echo'] });
+
+  const state = createState();
+  const app = createWebApp(state, {
+    apiToken: TEST_TOKEN,
+    skipConfig: false,
+    host: '127.0.0.1',
+  });
+
+  await mcpServer.start(app);
+
+  const port = await new Promise<number>((resolve) => {
+    httpServer = app.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await mcpServer.stop();
+  if (httpServer) {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  }
+  fs.rmSync(tmpConfigDir, { recursive: true, force: true });
+  fs.rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  echoExecutor.mockClear();
+  dangerExecutor.mockClear();
+  writePolicy({ auto_approve: ['local:agent/echo'] });
+});
+
+describe('MCP HTTP authentication', () => {
+  it('rejects unauthenticated POST /mcp', async () => {
+    const res = await httpRequest('POST', '/mcp', {
+      token: null,
+      body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '0.0.1' },
+      } },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects unauthenticated GET /mcp', async () => {
+    const res = await httpRequest('GET', '/mcp', { token: null });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects unauthenticated DELETE /mcp', async () => {
+    const res = await httpRequest('DELETE', '/mcp', { token: null });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('MCP connection consent (DR-034)', () => {
+  it('rejects tools/call without an approved session', async () => {
+    const call = await mcpJsonRpc('tools/call', { name: 'echo', arguments: {} }, { id: 99 });
+    expect(call.http.statusCode).toBe(403);
+    expect(String(call.http.body?.error || '')).toMatch(/consent/i);
+    expect(echoExecutor).not.toHaveBeenCalled();
+  });
+
+  it('initialize blocks until connection is approved', async () => {
+    const initPromise = httpRequest('POST', '/mcp', {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'consent-block-client', version: '1.0.0' },
+        },
+      },
+      headers: { 'MCP-Protocol-Version': '2024-11-05' },
+    });
+
+    const requestId = await waitForPendingConnection();
+    const list = await httpRequest('GET', '/api/mcp/connections');
+    expect(list.body.pending.some((p: { clientName: string }) => p.clientName === 'consent-block-client')).toBe(true);
+
+    await httpRequest('POST', `/api/mcp/connections/${requestId}`, {
+      body: { decision: 'allow' },
+    });
+
+    const res = await initPromise;
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeTruthy();
+  });
+
+  it('denied connection returns 403 and creates no session', async () => {
+    const initPromise = httpRequest('POST', '/mcp', {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'denied-client', version: '1.0.0' },
+        },
+      },
+      headers: { 'MCP-Protocol-Version': '2024-11-05' },
+    });
+
+    const requestId = await waitForPendingConnection();
+    await httpRequest('POST', `/api/mcp/connections/${requestId}`, {
+      body: { decision: 'deny' },
+    });
+
+    const res = await initPromise;
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toMatch(/denied/i);
+    expect(mcpServer.listSessions().some((s) => s.clientName === 'denied-client')).toBe(false);
+  });
+
+  it('Allow & Remember skips consent on reconnect', async () => {
+    const name = `remembered-${++clientSeq}`;
+    const session1 = await mcpConnect(name, true);
+    expect(session1).toBeTruthy();
+
+    // Second initialize should not create a pending connection
+    const res = await httpRequest('POST', '/mcp', {
+      body: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name, version: '0.0.2' },
+        },
+      },
+      headers: { 'MCP-Protocol-Version': '2024-11-05' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeTruthy();
+
+    const list = await httpRequest('GET', '/api/mcp/connections');
+    expect(list.body.pending.some((p: { clientName: string }) => p.clientName === name)).toBe(false);
+    expect(list.body.remembered).toContain(name);
+  });
+
+  it('does not remember unknown-client placeholder', async () => {
+    const sessionId = await mcpConnect('unknown-client', true);
+    expect(sessionId).toBeTruthy();
+
+    const list = await httpRequest('GET', '/api/mcp/connections');
+    expect(list.body.remembered).not.toContain('unknown-client');
+
+    // Next initialize with the same placeholder still requires consent
+    const initPromise = httpRequest('POST', '/mcp', {
+      body: {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'unknown-client', version: '0.0.3' },
+        },
+      },
+      headers: { 'MCP-Protocol-Version': '2024-11-05' },
+    });
+    const requestId = await waitForPendingConnection();
+    await httpRequest('POST', `/api/mcp/connections/${requestId}`, {
+      body: { decision: 'allow' },
+    });
+    const res = await initPromise;
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('MCP HTTP tool_policy', () => {
+  it('rejects disabled_tools via authenticated authorizeAndExecute (same path as /mcp handlers)', async () => {
+    writePolicy({ disabled_tools: ['local:agent/danger'] });
+    const tool = registry.resolve('danger')!;
+    const result = await mcpServer.authorizeAndExecute(tool, {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/disabled/);
+    expect(dangerExecutor).not.toHaveBeenCalled();
+  });
+
+  it('auto_approve runs only when policy allows', async () => {
+    writePolicy({ auto_approve: ['local:agent/echo'] });
+    const echo = registry.resolve('echo')!;
+    const ok = await mcpServer.authorizeAndExecute(echo, { msg: 'hi' });
+    expect(ok.isError).toBeUndefined();
+    expect(echoExecutor).toHaveBeenCalled();
+
+    echoExecutor.mockClear();
+    const danger = registry.resolve('danger')!;
+    const execPromise = mcpServer.authorizeAndExecute(danger, {});
+    let requestId: string | undefined;
+    for (let i = 0; i < 20; i++) {
+      const list = await httpRequest('GET', '/api/mcp/approvals');
+      if (list.body.pending?.length > 0) {
+        requestId = list.body.pending[0].requestId;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(requestId).toBeDefined();
+    expect(dangerExecutor).not.toHaveBeenCalled();
+
+    await httpRequest('POST', `/api/mcp/approvals/${requestId}`, {
+      body: { decision: 'deny' },
+    });
+    const denied = await execPromise;
+    expect(denied.isError).toBe(true);
+    expect(dangerExecutor).not.toHaveBeenCalled();
+  });
+
+  it('require_approval blocks until approve API allows execution', async () => {
+    writePolicy({
+      auto_approve: ['local:agent/*'],
+      require_approval: ['local:agent/danger'],
+    });
+
+    const danger = registry.resolve('danger')!;
+    const execPromise = mcpServer.authorizeAndExecute(danger, { force: true });
+
+    let requestId: string | undefined;
+    for (let i = 0; i < 20; i++) {
+      const list = await httpRequest('GET', '/api/mcp/approvals');
+      if (list.body.pending?.length > 0) {
+        requestId = list.body.pending[0].requestId;
+        expect(list.body.pending[0].namespacedName).toBe('local:agent/danger');
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(requestId).toBeDefined();
+    expect(dangerExecutor).not.toHaveBeenCalled();
+
+    const approve = await httpRequest('POST', `/api/mcp/approvals/${requestId}`, {
+      body: { decision: 'allow' },
+    });
+    expect(approve.statusCode).toBe(200);
+
+    const result = await execPromise;
+    expect(result.isError).toBeUndefined();
+    expect(dangerExecutor).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('E2E: authenticated tools/call honors disabled_tools (after connection consent)', async () => {
+    writePolicy({
+      disabled_tools: ['local:agent/danger'],
+      auto_approve: ['local:agent/echo'],
+    });
+
+    const sessionId = await mcpConnect();
+    const call = await mcpJsonRpc('tools/call', {
+      name: 'danger',
+      arguments: {},
+    }, { id: 42, sessionId });
+
+    expect(call.http.statusCode).toBe(200);
+    const rpc = call.rpc;
+    if (rpc?.result) {
+      expect(rpc.result.isError).toBe(true);
+      expect(String(rpc.result.content?.[0]?.text || '')).toMatch(/disabled|not found|denied/i);
+    } else {
+      expect(String(rpc?.error?.message || '')).toMatch(/disabled|not found|denied/i);
+    }
+    expect(dangerExecutor).not.toHaveBeenCalled();
+  });
+
+  it('E2E: authenticated tools/call auto_approve executes (after connection consent)', async () => {
+    writePolicy({ auto_approve: ['local:agent/echo'] });
+
+    const sessionId = await mcpConnect();
+    const call = await mcpJsonRpc('tools/call', {
+      name: 'echo',
+      arguments: { msg: 'via-mcp' },
+    }, { id: 43, sessionId });
+
+    expect(call.http.statusCode).toBe(200);
+    expect(call.rpc?.result?.isError).not.toBe(true);
+    expect(echoExecutor).toHaveBeenCalled();
+    expect(String(call.rpc?.result?.content?.[0]?.text || '')).toContain('echoed');
+  });
+
+  it('E2E: require_approval via POST /mcp blocks until approve API', async () => {
+    writePolicy({
+      auto_approve: ['local:agent/echo'],
+      require_approval: ['local:agent/danger'],
+    });
+
+    const sessionId = await mcpConnect();
+    const callPromise = mcpJsonRpc('tools/call', {
+      name: 'danger',
+      arguments: {},
+    }, { id: 44, sessionId });
+
+    let requestId: string | undefined;
+    for (let i = 0; i < 40; i++) {
+      const list = await httpRequest('GET', '/api/mcp/approvals');
+      if (list.body.pending?.length > 0) {
+        requestId = list.body.pending[0].requestId;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(requestId).toBeDefined();
+    expect(dangerExecutor).not.toHaveBeenCalled();
+
+    await httpRequest('POST', `/api/mcp/approvals/${requestId}`, {
+      body: { decision: 'allow' },
+    });
+
+    const call = await callPromise;
+    expect(call.http.statusCode).toBe(200);
+    expect(call.rpc?.result?.isError).not.toBe(true);
+    expect(dangerExecutor).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Route `/mcp` tool calls through the shared `createToolValidator` / `authorizeToolExecution` path used by chat (DR-033).
- Require explicit connection consent before issuing an `Mcp-Session-Id`; reject `tools/call` without an approved session (DR-034).
- Add MCP approvals + connections APIs and dashboard UX; refuse to remember `unknown-client` / empty names.
- Pending connection/approval promises auto-deny after 5 minutes; remembered clients can be forgotten via REST/UI.
## Security model
- Layered: DR-030 Bearer/cookie auth → connection consent → shared tool policy.
- Consent is interactive friction for clients, not a second principal: the same API token can call `/mcp` and approve via `/api/mcp/connections`.
- `remember` is a DX shortcut on `clientInfo.name` for the daemon lifetime, not strong client identity.
## Decisions
- **DR-033** — MCP HTTP uses the same tool approval policy as chat (sessionful Streamable HTTP).
- **DR-034** — Explicit MCP connection consent, remember/forget, 5m pending TTL.
## Test plan
- [x] Rebased on `main` (post-#78); OpenAI passthrough behavior preserved
- [x] Integration: 401 unauthenticated `/mcp`, 403 without session, consent allow/deny/remember
- [x] Integration: `unknown-client` not remembered; forget remembered client
- [x] Integration: pending connection + approval TTL auto-deny
- [x] Integration: disabled / auto_approve / require_approval via MCP path
- [x] CI green on this branch
Issue: https://redhat.atlassian.net/browse/AAP-82806
