### PR TITLE
feat(openai-compat): opt-in tools passthrough for /v1

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -58,9 +58,11 @@ default from DR-019). Opt in to **passthrough** so clients like
 | Level | Key | UI |
 |-------|-----|-----|
 | Global | `openai_compat.tools: off \| passthrough` | YAML only |
-| Per model | `openai_compat_tools: off \| passthrough` | YAML or **Configure model** checkbox (“Allow OpenAI tools on /v1”) |
+| Per model | `openai_compat_tools: off \| passthrough` | YAML for both values; dashboard **Configure model** checkbox only sets `passthrough` or clears the key (inherit global) |
 
-Resolve order: **per-model → global → `off`**.
+Resolve order: **per-model → global → `off`**. To force a model `off` when
+global is `passthrough`, set `openai_compat_tools: off` in YAML (the checkbox
+cannot force `off`).
 
 ```yaml
 openai_compat:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,6 +48,38 @@ providers:
         model_id: "qwen2.5-coder:7b"        # Map virtual name to actual model ID
 ```
 
+### OpenAI-compatible tools (`openai_compat`) — DR-032
+
+By default, `POST /v1/chat/completions` **ignores** request `tools` (secure
+default from DR-019). Opt in to **passthrough** so clients like
+[Open WebUI](https://docs.openwebui.com/) Native function calling can send
+`tools`, receive structured `tool_calls`, and execute tools **themselves**.
+
+| Level | Key | UI |
+|-------|-----|-----|
+| Global | `openai_compat.tools: off \| passthrough` | YAML only |
+| Per model | `openai_compat_tools: off \| passthrough` | YAML or **Configure model** checkbox (“Allow OpenAI tools on /v1”) |
+
+Resolve order: **per-model → global → `off`**.
+
+```yaml
+openai_compat:
+  tools: off                         # default — Cursor/aider/scripts stay tool-free on /v1
+
+providers:
+  openrouter:
+    engine: openrouter
+    models:
+      anthropic/claude-sonnet-4: {}
+      x-ai/grok-3:
+        openai_compat_tools: passthrough   # Open WebUI Native FC for this model only
+```
+
+**Security tradeoff:** Passthrough trusts the client’s tool list and does not
+use Abbenay’s approval UI. Prefer enabling it only on models you use with
+trusted clients. For Abbenay-executed / approval-gated tools, use the dashboard,
+gRPC, or MCP paths instead of `/v1`.
+
 ### HTTP API security (`server`)
 
 The web dashboard, REST API (`/api/*`), OpenAI-compatible API (`/v1/*`), and

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -470,3 +470,23 @@ access returns "not found".
 not isolate sessions between authenticated principals sharing one daemon.
 Ownership closes H9: HTTP clients, CLI, and named consumers cannot enumerate
 or read each other's conversation history.
+
+---
+
+## DR-032: Opt-in OpenAI-compatible tools passthrough on `/v1`
+
+**Date:** 2026-07-17
+**Decision:** `/v1/chat/completions` keeps tools disabled by default (DR-019).
+Operators may opt in to **passthrough** via global `openai_compat.tools` and/or
+per-model `openai_compat_tools` (dashboard checkbox or YAML). In passthrough,
+Abbenay forwards client-provided OpenAI `tools` to the model and returns
+structured `tool_calls` (streaming and non-streaming); the **client** executes
+tools and posts `role: tool` follow-ups. Abbenay does not run MCP/tool
+execution or the approval UI on `/v1`. Resolve order: model override → global →
+`off`.
+**Rationale:** Clients such as Open WebUI Native function calling need
+OpenAI-shaped tool schemas and `tool_calls` through a drop-in `/v1` endpoint.
+Forcing tools off forever breaks those clients; enabling Abbenay-side execution
+on `/v1` without an approval UI would weaken DR-019. Passthrough preserves the
+secure default while unblocking client-executed tools for explicitly opted-in
+models.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -478,7 +478,9 @@ or read each other's conversation history.
 **Date:** 2026-07-17
 **Decision:** `/v1/chat/completions` keeps tools disabled by default (DR-019).
 Operators may opt in to **passthrough** via global `openai_compat.tools` and/or
-per-model `openai_compat_tools` (dashboard checkbox or YAML). In passthrough,
+per-model `openai_compat_tools` (YAML, or the dashboard checkbox which sets
+`passthrough` / clears the override; forcing per-model `off` is YAML-only).
+In passthrough,
 Abbenay forwards client-provided OpenAI `tools` to the model and returns
 structured `tool_calls` (streaming and non-streaming); the **client** executes
 tools and posts `role: tool` follow-ups. Abbenay does not run MCP/tool

--- a/packages/daemon/src/core/config.test.ts
+++ b/packages/daemon/src/core/config.test.ts
@@ -272,6 +272,20 @@ describe('mergeConfigs', () => {
     expect(result.providers!.ollama).toBeDefined();
     expect(result.providers!.ollama.engine).toBe('ollama');
   });
+
+  it('should merge openai_compat with workspace overriding user fields', () => {
+    const userConfig: ConfigFile = {
+      providers: {},
+      openai_compat: { tools: 'off' },
+    };
+    const wsConfig: ConfigFile = {
+      providers: {},
+      openai_compat: { tools: 'passthrough' },
+    };
+
+    const result = mergeConfigs(userConfig, wsConfig);
+    expect(result.openai_compat?.tools).toBe('passthrough');
+  });
 });
 
 // ── mergeMultipleWorkspaceConfigs ────────────────────────────────────────────

--- a/packages/daemon/src/core/config.ts
+++ b/packages/daemon/src/core/config.ts
@@ -45,6 +45,9 @@ export function isValidVirtualName(name: string): boolean {
  * - Key with `model_id` → the key is a virtual name, model_id is the actual engine model
  * - `{}` = enabled with all default params
  */
+/** Opt-in mode for OpenAI-compatible `/v1` tools (DR-032). */
+export type OpenAICompatToolsMode = 'off' | 'passthrough';
+
 export interface ModelConfig {
   /** Actual engine model ID — required when the key is a virtual name */
   model_id?: string;
@@ -64,6 +67,11 @@ export interface ModelConfig {
   max_tokens?: number;
   /** Request timeout in milliseconds */
   timeout?: number;
+  /**
+   * Per-model override for OpenAI-compatible `/v1` tools passthrough.
+   * When unset, inherits `openai_compat.tools` (default `off`).
+   */
+  openai_compat_tools?: OpenAICompatToolsMode;
 }
 
 /**
@@ -164,6 +172,15 @@ export interface ServerConfig {
  * Full configuration file structure.
  * Keys in `providers` are virtual provider names (user-defined IDs).
  */
+/**
+ * Global defaults for the OpenAI-compatible HTTP API (`/v1/*`).
+ * Secure-by-default: tools stay off unless opted in (DR-019 / DR-032).
+ */
+export interface OpenAICompatConfig {
+  /** `off` (default) | `passthrough` — forward client tools / return tool_calls */
+  tools?: OpenAICompatToolsMode;
+}
+
 export interface ConfigFile {
   providers?: Record<string, ProviderConfig>;
   /** External MCP servers for tool aggregation */
@@ -174,6 +191,8 @@ export interface ConfigFile {
   consumers?: Record<string, ConsumerConfig>;
   /** HTTP / web dashboard server security */
   server?: ServerConfig;
+  /** OpenAI-compatible `/v1` API defaults */
+  openai_compat?: OpenAICompatConfig;
 }
 
 // ── Path helpers ───────────────────────────────────────────────────────
@@ -352,6 +371,14 @@ export function mergeConfigs(userConfig: ConfigFile, workspaceConfig: ConfigFile
       require_approval: [...(up.require_approval || []), ...(wp.require_approval || [])],
       disabled_tools: [...(up.disabled_tools || []), ...(wp.disabled_tools || [])],
       aliases: { ...up.aliases, ...wp.aliases },
+    };
+  }
+
+  // openai_compat: workspace overrides user at field level
+  if (userConfig.openai_compat || workspaceConfig.openai_compat) {
+    merged.openai_compat = {
+      ...userConfig.openai_compat,
+      ...workspaceConfig.openai_compat,
     };
   }
   

--- a/packages/daemon/src/core/engines-tool-calls.test.ts
+++ b/packages/daemon/src/core/engines-tool-calls.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { extractToolCallFields } from './engines.js';
+import { coerceToolCallInput, extractToolCallFields } from './engines.js';
 
 describe('extractToolCallFields', () => {
   it('reads OpenAI nested function tool_calls', () => {
@@ -36,5 +36,23 @@ describe('extractToolCallFields', () => {
       name: '',
       arguments: undefined,
     });
+  });
+});
+
+describe('coerceToolCallInput', () => {
+  it('keeps plain objects', () => {
+    expect(coerceToolCallInput({ q: 'x' })).toEqual({ q: 'x' });
+  });
+
+  it('parses JSON object strings', () => {
+    expect(coerceToolCallInput('{"q":"x"}')).toEqual({ q: 'x' });
+  });
+
+  it('falls back to {} for primitives, arrays, and invalid JSON', () => {
+    expect(coerceToolCallInput('5')).toEqual({});
+    expect(coerceToolCallInput('[]')).toEqual({});
+    expect(coerceToolCallInput([])).toEqual({});
+    expect(coerceToolCallInput(null)).toEqual({});
+    expect(coerceToolCallInput('not-json')).toEqual({});
   });
 });

--- a/packages/daemon/src/core/engines-tool-calls.test.ts
+++ b/packages/daemon/src/core/engines-tool-calls.test.ts
@@ -37,6 +37,17 @@ describe('extractToolCallFields', () => {
       arguments: undefined,
     });
   });
+
+  it('rejects non-string id/name instead of String(object)', () => {
+    expect(extractToolCallFields({
+      id: { nested: true },
+      function: { name: { bad: true }, arguments: '{}' },
+    })).toEqual({
+      id: '',
+      name: '',
+      arguments: '{}',
+    });
+  });
 });
 
 describe('coerceToolCallInput', () => {

--- a/packages/daemon/src/core/engines-tool-calls.test.ts
+++ b/packages/daemon/src/core/engines-tool-calls.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for OpenAI / flat tool_calls normalization in the engine adapter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractToolCallFields } from './engines.js';
+
+describe('extractToolCallFields', () => {
+  it('reads OpenAI nested function tool_calls', () => {
+    expect(extractToolCallFields({
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'web_search', arguments: '{"q":"x"}' },
+    })).toEqual({
+      id: 'call_1',
+      name: 'web_search',
+      arguments: '{"q":"x"}',
+    });
+  });
+
+  it('reads flat Abbenay tool_calls', () => {
+    expect(extractToolCallFields({
+      id: 'call_2',
+      name: 'search',
+      arguments: { q: 'y' },
+    })).toEqual({
+      id: 'call_2',
+      name: 'search',
+      arguments: { q: 'y' },
+    });
+  });
+
+  it('tolerates missing fields', () => {
+    expect(extractToolCallFields(null)).toEqual({
+      id: '',
+      name: '',
+      arguments: undefined,
+    });
+  });
+});

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -905,13 +905,16 @@ export async function* streamChat(
     // Convert messages to Vercel AI SDK format
     const aiMessages = convertMessages(messages);
 
-    // Convert ToolDefinition[] to Vercel AI SDK tool() objects
-    const hasTools = tools && tools.length > 0 && toolExecutor;
+    // Convert ToolDefinition[] to Vercel AI SDK tool() objects.
+    // With an executor: Abbenay runs tools (auto mode).
+    // Without an executor: schemas only (passthrough) — client executes tools.
+    const hasTools = !!(tools && tools.length > 0);
+    const effectiveMaxSteps = hasTools && !toolExecutor ? 1 : maxSteps;
     let aiTools: ToolSet | undefined;
 
     if (hasTools) {
       const toolRecord: ToolSet = {};
-      for (const t of tools) {
+      for (const t of tools!) {
         let schema: JSONSchema7;
         try {
           schema = JSON.parse(t.inputSchema) as JSONSchema7;
@@ -925,18 +928,25 @@ export async function* streamChat(
           schema.properties = {};
         }
 
-        toolRecord[t.name] = tool({
-          description: t.description,
-          inputSchema: jsonSchema(schema),
-          execute: async (args: Record<string, unknown>) => {
-            if (toolValidator) {
-              const decision = await toolValidator(t.name, args);
-              if (decision === 'deny') return { error: 'Tool execution denied by policy' };
-              if (decision === 'abort') throw new Error('Tool execution aborted by policy');
-            }
-            return toolExecutor!(t.name, args);
-          },
-        });
+        if (toolExecutor) {
+          toolRecord[t.name] = tool({
+            description: t.description,
+            inputSchema: jsonSchema(schema),
+            execute: async (args: Record<string, unknown>) => {
+              if (toolValidator) {
+                const decision = await toolValidator(t.name, args);
+                if (decision === 'deny') return { error: 'Tool execution denied by policy' };
+                if (decision === 'abort') throw new Error('Tool execution aborted by policy');
+              }
+              return toolExecutor(t.name, args);
+            },
+          });
+        } else {
+          toolRecord[t.name] = tool({
+            description: t.description,
+            inputSchema: jsonSchema(schema),
+          });
+        }
       }
       aiTools = toolRecord;
     }
@@ -945,7 +955,7 @@ export async function* streamChat(
       model,
       messages: aiMessages,
       ...(aiTools ? { tools: aiTools } : {}),
-      ...(maxSteps > 1 ? { stopWhen: stepCountIs(maxSteps) } : {}),
+      ...(effectiveMaxSteps > 1 ? { stopWhen: stepCountIs(effectiveMaxSteps) } : {}),
       ...(params?.temperature != null ? { temperature: params.temperature } : {}),
       ...(params?.maxTokens != null ? { maxTokens: params.maxTokens } : {}),
       ...(params?.top_p != null ? { topP: params.top_p } : {}),
@@ -1007,6 +1017,27 @@ export async function* streamChat(
 // ── Message conversion ─────────────────────────────────────────────────
 
 /**
+ * Normalize a tool-call entry from flat Abbenay shape or OpenAI nested shape.
+ * Flat: `{ id, name, arguments }`
+ * OpenAI: `{ id, type, function: { name, arguments } }`
+ */
+export function extractToolCallFields(tc: unknown): {
+  id: string;
+  name: string;
+  arguments: unknown;
+} {
+  const item = tc && typeof tc === 'object' ? tc as Record<string, unknown> : {};
+  const fn = item.function && typeof item.function === 'object'
+    ? item.function as Record<string, unknown>
+    : undefined;
+  return {
+    id: String(item.id ?? ''),
+    name: String(fn?.name ?? item.name ?? ''),
+    arguments: fn?.arguments ?? item.arguments,
+  };
+}
+
+/**
  * Convert our internal message format to Vercel AI SDK ModelMessage format.
  */
 function convertMessages(messages: ChatMessage[]): ModelMessage[] {
@@ -1025,13 +1056,22 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
         }
         if (m.tool_calls && m.tool_calls.length > 0) {
           for (const tc of m.tool_calls) {
-            const item = tc && typeof tc === 'object' ? tc as Record<string, unknown> : {};
-            const args = item.arguments;
+            const { id, name, arguments: args } = extractToolCallFields(tc);
+            let input: Record<string, unknown> = {};
+            if (typeof args === 'string') {
+              try {
+                input = JSON.parse(args) as Record<string, unknown>;
+              } catch {
+                input = {};
+              }
+            } else if (args && typeof args === 'object') {
+              input = args as Record<string, unknown>;
+            }
             parts.push({
               type: 'tool-call',
-              toolCallId: String(item.id ?? ''),
-              toolName: String(item.name ?? ''),
-              input: typeof args === 'string' ? JSON.parse(args) as Record<string, unknown> : (args && typeof args === 'object' ? args as Record<string, unknown> : {}),
+              toolCallId: id,
+              toolName: name,
+              input,
             });
           }
         }

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -955,7 +955,9 @@ export async function* streamChat(
       model,
       messages: aiMessages,
       ...(aiTools ? { tools: aiTools } : {}),
-      ...(effectiveMaxSteps > 1 ? { stopWhen: stepCountIs(effectiveMaxSteps) } : {}),
+      // Always bound tool loops when tools are registered — including passthrough
+      // (effectiveMaxSteps === 1) so we do not rely on AI SDK defaults alone.
+      ...(aiTools ? { stopWhen: stepCountIs(effectiveMaxSteps) } : {}),
       ...(params?.temperature != null ? { temperature: params.temperature } : {}),
       ...(params?.maxTokens != null ? { maxTokens: params.maxTokens } : {}),
       ...(params?.top_p != null ? { topP: params.top_p } : {}),

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -1037,9 +1037,12 @@ export function extractToolCallFields(tc: unknown): {
   const fn = item.function && typeof item.function === 'object'
     ? item.function as Record<string, unknown>
     : undefined;
+  const rawId = item.id;
+  const rawName = fn?.name ?? item.name;
   return {
-    id: String(item.id ?? ''),
-    name: String(fn?.name ?? item.name ?? ''),
+    // Wire-protocol fields must be real strings — String(object) → "[object Object]".
+    id: typeof rawId === 'string' ? rawId : '',
+    name: typeof rawName === 'string' ? rawName : '',
     arguments: fn?.arguments ?? item.arguments,
   };
 }

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -1044,6 +1044,22 @@ export function extractToolCallFields(tc: unknown): {
   };
 }
 
+/** Coerce tool-call arguments to a plain object for the AI SDK `input` field. */
+export function coerceToolCallInput(args: unknown): Record<string, unknown> {
+  let value = args;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
 /**
  * Convert our internal message format to Vercel AI SDK ModelMessage format.
  */
@@ -1064,21 +1080,11 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
         if (m.tool_calls && m.tool_calls.length > 0) {
           for (const tc of m.tool_calls) {
             const { id, name, arguments: args } = extractToolCallFields(tc);
-            let input: Record<string, unknown> = {};
-            if (typeof args === 'string') {
-              try {
-                input = JSON.parse(args) as Record<string, unknown>;
-              } catch {
-                input = {};
-              }
-            } else if (args && typeof args === 'object') {
-              input = args as Record<string, unknown>;
-            }
             parts.push({
               type: 'tool-call',
               toolCallId: id,
               toolName: name,
-              input,
+              input: coerceToolCallInput(args),
             });
           }
         }

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -917,14 +917,19 @@ export async function* streamChat(
       for (const t of tools!) {
         let schema: JSONSchema7;
         try {
-          schema = JSON.parse(t.inputSchema) as JSONSchema7;
+          const parsed: unknown = JSON.parse(t.inputSchema);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            schema = parsed as JSONSchema7;
+          } else {
+            schema = { type: 'object', properties: {} };
+          }
         } catch {
           schema = { type: 'object', properties: {} };
         }
         if (!schema.type) {
           schema.type = 'object';
         }
-        if (!schema.properties) {
+        if (!schema.properties || typeof schema.properties !== 'object') {
           schema.properties = {};
         }
 

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -1083,10 +1083,15 @@ function convertMessages(messages: ChatMessage[]): ModelMessage[] {
         if (m.tool_calls && m.tool_calls.length > 0) {
           for (const tc of m.tool_calls) {
             const { id, name, arguments: args } = extractToolCallFields(tc);
+            const toolCallId = id.trim();
+            const toolName = name.trim();
+            if (!toolCallId || !toolName) {
+              continue;
+            }
             parts.push({
               type: 'tool-call',
-              toolCallId: id,
-              toolName: name,
+              toolCallId,
+              toolName,
               input: coerceToolCallInput(args),
             });
           }

--- a/packages/daemon/src/core/index.ts
+++ b/packages/daemon/src/core/index.ts
@@ -155,6 +155,7 @@ export {
 /** Shared constants */
 export { DEFAULT_WEB_PORT, DEFAULT_HTTP_HOST } from './constants.js';
 export type { ServerConfig } from './config.js';
+export type { OpenAICompatConfig, OpenAICompatToolsMode } from './config.js';
 
 /** Platform-aware path utilities */
 export {

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -612,7 +612,8 @@ export class CoreState {
       tools = undefined;
       resolvedExecutor = undefined;
     } else if (effectiveToolMode === 'passthrough') {
-      tools = undefined;
+      // Client-provided schemas only — no Abbenay executor (caller runs tools).
+      tools = toolOptions?.tools;
       resolvedExecutor = undefined;
       console.warn(`[State] passthrough mode: tools will be sent to LLM but not executed (delegated to caller)`);
     } else {
@@ -669,11 +670,14 @@ export class CoreState {
     }
 
     // ── Resolve maxSteps for tool loop ──
-    // Priority: caller > config tool_policy > policy tool.max_tool_iterations > default
-    const maxSteps = toolOptions?.maxToolIterations
-      ?? toolPolicy?.max_tool_iterations
-      ?? flatPolicy?.maxToolIterations
-      ?? 10;
+    // Priority: caller > config tool_policy > policy tool.max_tool_iterations > default.
+    // Passthrough never runs a multi-step executor loop — stop after the model proposes calls.
+    const maxSteps = effectiveToolMode === 'passthrough'
+      ? 1
+      : (toolOptions?.maxToolIterations
+        ?? toolPolicy?.max_tool_iterations
+        ?? flatPolicy?.maxToolIterations
+        ?? 10);
 
     // ── Call the actual engine ──
     const isJsonStrict = flatPolicy?.outputFormat === 'json_only';

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -329,6 +329,23 @@ describe('mapOpenAIToolsToDefinitions', () => {
     expect(mapOpenAIToolsToDefinitions(null)).toEqual([]);
     expect(mapOpenAIToolsToDefinitions([{ type: 'function', function: {} }])).toEqual([]);
   });
+
+  it('rejects non-function tool types', () => {
+    expect(mapOpenAIToolsToDefinitions([
+      { type: 'custom', function: { name: 'x', parameters: {} } },
+    ])).toEqual([]);
+  });
+
+  it('coerces non-object parameters to an empty object schema', () => {
+    const defs = mapOpenAIToolsToDefinitions([
+      {
+        type: 'function',
+        function: { name: 'web_search', parameters: 5 },
+      },
+    ]);
+    expect(defs).toHaveLength(1);
+    expect(JSON.parse(defs[0].inputSchema)).toEqual({ type: 'object', properties: {} });
+  });
 });
 
 describe('normalizeOpenAIToolCalls', () => {
@@ -355,5 +372,12 @@ describe('normalizeOpenAIToolCalls', () => {
     ]);
     expect(normalized![0].function.name).toBe('search');
     expect(normalized![0].function.arguments).toBe('{"q":"b"}');
+  });
+
+  it('skips entries with empty tool names', () => {
+    expect(normalizeOpenAIToolCalls([
+      { id: 'call_x', type: 'function', function: { name: '', arguments: '{}' } },
+      { id: 'call_y', name: '   ', arguments: '{}' },
+    ])).toBeUndefined();
   });
 });

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -269,6 +269,25 @@ describe('buildCompleteResponse', () => {
     expect(result.choices[0].message.content).toBeNull();
     expect(result.choices[0].message.tool_calls).toEqual(toolCalls);
   });
+
+  it('nulls content whenever tool_calls are present', () => {
+    const toolCalls = [{
+      id: 'call_abc',
+      type: 'function' as const,
+      function: { name: 'web_search', arguments: '{"q":"x"}' },
+    }];
+    const result = buildCompleteResponse(
+      'id',
+      'model',
+      0,
+      'thinking aloud',
+      'tool-calls',
+      toolCalls,
+    ) as any;
+
+    expect(result.choices[0].message.content).toBeNull();
+    expect(result.choices[0].message.tool_calls).toEqual(toolCalls);
+  });
 });
 
 // ── resolveOpenAICompatToolsMode ────────────────────────────────────────

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -16,6 +16,7 @@ import {
   resolveOpenAICompatToolsMode,
   mapOpenAIToolsToDefinitions,
   normalizeOpenAIToolCalls,
+  normalizeOpenAIChatMessage,
   type StreamChunkOptions,
 } from './openai-compat.js';
 import type { ModelInfo } from '../../core/state.js';
@@ -390,5 +391,47 @@ describe('normalizeOpenAIToolCalls', () => {
       { id: 'call_x', type: 'function', function: { name: '', arguments: '{}' } },
       { id: 'call_y', name: '   ', arguments: '{}' },
     ])).toBeUndefined();
+  });
+});
+
+describe('normalizeOpenAIChatMessage', () => {
+  it('keeps string primitives', () => {
+    expect(normalizeOpenAIChatMessage({
+      role: 'assistant',
+      content: 'hi',
+      name: 'bot',
+      tool_call_id: 'call_1',
+    })).toEqual({
+      role: 'assistant',
+      content: 'hi',
+      name: 'bot',
+      tool_call_id: 'call_1',
+      tool_calls: undefined,
+    });
+  });
+
+  it('coerces non-string content/role/name/tool_call_id', () => {
+    expect(normalizeOpenAIChatMessage({
+      role: 1,
+      content: { text: 'nope' },
+      name: ['x'],
+      tool_call_id: { id: 'y' },
+    })).toEqual({
+      role: 'user',
+      content: '',
+      name: undefined,
+      tool_call_id: undefined,
+      tool_calls: undefined,
+    });
+  });
+
+  it('tolerates non-object messages', () => {
+    expect(normalizeOpenAIChatMessage(null)).toEqual({
+      role: 'user',
+      content: '',
+      name: undefined,
+      tool_call_id: undefined,
+      tool_calls: undefined,
+    });
   });
 });

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -288,6 +288,24 @@ describe('buildCompleteResponse', () => {
     expect(result.choices[0].message.content).toBeNull();
     expect(result.choices[0].message.tool_calls).toEqual(toolCalls);
   });
+
+  it('forces finish_reason tool_calls when tool_calls are present', () => {
+    const toolCalls = [{
+      id: 'call_abc',
+      type: 'function' as const,
+      function: { name: 'web_search', arguments: '{"q":"x"}' },
+    }];
+    const result = buildCompleteResponse(
+      'id',
+      'model',
+      0,
+      '',
+      'stop',
+      toolCalls,
+    ) as any;
+
+    expect(result.choices[0].finish_reason).toBe('tool_calls');
+  });
 });
 
 // ── resolveOpenAICompatToolsMode ────────────────────────────────────────

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -425,6 +425,21 @@ describe('normalizeOpenAIChatMessage', () => {
     });
   });
 
+  it('trims role/name/tool_call_id whitespace', () => {
+    expect(normalizeOpenAIChatMessage({
+      role: 'assistant ',
+      content: 'hi',
+      name: ' bot ',
+      tool_call_id: ' call_1 ',
+    })).toEqual({
+      role: 'assistant',
+      content: 'hi',
+      name: 'bot',
+      tool_call_id: 'call_1',
+      tool_calls: undefined,
+    });
+  });
+
   it('tolerates non-object messages', () => {
     expect(normalizeOpenAIChatMessage(null)).toEqual({
       role: 'user',

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -13,10 +13,14 @@ import {
   buildStreamChunk,
   buildCompleteResponse,
   generateChatId,
+  resolveOpenAICompatToolsMode,
+  mapOpenAIToolsToDefinitions,
+  normalizeOpenAIToolCalls,
   type StreamChunkOptions,
 } from './openai-compat.js';
 import type { ModelInfo } from '../../core/state.js';
 import type { ChatChunk } from '../../core/engines.js';
+import type { ConfigFile } from '../../core/config.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- test assertions need flexible access to untyped response shapes */
 
@@ -232,5 +236,124 @@ describe('buildCompleteResponse', () => {
   it('maps finish reason correctly', () => {
     const result = buildCompleteResponse('id', 'model', 0, '', 'length') as any;
     expect(result.choices[0].finish_reason).toBe('length');
+  });
+
+  it('includes tool_calls on the assistant message when provided', () => {
+    const toolCalls = [{
+      id: 'call_abc',
+      type: 'function' as const,
+      function: { name: 'web_search', arguments: '{"q":"x"}' },
+    }];
+    const result = buildCompleteResponse(
+      'id',
+      'model',
+      0,
+      '',
+      'tool-calls',
+      toolCalls,
+    ) as any;
+
+    expect(result.choices[0].finish_reason).toBe('tool_calls');
+    expect(result.choices[0].message.content).toBeNull();
+    expect(result.choices[0].message.tool_calls).toEqual(toolCalls);
+  });
+});
+
+// ── resolveOpenAICompatToolsMode ────────────────────────────────────────
+
+describe('resolveOpenAICompatToolsMode', () => {
+  it('defaults to off with empty config', () => {
+    expect(resolveOpenAICompatToolsMode('openai/gpt-4o', {})).toBe('off');
+    expect(resolveOpenAICompatToolsMode('openai/gpt-4o', null)).toBe('off');
+  });
+
+  it('uses global openai_compat.tools', () => {
+    const config: ConfigFile = { openai_compat: { tools: 'passthrough' } };
+    expect(resolveOpenAICompatToolsMode('openai/gpt-4o', config)).toBe('passthrough');
+  });
+
+  it('prefers per-model override over global', () => {
+    const config: ConfigFile = {
+      openai_compat: { tools: 'off' },
+      providers: {
+        openrouter: {
+          engine: 'openrouter',
+          models: {
+            'x-ai/grok-3': { openai_compat_tools: 'passthrough' },
+          },
+        },
+      },
+    };
+    expect(resolveOpenAICompatToolsMode('openrouter/x-ai/grok-3', config)).toBe('passthrough');
+    expect(resolveOpenAICompatToolsMode('openrouter/other', config)).toBe('off');
+  });
+
+  it('allows model to force off when global is passthrough', () => {
+    const config: ConfigFile = {
+      openai_compat: { tools: 'passthrough' },
+      providers: {
+        openai: {
+          engine: 'openai',
+          models: { 'gpt-4o': { openai_compat_tools: 'off' } },
+        },
+      },
+    };
+    expect(resolveOpenAICompatToolsMode('openai/gpt-4o', config)).toBe('off');
+  });
+});
+
+// ── mapOpenAIToolsToDefinitions / normalizeOpenAIToolCalls ─────────────
+
+describe('mapOpenAIToolsToDefinitions', () => {
+  it('maps OpenAI function tools to ToolDefinition', () => {
+    const defs = mapOpenAIToolsToDefinitions([
+      {
+        type: 'function',
+        function: {
+          name: 'web_search',
+          description: 'Search the web',
+          parameters: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+      },
+    ]);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('web_search');
+    expect(defs[0].description).toBe('Search the web');
+    expect(JSON.parse(defs[0].inputSchema)).toEqual({
+      type: 'object',
+      properties: { q: { type: 'string' } },
+    });
+  });
+
+  it('returns empty for non-arrays and invalid entries', () => {
+    expect(mapOpenAIToolsToDefinitions(null)).toEqual([]);
+    expect(mapOpenAIToolsToDefinitions([{ type: 'function', function: {} }])).toEqual([]);
+  });
+});
+
+describe('normalizeOpenAIToolCalls', () => {
+  it('normalizes OpenAI nested tool_calls', () => {
+    const normalized = normalizeOpenAIToolCalls([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search', arguments: '{"q":"a"}' },
+      },
+    ]);
+    expect(normalized).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search', arguments: '{"q":"a"}' },
+      },
+    ]);
+  });
+
+  it('normalizes flat tool_calls', () => {
+    const normalized = normalizeOpenAIToolCalls([
+      { id: 'call_2', name: 'search', arguments: { q: 'b' } },
+    ]);
+    expect(normalized![0].function.name).toBe('search');
+    expect(normalized![0].function.arguments).toBe('{"q":"b"}');
   });
 });

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -169,6 +169,17 @@ describe('buildStreamChunk', () => {
       };
       expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
     });
+
+    it('returns null for running tool chunks with empty name', () => {
+      const chunk: ChatChunk = {
+        type: 'tool',
+        name: '',
+        state: 'running',
+        call: { params: { q: 'test' }, result: undefined },
+        done: false,
+      };
+      expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
+    });
   });
 
   describe('done chunks', () => {

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -3,14 +3,23 @@
  *
  * Translates between the OpenAI wire format and Abbenay's DaemonState,
  * making Abbenay a drop-in replacement for any OpenAI-compatible client
- * (Cursor, Continue, aider, any `openai` SDK script, etc.).
+ * (Cursor, Continue, aider, Open WebUI, any `openai` SDK script, etc.).
+ *
+ * Tools on `/v1` are off by default (DR-019). Opt-in passthrough (DR-032)
+ * forwards client `tools` and returns `tool_calls` for client-side execution.
  */
 
 import * as crypto from 'node:crypto';
 import type { Express, Request, Response } from 'express';
 import type { DaemonState } from '../../daemon/state.js';
 import type { ModelInfo, ChatToolOptions } from '../../core/state.js';
-import type { ChatChunk } from '../../core/engines.js';
+import type { ChatChunk, ToolDefinition } from '../../core/engines.js';
+import { extractToolCallFields } from '../../core/engines.js';
+import {
+  loadConfig,
+  type ConfigFile,
+  type OpenAICompatToolsMode,
+} from '../../core/config.js';
 
 // ── Format helpers (exported for unit testing) ──────────────────────────
 
@@ -43,6 +52,81 @@ export interface StreamChunkOptions {
   id: string;
   model: string;
   created: number;
+}
+
+export interface OpenAIToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+/**
+ * Resolve `/v1` tools mode: model override → global → `off`.
+ */
+export function resolveOpenAICompatToolsMode(
+  compositeModelId: string,
+  config: ConfigFile | null | undefined,
+): OpenAICompatToolsMode {
+  const globalMode = config?.openai_compat?.tools === 'passthrough' ? 'passthrough' : 'off';
+  const slashIdx = compositeModelId.indexOf('/');
+  if (slashIdx === -1) {
+    return globalMode;
+  }
+  const providerId = compositeModelId.substring(0, slashIdx);
+  const modelName = compositeModelId.substring(slashIdx + 1);
+  const modelMode = config?.providers?.[providerId]?.models?.[modelName]?.openai_compat_tools;
+  if (modelMode === 'passthrough' || modelMode === 'off') {
+    return modelMode;
+  }
+  return globalMode;
+}
+
+/**
+ * Map OpenAI `tools` request entries to Abbenay ToolDefinition[].
+ */
+export function mapOpenAIToolsToDefinitions(tools: unknown): ToolDefinition[] {
+  if (!Array.isArray(tools)) {
+    return [];
+  }
+  const out: ToolDefinition[] = [];
+  for (const entry of tools) {
+    if (!entry || typeof entry !== 'object') continue;
+    const t = entry as Record<string, unknown>;
+    const fn = t.function && typeof t.function === 'object'
+      ? t.function as Record<string, unknown>
+      : undefined;
+    const name = typeof fn?.name === 'string' ? fn.name : undefined;
+    if (!name) continue;
+    const description = typeof fn?.description === 'string' ? fn.description : '';
+    const parameters = fn?.parameters ?? { type: 'object', properties: {} };
+    out.push({
+      name,
+      description,
+      inputSchema: JSON.stringify(parameters),
+    });
+  }
+  return out;
+}
+
+/**
+ * Normalize OpenAI nested tool_calls on inbound messages to a stable shape
+ * that convertMessages / engines understand (also accepts flat entries).
+ */
+export function normalizeOpenAIToolCalls(toolCalls: unknown): OpenAIToolCall[] | undefined {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return undefined;
+  }
+  return toolCalls.map((tc) => {
+    const { id, name, arguments: args } = extractToolCallFields(tc);
+    const argStr = typeof args === 'string'
+      ? args
+      : JSON.stringify(args ?? {});
+    return {
+      id: id || `call_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+      type: 'function' as const,
+      function: { name, arguments: argStr },
+    };
+  });
 }
 
 export function buildStreamChunk(
@@ -98,7 +182,15 @@ export function buildCompleteResponse(
   created: number,
   content: string,
   finishReason: string,
+  toolCalls?: OpenAIToolCall[],
 ): object {
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    content: toolCalls && toolCalls.length > 0 ? (content || null) : content,
+  };
+  if (toolCalls && toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
   return {
     id,
     object: 'chat.completion',
@@ -106,7 +198,7 @@ export function buildCompleteResponse(
     model,
     choices: [{
       index: 0,
-      message: { role: 'assistant', content },
+      message,
       finish_reason: mapFinishReason(finishReason),
     }],
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
@@ -115,6 +207,22 @@ export function buildCompleteResponse(
 
 function openAIError(res: Response, status: number, message: string, type: string): void {
   res.status(status).json({ error: { message, type } });
+}
+
+function toolCallFromChunk(chunk: ChatChunk): OpenAIToolCall | null {
+  if (chunk.type !== 'tool' || chunk.state !== 'running' || !chunk.call) {
+    return null;
+  }
+  return {
+    id: `call_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+    type: 'function',
+    function: {
+      name: chunk.name || '',
+      arguments: typeof chunk.call.params === 'string'
+        ? chunk.call.params
+        : JSON.stringify(chunk.call.params ?? {}),
+    },
+  };
 }
 
 // ── Route registration ──────────────────────────────────────────────────
@@ -151,6 +259,7 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
       top_p,
       max_tokens,
       max_completion_tokens,
+      tools,
     } = req.body;
 
     if (!model) {
@@ -168,7 +277,7 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
         content: m.content || '',
         name: m.name || undefined,
         tool_call_id: m.tool_call_id || undefined,
-        tool_calls: m.tool_calls || undefined,
+        tool_calls: normalizeOpenAIToolCalls(m.tool_calls) ?? m.tool_calls ?? undefined,
       }),
     );
 
@@ -179,13 +288,13 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
     if (effectiveMaxTokens != null) requestParams.maxTokens = effectiveMaxTokens;
     const hasParams = Object.keys(requestParams).length > 0;
 
-    // OpenAI-compatible transport has no approval UI, so tools are disabled
-    // to preserve secure-by-default (DR-019). M2 can add opt-in via config
-    // that would parse `tools` from the request and wire onToolApprovalNeeded.
-    const toolOptions: ChatToolOptions = {
-      toolMode: 'none',
-      tools: undefined,
-    };
+    // Secure-by-default (DR-019): tools off unless config opts into passthrough (DR-032).
+    const config = loadConfig();
+    const mode = resolveOpenAICompatToolsMode(String(model), config);
+    const mappedTools = mapOpenAIToolsToDefinitions(tools);
+    const toolOptions: ChatToolOptions = mode === 'passthrough' && mappedTools.length > 0
+      ? { toolMode: 'passthrough', tools: mappedTools, maxToolIterations: 1 }
+      : { toolMode: 'none', tools: undefined };
 
     const chatId = generateChatId();
     const created = Math.floor(Date.now() / 1000);
@@ -204,7 +313,7 @@ function handleStreaming(
   res: Response,
   state: DaemonState,
   model: string,
-  messages: Array<{ role: string; content: string }>,
+  messages: Array<{ role: string; content: string; name?: string; tool_call_id?: string; tool_calls?: unknown }>,
   params: Record<string, unknown> | undefined,
   toolOptions: ChatToolOptions,
   chatId: string,
@@ -272,7 +381,7 @@ async function handleNonStreaming(
   res: Response,
   state: DaemonState,
   model: string,
-  messages: Array<{ role: string; content: string }>,
+  messages: Array<{ role: string; content: string; name?: string; tool_call_id?: string; tool_calls?: unknown }>,
   params: Record<string, unknown> | undefined,
   toolOptions: ChatToolOptions,
   chatId: string,
@@ -281,10 +390,14 @@ async function handleNonStreaming(
   try {
     let content = '';
     let finishReason = 'stop';
+    const toolCalls: OpenAIToolCall[] = [];
 
     for await (const chunk of state.chat(model, messages, params, toolOptions)) {
       if (chunk.type === 'text') {
         content += chunk.text;
+      } else if (chunk.type === 'tool') {
+        const tc = toolCallFromChunk(chunk);
+        if (tc) toolCalls.push(tc);
       } else if (chunk.type === 'done') {
         finishReason = chunk.finishReason;
       } else if (chunk.type === 'error') {
@@ -293,7 +406,14 @@ async function handleNonStreaming(
       }
     }
 
-    res.json(buildCompleteResponse(chatId, model, created, content, finishReason));
+    res.json(buildCompleteResponse(
+      chatId,
+      model,
+      created,
+      content,
+      finishReason,
+      toolCalls.length > 0 ? toolCalls : undefined,
+    ));
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     openAIError(res, 500, msg, 'server_error');

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -175,11 +175,11 @@ export function normalizeOpenAIChatMessage(raw: unknown): {
   tool_calls?: OpenAIToolCall[];
 } {
   const m = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
-  const role = typeof m.role === 'string' && m.role.trim() ? m.role : 'user';
+  const role = typeof m.role === 'string' && m.role.trim() ? m.role.trim() : 'user';
   const content = typeof m.content === 'string' ? m.content : '';
-  const name = typeof m.name === 'string' && m.name ? m.name : undefined;
-  const tool_call_id = typeof m.tool_call_id === 'string' && m.tool_call_id
-    ? m.tool_call_id
+  const name = typeof m.name === 'string' && m.name.trim() ? m.name.trim() : undefined;
+  const tool_call_id = typeof m.tool_call_id === 'string' && m.tool_call_id.trim()
+    ? m.tool_call_id.trim()
     : undefined;
   return {
     role,

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -272,13 +272,18 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
     }
 
     const chatMessages = messages.map(
-      (m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown }) => ({
-        role: m.role || 'user',
-        content: m.content || '',
-        name: m.name || undefined,
-        tool_call_id: m.tool_call_id || undefined,
-        tool_calls: normalizeOpenAIToolCalls(m.tool_calls) ?? m.tool_calls ?? undefined,
-      }),
+      (m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown }) => {
+        const normalized = normalizeOpenAIToolCalls(m.tool_calls);
+        const toolCalls = normalized
+          ?? (Array.isArray(m.tool_calls) ? m.tool_calls as unknown[] : undefined);
+        return {
+          role: m.role || 'user',
+          content: m.content || '',
+          name: m.name || undefined,
+          tool_call_id: m.tool_call_id || undefined,
+          tool_calls: toolCalls,
+        };
+      },
     );
 
     const requestParams: Record<string, unknown> = {};
@@ -289,12 +294,18 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
     const hasParams = Object.keys(requestParams).length > 0;
 
     // Secure-by-default (DR-019): tools off unless config opts into passthrough (DR-032).
-    const config = loadConfig();
-    const mode = resolveOpenAICompatToolsMode(String(model), config);
-    const mappedTools = mapOpenAIToolsToDefinitions(tools);
-    const toolOptions: ChatToolOptions = mode === 'passthrough' && mappedTools.length > 0
-      ? { toolMode: 'passthrough', tools: mappedTools, maxToolIterations: 1 }
-      : { toolMode: 'none', tools: undefined };
+    // Skip disk config + tool mapping when the request has no tools (common default path).
+    let toolOptions: ChatToolOptions = { toolMode: 'none', tools: undefined };
+    if (Array.isArray(tools) && tools.length > 0) {
+      const config = loadConfig();
+      const mode = resolveOpenAICompatToolsMode(String(model), config);
+      if (mode === 'passthrough') {
+        const mappedTools = mapOpenAIToolsToDefinitions(tools);
+        if (mappedTools.length > 0) {
+          toolOptions = { toolMode: 'passthrough', tools: mappedTools, maxToolIterations: 1 };
+        }
+      }
+    }
 
     const chatId = generateChatId();
     const created = Math.floor(Date.now() / 1000);
@@ -313,7 +324,7 @@ function handleStreaming(
   res: Response,
   state: DaemonState,
   model: string,
-  messages: Array<{ role: string; content: string; name?: string; tool_call_id?: string; tool_calls?: unknown }>,
+  messages: Array<{ role: string; content: string; name?: string; tool_call_id?: string; tool_calls?: unknown[] }>,
   params: Record<string, unknown> | undefined,
   toolOptions: ChatToolOptions,
   chatId: string,
@@ -381,7 +392,7 @@ async function handleNonStreaming(
   res: Response,
   state: DaemonState,
   model: string,
-  messages: Array<{ role: string; content: string; name?: string; tool_call_id?: string; tool_calls?: unknown }>,
+  messages: Array<{ role: string; content: string; name?: string; tool_call_id?: string; tool_calls?: unknown[] }>,
   params: Record<string, unknown> | undefined,
   toolOptions: ChatToolOptions,
   chatId: string,

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -163,6 +163,33 @@ export function normalizeOpenAIToolCalls(toolCalls: unknown): OpenAIToolCall[] |
   return out.length > 0 ? out : undefined;
 }
 
+/**
+ * Coerce a single OpenAI chat message into Abbenay ChatMessage primitives.
+ * Non-string content/role/name/tool_call_id must not reach core `.trim()` paths.
+ */
+export function normalizeOpenAIChatMessage(raw: unknown): {
+  role: string;
+  content: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: OpenAIToolCall[];
+} {
+  const m = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
+  const role = typeof m.role === 'string' && m.role.trim() ? m.role : 'user';
+  const content = typeof m.content === 'string' ? m.content : '';
+  const name = typeof m.name === 'string' && m.name ? m.name : undefined;
+  const tool_call_id = typeof m.tool_call_id === 'string' && m.tool_call_id
+    ? m.tool_call_id
+    : undefined;
+  return {
+    role,
+    content,
+    name,
+    tool_call_id,
+    tool_calls: normalizeOpenAIToolCalls(m.tool_calls),
+  };
+}
+
 export function buildStreamChunk(
   chunk: ChatChunk,
   opts: StreamChunkOptions,
@@ -313,16 +340,7 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
       return;
     }
 
-    const chatMessages = messages.map(
-      (m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown }) => ({
-        role: m.role || 'user',
-        content: m.content || '',
-        name: m.name || undefined,
-        tool_call_id: m.tool_call_id || undefined,
-        // Only pass sanitized tool_calls — never the raw request array.
-        tool_calls: normalizeOpenAIToolCalls(m.tool_calls),
-      }),
-    );
+    const chatMessages = messages.map((m: unknown) => normalizeOpenAIChatMessage(m));
 
     const requestParams: Record<string, unknown> = {};
     if (temperature != null) requestParams.temperature = temperature;

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -81,6 +81,34 @@ export function resolveOpenAICompatToolsMode(
   return globalMode;
 }
 
+/** Defensive JSON.stringify for untrusted client payloads. */
+function safeJsonStringify(value: unknown, fallback: string): string {
+  try {
+    const s = JSON.stringify(value);
+    return typeof s === 'string' ? s : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Coerce OpenAI tool `parameters` into a JSON Schema object safe for engines.ts.
+ */
+export function coerceToolParametersSchema(parameters: unknown): Record<string, unknown> {
+  if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+    const obj = parameters as Record<string, unknown>;
+    const properties = (obj.properties && typeof obj.properties === 'object' && !Array.isArray(obj.properties))
+      ? obj.properties
+      : {};
+    return {
+      ...obj,
+      type: typeof obj.type === 'string' ? obj.type : 'object',
+      properties,
+    };
+  }
+  return { type: 'object', properties: {} };
+}
+
 /**
  * Map OpenAI `tools` request entries to Abbenay ToolDefinition[].
  */
@@ -92,17 +120,19 @@ export function mapOpenAIToolsToDefinitions(tools: unknown): ToolDefinition[] {
   for (const entry of tools) {
     if (!entry || typeof entry !== 'object') continue;
     const t = entry as Record<string, unknown>;
+    // OpenAI tools are type:"function"; reject other tool kinds.
+    if (t.type !== undefined && t.type !== 'function') continue;
     const fn = t.function && typeof t.function === 'object'
       ? t.function as Record<string, unknown>
       : undefined;
-    const name = typeof fn?.name === 'string' ? fn.name : undefined;
+    const name = typeof fn?.name === 'string' ? fn.name.trim() : '';
     if (!name) continue;
     const description = typeof fn?.description === 'string' ? fn.description : '';
-    const parameters = fn?.parameters ?? { type: 'object', properties: {} };
+    const parameters = coerceToolParametersSchema(fn?.parameters);
     out.push({
       name,
       description,
-      inputSchema: JSON.stringify(parameters),
+      inputSchema: safeJsonStringify(parameters, '{"type":"object","properties":{}}'),
     });
   }
   return out;
@@ -116,17 +146,21 @@ export function normalizeOpenAIToolCalls(toolCalls: unknown): OpenAIToolCall[] |
   if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
     return undefined;
   }
-  return toolCalls.map((tc) => {
+  const out: OpenAIToolCall[] = [];
+  for (const tc of toolCalls) {
     const { id, name, arguments: args } = extractToolCallFields(tc);
+    const toolName = name.trim();
+    if (!toolName) continue;
     const argStr = typeof args === 'string'
       ? args
-      : JSON.stringify(args ?? {});
-    return {
+      : safeJsonStringify(args ?? {}, '{}');
+    out.push({
       id: id || `call_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
       type: 'function' as const,
-      function: { name, arguments: argStr },
-    };
-  });
+      function: { name: toolName, arguments: argStr },
+    });
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 export function buildStreamChunk(

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -266,7 +266,8 @@ export function buildCompleteResponse(
     choices: [{
       index: 0,
       message,
-      finish_reason: mapFinishReason(finishReason),
+      // Clients expect tool_calls finish_reason whenever message.tool_calls is set.
+      finish_reason: mapFinishReason(hasToolCalls ? 'tool-calls' : finishReason),
     }],
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
   };

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -420,14 +420,14 @@ function handleStreaming(
       for await (const chunk of state.chat(model, messages, params, toolOptions)) {
         if (ended) break;
 
-        if (chunk.type === 'tool' && chunk.state === 'running') {
-          toolCallIndex++;
-        }
-
-        const mapped = buildStreamChunk(chunk, opts, toolCallIndex - 1, isFirstChunk);
+        const mapped = buildStreamChunk(chunk, opts, toolCallIndex, isFirstChunk);
         if (mapped) {
           safeWrite(`data: ${JSON.stringify(mapped)}\n\n`);
           isFirstChunk = false;
+          // Only advance after a tool_calls delta is actually emitted (empty names return null).
+          if (chunk.type === 'tool' && chunk.state === 'running') {
+            toolCallIndex++;
+          }
         }
 
         if (chunk.type === 'error') {

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -185,15 +185,19 @@ export function buildStreamChunk(
   if (chunk.type === 'tool' && chunk.state === 'running' && chunk.call) {
     const delta: Record<string, unknown> = {};
     if (isFirstChunk) delta.role = 'assistant';
+    const toolName = (chunk.name || '').trim();
+    if (!toolName) {
+      return null;
+    }
     delta.tool_calls = [{
       index: toolCallIndex,
       id: `call_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
       type: 'function',
       function: {
-        name: chunk.name,
+        name: toolName,
         arguments: typeof chunk.call.params === 'string'
           ? chunk.call.params
-          : JSON.stringify(chunk.call.params ?? {}),
+          : safeJsonStringify(chunk.call.params ?? {}, '{}'),
       },
     }];
     return { ...base, choices: [{ index: 0, delta, finish_reason: null }] };
@@ -247,14 +251,18 @@ function toolCallFromChunk(chunk: ChatChunk): OpenAIToolCall | null {
   if (chunk.type !== 'tool' || chunk.state !== 'running' || !chunk.call) {
     return null;
   }
+  const name = (chunk.name || '').trim();
+  if (!name) {
+    return null;
+  }
   return {
     id: `call_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
     type: 'function',
     function: {
-      name: chunk.name || '',
+      name,
       arguments: typeof chunk.call.params === 'string'
         ? chunk.call.params
-        : JSON.stringify(chunk.call.params ?? {}),
+        : safeJsonStringify(chunk.call.params ?? {}, '{}'),
     },
   };
 }
@@ -306,18 +314,14 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
     }
 
     const chatMessages = messages.map(
-      (m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown }) => {
-        const normalized = normalizeOpenAIToolCalls(m.tool_calls);
-        const toolCalls = normalized
-          ?? (Array.isArray(m.tool_calls) ? m.tool_calls as unknown[] : undefined);
-        return {
-          role: m.role || 'user',
-          content: m.content || '',
-          name: m.name || undefined,
-          tool_call_id: m.tool_call_id || undefined,
-          tool_calls: toolCalls,
-        };
-      },
+      (m: { role?: string; content?: string; name?: string; tool_call_id?: string; tool_calls?: unknown }) => ({
+        role: m.role || 'user',
+        content: m.content || '',
+        name: m.name || undefined,
+        tool_call_id: m.tool_call_id || undefined,
+        // Only pass sanitized tool_calls — never the raw request array.
+        tool_calls: normalizeOpenAIToolCalls(m.tool_calls),
+      }),
     );
 
     const requestParams: Record<string, unknown> = {};

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -249,11 +249,13 @@ export function buildCompleteResponse(
   finishReason: string,
   toolCalls?: OpenAIToolCall[],
 ): object {
+  const hasToolCalls = Boolean(toolCalls && toolCalls.length > 0);
   const message: Record<string, unknown> = {
     role: 'assistant',
-    content: toolCalls && toolCalls.length > 0 ? (content || null) : content,
+    // OpenAI clients often ignore tool_calls when content is a non-null string.
+    content: hasToolCalls ? null : content,
   };
-  if (toolCalls && toolCalls.length > 0) {
+  if (hasToolCalls) {
     message.tool_calls = toolCalls;
   }
   return {

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -1054,9 +1054,9 @@
                              @change="updateModelParam(modelName, 'openai_compat_tools', $event.target.checked ? 'passthrough' : undefined)">
                       <span>
                         <span style="font-weight: 500;">Allow OpenAI tools on /v1</span>
-                        <span class="info-tip" data-tip="When checked, /v1/chat/completions forwards client tools and returns tool_calls for this model. The client executes tools (e.g. Open WebUI Native FC) — Abbenay does not run an approval UI on /v1. Unchecked inherits the global openai_compat.tools default (off)." @mouseenter="showTip($el)" @mouseleave="hideTip()"><span class="info-icon">i</span></span>
+                        <span class="info-tip" data-tip="Checked: force tools passthrough for this model on /v1 (client executes tools; no Abbenay approval UI). Unchecked: clear the per-model override and inherit global openai_compat.tools — which defaults to off, but if global is passthrough this model stays enabled." @mouseenter="showTip($el)" @mouseleave="hideTip()"><span class="info-icon">i</span></span>
                         <div style="font-size: 0.75rem; color: #6a6e73; margin-top: 4px;">
-                          For clients that send tools and run them locally (passthrough). Secure default remains off.
+                          Passthrough for client-executed tools (e.g. Open WebUI). Unchecked inherits global (default off).
                         </div>
                       </span>
                     </label>

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -1044,6 +1044,24 @@
                     </div>
                   </fieldset>
 
+                  <!-- OpenAI-compatible /v1 tools (DR-032) -->
+                  <fieldset style="border: 1px solid #d2d2d2; border-radius: 4px; padding: 16px; margin-bottom: 16px;">
+                    <legend style="font-size: 0.85rem; font-weight: 600; padding: 0 8px;">OpenAI-compatible API</legend>
+                    <label style="display: flex; align-items: flex-start; gap: 8px; font-size: 0.85rem; cursor: pointer;">
+                      <input type="checkbox"
+                             style="margin-top: 2px;"
+                             :checked="cfg.openai_compat_tools === 'passthrough'"
+                             @change="updateModelParam(modelName, 'openai_compat_tools', $event.target.checked ? 'passthrough' : undefined)">
+                      <span>
+                        <span style="font-weight: 500;">Allow OpenAI tools on /v1</span>
+                        <span class="info-tip" data-tip="When checked, /v1/chat/completions forwards client tools and returns tool_calls for this model. The client executes tools (e.g. Open WebUI Native FC) — Abbenay does not run an approval UI on /v1. Unchecked inherits the global openai_compat.tools default (off)." @mouseenter="showTip($el)" @mouseleave="hideTip()"><span class="info-icon">i</span></span>
+                        <div style="font-size: 0.75rem; color: #6a6e73; margin-top: 4px;">
+                          For clients that send tools and run them locally (passthrough). Secure default remains off.
+                        </div>
+                      </span>
+                    </label>
+                  </fieldset>
+
                   <!-- Add Variant removed — user can add same model again from Available list -->
                 </div>
               </div>
@@ -1548,6 +1566,7 @@ function dashboard() {
       if (params.top_k != null) parts.push(`top_k=${params.top_k}`);
       if (params.max_tokens != null) parts.push(`max=${params.max_tokens}`);
       if (params.system_prompt) parts.push('sys_prompt');
+      if (params.openai_compat_tools === 'passthrough') parts.push('v1_tools');
       return parts.length > 0 ? parts.join(', ') : 'default';
     },
     

--- a/packages/daemon/tests/integration/openai-compat.test.ts
+++ b/packages/daemon/tests/integration/openai-compat.test.ts
@@ -7,13 +7,15 @@
  * streaming, non-streaming, error handling, and tool calls.
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import * as http from 'node:http';
 import { createWebApp } from '../../src/daemon/web/server.js';
 import type { DaemonState } from '../../src/daemon/state.js';
-import type { ProviderInfo, ModelInfo } from '../../src/core/state.js';
+import type { ProviderInfo, ModelInfo, ChatToolOptions } from '../../src/core/state.js';
 import type { ConnectedClient } from '../../src/daemon/state.js';
 import type { SecretStore } from '../../src/core/secrets.js';
+import * as configMod from '../../src/core/config.js';
+import type { ConfigFile } from '../../src/core/config.js';
 
 // ── Mock DaemonState ────────────────────────────────────────────────────
 
@@ -31,6 +33,10 @@ let mockChatConfig: MockChatConfig = {
   ],
   chunkDelayMs: 0,
 };
+
+/** Last toolOptions passed to mock chat (for tools passthrough assertions). */
+let lastChatToolOptions: ChatToolOptions | undefined;
+let mockLoadConfigResult: ConfigFile = { providers: {} };
 
 const mockSecretStore: SecretStore = {
   async get() { return null; },
@@ -66,7 +72,13 @@ function createMockState(): DaemonState {
       ] as ModelInfo[];
     },
 
-    async* chat() {
+    async* chat(
+      _model: string,
+      _messages: unknown,
+      _params?: unknown,
+      toolOptions?: ChatToolOptions,
+    ) {
+      lastChatToolOptions = toolOptions;
       if (mockChatConfig.throwError) {
         throw new Error(mockChatConfig.throwError);
       }
@@ -84,6 +96,7 @@ let httpServer: http.Server;
 let baseUrl: string;
 
 beforeAll(async () => {
+  vi.spyOn(configMod, 'loadConfig').mockImplementation(() => mockLoadConfigResult);
   const state = createMockState();
   const app = createWebApp(state, { apiToken: 'test-integration-token', skipConfig: true });
   const port = await new Promise<number>((resolve) => {
@@ -96,6 +109,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  vi.restoreAllMocks();
   if (httpServer) {
     await new Promise<void>((resolve) => httpServer.close(() => resolve()));
   }
@@ -110,6 +124,8 @@ beforeEach(() => {
     ],
     chunkDelayMs: 0,
   };
+  lastChatToolOptions = undefined;
+  mockLoadConfigResult = { providers: {} };
 });
 
 // ── HTTP helpers ────────────────────────────────────────────────────────
@@ -427,6 +443,15 @@ describe('POST /v1/chat/completions — error cases', () => {
 });
 
 describe('POST /v1/chat/completions — tool calls', () => {
+  const sampleTools = [{
+    type: 'function',
+    function: {
+      name: 'web_search',
+      description: 'Search',
+      parameters: { type: 'object', properties: { q: { type: 'string' } } },
+    },
+  }];
+
   it('streams tool calls in OpenAI tool_calls format', async () => {
     mockChatConfig = {
       chunks: [
@@ -450,6 +475,74 @@ describe('POST /v1/chat/completions — tool calls', () => {
 
     const doneChunk = events.find(e => e.choices?.[0]?.finish_reason === 'tool_calls');
     expect(doneChunk).toBeDefined();
+  });
+
+  it('ignores request tools when openai_compat tools mode is off (default)', async () => {
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+    });
+
+    expect(lastChatToolOptions?.toolMode).toBe('none');
+    expect(lastChatToolOptions?.tools).toBeUndefined();
+  });
+
+  it('forwards tools in passthrough mode when globally enabled', async () => {
+    mockLoadConfigResult = { openai_compat: { tools: 'passthrough' } };
+
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+    });
+
+    expect(lastChatToolOptions?.toolMode).toBe('passthrough');
+    expect(lastChatToolOptions?.tools).toHaveLength(1);
+    expect(lastChatToolOptions?.tools?.[0].name).toBe('web_search');
+  });
+
+  it('forwards tools when per-model openai_compat_tools is passthrough', async () => {
+    mockLoadConfigResult = {
+      providers: {
+        openai: {
+          engine: 'openai',
+          models: { 'gpt-4o': { openai_compat_tools: 'passthrough' } },
+        },
+      },
+    };
+
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+    });
+
+    expect(lastChatToolOptions?.toolMode).toBe('passthrough');
+    expect(lastChatToolOptions?.tools?.[0].name).toBe('web_search');
+  });
+
+  it('returns non-streaming tool_calls when chat yields tool chunks', async () => {
+    mockLoadConfigResult = { openai_compat: { tools: 'passthrough' } };
+    mockChatConfig = {
+      chunks: [
+        { type: 'tool', name: 'web_search', state: 'running', call: { params: { q: 'x' }, result: undefined }, done: false },
+        { type: 'done', finishReason: 'tool-calls' },
+      ],
+      chunkDelayMs: 0,
+    };
+
+    const { statusCode, body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Search' }],
+      tools: sampleTools,
+    });
+
+    expect(statusCode).toBe(200);
+    expect(body.choices[0].finish_reason).toBe('tool_calls');
+    expect(body.choices[0].message.tool_calls).toHaveLength(1);
+    expect(body.choices[0].message.tool_calls[0].function.name).toBe('web_search');
+    expect(body.choices[0].message.tool_calls[0].function.arguments).toBe('{"q":"x"}');
   });
 });
 


### PR DESCRIPTION
## Summary

- Opt-in OpenAI `tools` / `tool_calls` on `/v1/chat/completions` for clients like Open WebUI Native FC (fixes #73)
- Default remains tools off (DR-019); enable via global `openai_compat.tools` and/or per-model `openai_compat_tools` (dashboard checkbox)
- Fix core `passthrough` so schemas reach the model without Abbenay executing tools; non-streaming responses include `tool_calls`

## Changes

- `CoreState` / `streamChat`: passthrough forwards client tools without an executor (`maxSteps` 1); `convertMessages` accepts OpenAI nested `tool_calls`
- Config: `openai_compat.tools`, `ModelConfig.openai_compat_tools`; DR-032 + CONFIGURATION (Open WebUI / security tradeoff)
- Dashboard model config: “Allow OpenAI tools on /v1” checkbox + `v1_tools` badge
- Unit + integration tests for off default, global/model passthrough, non-streaming `tool_calls`

Follow-up: #77 (`tool_choice` mapping)

## Test plan

- [x] `npm run lint` (0 errors)
- [x] `npm test` (569 daemon + 24 vscode)
- [ ] Manual: leave default off — `/v1` request with `tools` still ignores them
- [ ] Manual: enable checkbox on one model — Open WebUI Native FC / web search receives structured `tool_calls`
- [ ] Manual: save config and confirm YAML has `openai_compat_tools: passthrough`