### PR TITLE
fix(daemon): raise Express JSON body limit for tool payloads

### DIFF
--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -113,9 +113,11 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   const security = resolveHttpSecurity(port, options?.host, options);
   app.locals.httpSecurity = security;
 
-  // Parse JSON / form bodies (form used by POST /login)
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: false }));
+  // Parse JSON / form bodies (form used by POST /login).
+  // Default Express limit is 100kb — too small for Open WebUI Legacy/Default
+  // function-calling payloads that embed MCP tool schemas in the prompt.
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: false, limit: '10mb' }));
 
   // CORS — explicit allowlist only (never *)
   app.use(createCorsMiddleware(security.corsOrigins));

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -119,12 +119,15 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   // JSON bodies: default 100kb for /api and most routes. Defer parsing for
   // /v1/chat/completions so the larger limit runs only after requireAuth
   // (Open WebUI Legacy/Default FC embeds MCP tool schemas; ~200kb+).
+  const defaultJsonParser = express.json();
+  const isChatCompletionsPath = (path: string): boolean =>
+    path === '/v1/chat/completions' || path === '/v1/chat/completions/';
   app.use((req, res, next) => {
-    if (req.path === '/v1/chat/completions') {
+    if (isChatCompletionsPath(req.path)) {
       next();
       return;
     }
-    express.json()(req, res, next);
+    defaultJsonParser(req, res, next);
   });
 
   // CORS — explicit allowlist only (never *)
@@ -312,7 +315,8 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   app.use('/mcp', requireAuth);
 
   // Large JSON limit only on authenticated chat-completions (not global /login).
-  app.use('/v1/chat/completions', express.json({ limit: '10mb' }));
+  const largeChatCompletionsJsonParser = express.json({ limit: '10mb' });
+  app.use('/v1/chat/completions', largeChatCompletionsJsonParser);
 
   // ── MCP connection consent + tool approval (DR-033 / DR-034) ───────────
   // Connection: initialize blocks until POST /api/mcp/connections resolves.

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -113,11 +113,19 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   const security = resolveHttpSecurity(port, options?.host, options);
   app.locals.httpSecurity = security;
 
-  // Parse JSON / form bodies (form used by POST /login).
-  // Default Express limit is 100kb — too small for Open WebUI Legacy/Default
-  // function-calling payloads that embed MCP tool schemas in the prompt.
-  app.use(express.json({ limit: '10mb' }));
-  app.use(express.urlencoded({ extended: false, limit: '10mb' }));
+  // Form bodies (POST /login) — keep Express default size limit (API token only).
+  app.use(express.urlencoded({ extended: false }));
+
+  // JSON bodies: default 100kb for /api and most routes. Defer parsing for
+  // /v1/chat/completions so the larger limit runs only after requireAuth
+  // (Open WebUI Legacy/Default FC embeds MCP tool schemas; ~200kb+).
+  app.use((req, res, next) => {
+    if (req.path === '/v1/chat/completions') {
+      next();
+      return;
+    }
+    express.json()(req, res, next);
+  });
 
   // CORS — explicit allowlist only (never *)
   app.use(createCorsMiddleware(security.corsOrigins));
@@ -302,6 +310,9 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
   app.use('/api', requireAuth);
   app.use('/v1', requireAuth);
   app.use('/mcp', requireAuth);
+
+  // Large JSON limit only on authenticated chat-completions (not global /login).
+  app.use('/v1/chat/completions', express.json({ limit: '10mb' }));
 
   // ── MCP connection consent + tool approval (DR-033 / DR-034) ───────────
   // Connection: initialize blocks until POST /api/mcp/connections resolves.

--- a/packages/daemon/tests/integration/openai-compat.test.ts
+++ b/packages/daemon/tests/integration/openai-compat.test.ts
@@ -380,6 +380,35 @@ describe('POST /v1/chat/completions (non-streaming)', () => {
     expect(resBody.choices[0].message.content).toBe('Hello world');
   });
 
+  it('accepts >100kb tools payloads on trailing-slash path', async () => {
+    const pad = 'x'.repeat(120 * 1024);
+    const body = {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'large_tool_schema',
+            description: pad,
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ],
+      stream: false,
+    };
+    expect(Buffer.byteLength(JSON.stringify(body))).toBeGreaterThan(100 * 1024);
+
+    const { statusCode, body: resBody } = await httpRequest(
+      'POST',
+      `${baseUrl}/v1/chat/completions/`,
+      body,
+    );
+
+    expect(statusCode).toBe(200);
+    expect(resBody.choices[0].message.content).toBe('Hello world');
+  });
+
   it('concatenates all text chunks into message content', async () => {
     const { body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
       model: 'openai/gpt-4o',

--- a/packages/daemon/tests/integration/openai-compat.test.ts
+++ b/packages/daemon/tests/integration/openai-compat.test.ts
@@ -346,6 +346,40 @@ describe('POST /v1/chat/completions (non-streaming)', () => {
     expect(body.id).toMatch(/^chatcmpl-/);
   });
 
+  it('accepts >100kb tools payloads without 413', async () => {
+    // Express default JSON limit is 100kb; Open WebUI Default/Legacy FC + MCP
+    // schemas commonly exceed that. Pad a tools array past 100kb to lock the
+    // authenticated /v1/chat/completions 10mb parser.
+    const pad = 'x'.repeat(120 * 1024);
+    const tools = [
+      {
+        type: 'function',
+        function: {
+          name: 'large_tool_schema',
+          description: pad,
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+    ];
+    const body = {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools,
+      stream: false,
+    };
+    expect(Buffer.byteLength(JSON.stringify(body))).toBeGreaterThan(100 * 1024);
+
+    const { statusCode, body: resBody } = await httpRequest(
+      'POST',
+      `${baseUrl}/v1/chat/completions`,
+      body,
+    );
+
+    expect(statusCode).toBe(200);
+    expect(resBody.object).toBe('chat.completion');
+    expect(resBody.choices[0].message.content).toBe('Hello world');
+  });
+
   it('concatenates all text chunks into message content', async () => {
     const { body } = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
       model: 'openai/gpt-4o',


### PR DESCRIPTION
## Summary
- Raise the Express JSON body limit to **10mb** only for authenticated `POST /v1/chat/completions`.
- Keep default Express limits for other JSON routes and for `urlencoded` (`POST /login`).
- Fixes `PayloadTooLargeError` (HTTP 413) when Open WebUI Default/Legacy function calling embeds MCP tool schemas in chat-completions bodies (observed ~200kb with a modest MCP tool set).

## Context
With `openai_compat_tools: passthrough`, Abbenay proxies OpenAI-compat chat completions. Clients that inline large `tools` arrays (Open WebUI + MCP) exceed Express’s default 100kb body parser limit. Native function calling can avoid this path; Default/Legacy still needs the higher limit.

The large parser is mounted **after** `requireAuth` so unauthenticated requests cannot force a 10mb JSON allocation. Login form parsing stays at the default limit.

## Test plan
- [x] Integration: `POST /v1/chat/completions` with a >100kb `tools` payload returns 200, not 413
- [x] Existing openai-compat integration suite still passes
- [ ] Optional: Open WebUI Default FC + MCP tools against Abbenay openai-compat proxy