### PR TITLE
fix(daemon): allow ABBENAY_HTTP_AUTH=0 on non-loopback binds

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ Works with Cursor, Continue, aider, and any `openai` SDK script (use the same
 token as the client API key). The HTTP server binds to `127.0.0.1` by default;
 use `--host 0.0.0.0` only when you intentionally expose it.
 
-> **WARNING:** Auth is on by default. `ABBENAY_HTTP_AUTH=0` disables it for
-> local development only — do not use with a non-loopback bind. See
+> **WARNING:** Auth is on by default. `ABBENAY_HTTP_AUTH=0` disables it on any
+> bind (including `--host 0.0.0.0`) — for example a cluster-internal pod, or
+> when a reverse proxy already authenticates callers. See
 > [Configuration](docs/CONFIGURATION.md#http-api-security-server).
 
 ### Using the core library

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -141,8 +141,8 @@ when unauthenticated.
 > **WARNING — disabling HTTP auth:** Auth is **on by default**. Setting
 > `ABBENAY_HTTP_AUTH=0` turns it off on any bind address (including
 > `--host 0.0.0.0`). That allows any process (and any website that can reach
-> the bind address) to call the daemon and read/write secrets, config, chat,
-> MCP, and sessions. The server logs a loud warning when auth is disabled.
+> this port) to call the daemon and read/write secrets, config, chat, MCP,
+> and sessions. The server logs a loud warning when auth is disabled.
 >
 > Legitimate cases for auth-off on a non-loopback bind include:
 > - **Cluster / production pod** — Abbenay as an internal Service, reachable

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -138,14 +138,26 @@ that connects over loopback still cannot auto-establish a session for a public
 hostname. API routes (`/api/*`, `/v1/*`, `/mcp`) continue to return `401` JSON
 when unauthenticated.
 
-> **WARNING — disabling HTTP auth:** Auth is **on by default**. For throwaway
-> local development only you may set `ABBENAY_HTTP_AUTH=0`. That allows any
-> process (and any website that can reach the bind address) to call the
-> daemon and read/write secrets, config, chat, MCP, and sessions. The server
-> logs a loud warning when auth is disabled. Combining `ABBENAY_HTTP_AUTH=0`
-> with `--host 0.0.0.0` (or any non-loopback bind) fails closed — the HTTP
-> server refuses to start. Prefer keeping auth enabled and using a local
-> token instead.
+> **WARNING — disabling HTTP auth:** Auth is **on by default**. Setting
+> `ABBENAY_HTTP_AUTH=0` turns it off on any bind address (including
+> `--host 0.0.0.0`). That allows any process (and any website that can reach
+> the bind address) to call the daemon and read/write secrets, config, chat,
+> MCP, and sessions. The server logs a loud warning when auth is disabled.
+>
+> Legitimate cases for auth-off on a non-loopback bind include:
+> - **Cluster / production pod** — Abbenay as an internal Service, reachable
+>   only on a private network (NetworkPolicy, mesh, or equivalent), with no
+>   public ingress to the daemon port
+> - **Auth at the proxy** — a reverse proxy, API gateway, or ingress that
+>   already authenticates callers (OAuth2 proxy, mesh mTLS, corporate SSO)
+>   and forwards only trusted traffic to Abbenay
+>
+> Auth-off disables Abbenay’s Bearer **and** dashboard CSRF checks. Abbenay
+> does not verify proxy-injected identity headers; isolation must come from
+> the network (who can reach the port). See
+> [CONTAINER.md](CONTAINER.md#security-http-bind-and-authentication) for
+> sketch examples. If neither shape applies, keep auth enabled and use a
+> strong `ABBENAY_API_TOKEN`.
 
 ### Tool policy
 

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -399,11 +399,14 @@ metadata:
   name: abbenay
 spec:
   type: ClusterIP
+  selector:
+    app: abbenay
   ports:
     - port: 8787
       targetPort: 8787
 ---
-# Optional: deny ingress except from your caller namespace/pods
+# Optional: deny ingress except from the caller namespace (name = ai-clients).
+# kubernetes.io/metadata.name is set automatically on the Namespace object.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -417,7 +420,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes: ai-clients
+              kubernetes.io/metadata.name: ai-clients
       ports:
         - protocol: TCP
           port: 8787

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -375,12 +375,70 @@ beyond loopback.
 `Authorization: Bearer <token>` on every request. CORS is allowlist-only
 (never `*`).
 
-> **WARNING:** `ABBENAY_HTTP_AUTH=0` disables HTTP auth for local development
-> only. Combining it with `--host 0.0.0.0` (or any non-loopback bind) fails
-> closed — the HTTP server refuses to start.
+> **WARNING:** `ABBENAY_HTTP_AUTH=0` disables HTTP auth on any bind, including
+> the container default `--host 0.0.0.0`. The server starts and logs a loud
+> warning; any client that can reach the published port has full API access.
 
-When exposing HTTP, always set a strong `ABBENAY_API_TOKEN` and restrict
-`server.cors_origins`. Keep `ABBENAY_HTTP_AUTH` enabled (the default).
+Typical production shapes that use auth-off intentionally. Abbenay does **not**
+validate proxy headers or mesh identity when auth is off — the security
+boundary is network isolation (who can open a TCP connection to the pod).
+
+**Cluster-internal Service** — other pods call Abbenay on the private network;
+no public Ingress/NodePort/LoadBalancer to `:8787`:
+
+```yaml
+# Deployment env (CMD already binds --host 0.0.0.0)
+env:
+  - name: ABBENAY_HTTP_AUTH
+    value: "0"
+---
+# Service: ClusterIP only (not NodePort / LoadBalancer)
+apiVersion: v1
+kind: Service
+metadata:
+  name: abbenay
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8787
+      targetPort: 8787
+---
+# Optional: deny ingress except from your caller namespace/pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: abbenay-internal-only
+spec:
+  podSelector:
+    matchLabels:
+      app: abbenay
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes: ai-clients
+      ports:
+        - protocol: TCP
+          port: 8787
+```
+
+**Auth at the proxy** — oauth2-proxy (or an API gateway / ingress auth) is the
+only path to Abbenay; the Abbenay Service stays ClusterIP and is not published
+publicly. Abbenay trusts the private hop:
+
+```yaml
+# Abbenay Deployment
+env:
+  - name: ABBENAY_HTTP_AUTH
+    value: "0"
+# oauth2-proxy (sketch): upstream = http://abbenay:8787
+# Ingress routes / → oauth2-proxy only; do not Ingress Abbenay directly.
+```
+
+When Abbenay itself must authenticate callers, keep `ABBENAY_HTTP_AUTH`
+enabled (the default), set a strong `ABBENAY_API_TOKEN`, and restrict
+`server.cors_origins`.
 
 ## Security: gRPC bind, TLS, and `--insecure`
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -252,10 +252,12 @@ curl -H "Authorization: Bearer $ABBENAY_API_TOKEN" \
 Point any OpenAI-compatible client at `http://127.0.0.1:8787/v1` and use the
 same token as the API key.
 
-> **WARNING:** HTTP auth is **enabled by default**. For throwaway local
-> development only you may set `ABBENAY_HTTP_AUTH=0` to skip Bearer tokens.
-> The server logs a warning. Combining that with `--host 0.0.0.0` refuses to
-> start. Prefer keeping auth on and using `ABBENAY_API_TOKEN` instead.
+> **WARNING:** HTTP auth is **enabled by default**. Set `ABBENAY_HTTP_AUTH=0`
+> to skip Bearer tokens on any bind (including `--host 0.0.0.0`). The server
+> logs a warning. Use auth-off when something else already protects the API
+> (for example a production pod on a private cluster network, or a reverse
+> proxy / gateway that authenticates callers). Otherwise keep auth on and
+> use `ABBENAY_API_TOKEN`.
 
 ### With the OpenAI Python SDK
 
@@ -295,8 +297,10 @@ Host can still auto-establish a session. Sign in with the API token (or
 `POST /login` with the token in the body). Avoid putting the token in the query
 string (it can leak via history, Referer, and logs).
 
-For throwaway local development only, `ABBENAY_HTTP_AUTH=0` disables HTTP auth
-(loopback bind only; refused with `--host 0.0.0.0`).
+`ABBENAY_HTTP_AUTH=0` disables HTTP auth on any bind (including `--host 0.0.0.0`);
+the server logs a loud warning. That is appropriate for a lab, a
+cluster-internal Service, or when a proxy already handles authentication —
+not for an unprotected public bind.
 
 Use the dashboard to:
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -443,17 +443,23 @@ state-changing requests. Prefer `GET/POST /login` (token in the form/body)
 over `/?token=` query login to avoid leaking credentials via history,
 Referer, and access logs; the query form remains for compatibility and uses
 a timing-safe compare. Cookies set the `Secure` flag when the request is
-HTTPS or `X-Forwarded-Proto: https`. For local development only,
-`ABBENAY_HTTP_AUTH=0` (or `false`/`off`/`no`/`disabled`) turns auth off and
-logs a loud warning. Combining auth-disabled with a non-loopback bind
-(`0.0.0.0`, LAN IP, etc.) fails closed: the HTTP server refuses to start.
+HTTPS or `X-Forwarded-Proto: https`. `ABBENAY_HTTP_AUTH=0` (or
+`false`/`off`/`no`/`disabled`) turns auth off on any bind address (including
+non-loopback) and logs a loud warning — an explicit opt-out, not the default.
+Intended auth-off deployments include a production pod as a cluster-internal
+Service (private network / NetworkPolicy) and Abbenay behind a reverse proxy
+or gateway that already authenticates callers.
 **Rationale:** The previous defaults (no auth, `Access-Control-Allow-Origin: *`,
 `app.listen(port)` → `0.0.0.0`) allowed any website the user visited to
 cross-origin call the daemon and read/write secrets, config, chat, MCP, and
 sessions. Secure-by-default closes that gap while keeping intentional network
 exposure possible for containers with an explicit opt-in and a strong token.
-An env-var escape hatch keeps local DX workable without baking an insecure
-default back into production paths.
+An env-var opt-out (`ABBENAY_HTTP_AUTH=0`) supports trusted-network labs,
+cluster-internal Services, and proxy-terminated auth without baking an
+insecure default into production paths. Refusing auth-off on non-loopback was
+later dropped: ProdSec required auth **on by default**, not a permanent ban
+on intentional disable when the platform or proxy already provides the
+security boundary.
 
 ---
 

--- a/packages/daemon/src/daemon/web/http-security.test.ts
+++ b/packages/daemon/src/daemon/web/http-security.test.ts
@@ -11,8 +11,6 @@ import {
   shouldRedirectDashboardToLogin,
   mayAutoEstablishDashboardSession,
   isHttpAuthEnabled,
-  assertHttpAuthBindAllowed,
-  HttpAuthBindSecurityError,
   resolveHttpApiToken,
   resolveHttpHost,
   resolveCorsOrigins,
@@ -214,25 +212,6 @@ describe('isHttpAuthEnabled', () => {
     expect(isHttpAuthEnabled({ authEnabled: true })).toBe(true);
     process.env.ABBENAY_HTTP_AUTH = '1';
     expect(isHttpAuthEnabled({ authEnabled: false })).toBe(false);
-  });
-});
-
-describe('assertHttpAuthBindAllowed', () => {
-  it('allows auth-disabled binds on loopback', () => {
-    expect(() => assertHttpAuthBindAllowed('127.0.0.1', false)).not.toThrow();
-    expect(() => assertHttpAuthBindAllowed('::1', false)).not.toThrow();
-    expect(() => assertHttpAuthBindAllowed('localhost', false)).not.toThrow();
-  });
-
-  it('allows auth-enabled binds on any host', () => {
-    expect(() => assertHttpAuthBindAllowed('0.0.0.0', true)).not.toThrow();
-    expect(() => assertHttpAuthBindAllowed('192.168.1.10', true)).not.toThrow();
-  });
-
-  it('refuses auth-disabled binds beyond loopback', () => {
-    expect(() => assertHttpAuthBindAllowed('0.0.0.0', false)).toThrow(HttpAuthBindSecurityError);
-    expect(() => assertHttpAuthBindAllowed('192.168.1.10', false)).toThrow(HttpAuthBindSecurityError);
-    expect(() => assertHttpAuthBindAllowed('::', false)).toThrow(HttpAuthBindSecurityError);
   });
 });
 

--- a/packages/daemon/src/daemon/web/http-security.ts
+++ b/packages/daemon/src/daemon/web/http-security.ts
@@ -35,7 +35,7 @@ export interface ResolvedHttpSecurity {
   apiToken: string;
   host: string;
   corsOrigins: string[];
-  /** False when ABBENAY_HTTP_AUTH disables auth (local-dev escape hatch). */
+  /** False when ABBENAY_HTTP_AUTH disables auth (explicit opt-out). */
   authEnabled: boolean;
   /** True when the token was freshly generated and persisted */
   generated: boolean;
@@ -73,8 +73,9 @@ const AUTH_DISABLE_VALUES = new Set(['0', 'false', 'off', 'no', 'disabled']);
 /**
  * Return true when HTTP auth is enabled (the secure default).
  *
- * Set `ABBENAY_HTTP_AUTH=0` (or false/off/no/disabled) to turn auth off for
- * local development only. Never disable auth when binding beyond loopback.
+ * Set `ABBENAY_HTTP_AUTH=0` (or false/off/no/disabled) to turn auth off.
+ * Allowed on any bind address (cluster-internal Service, auth at a reverse
+ * proxy, lab). The server logs a loud warning when auth is disabled.
  */
 export function isHttpAuthEnabled(options?: WebSecurityOptions): boolean {
   if (options?.authEnabled !== undefined) {
@@ -201,33 +202,6 @@ export function mayAutoEstablishDashboardSession(opts: {
   if (!opts.authEnabled) return true;
   if (opts.hasValidAuthCookie) return true;
   return !shouldRedirectDashboardToLogin({ ...opts, hasValidAuthCookie: false });
-}
-
-/**
- * Thrown when HTTP auth is disabled on a non-loopback bind (fail-closed).
- */
-export class HttpAuthBindSecurityError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'HttpAuthBindSecurityError';
-  }
-}
-
-/**
- * Refuse auth-disabled HTTP binds beyond loopback.
- *
- * `ABBENAY_HTTP_AUTH=0` is a local-dev escape hatch only. Combining it with
- * `--host 0.0.0.0` (or any non-loopback bind) would expose an unauthenticated
- * API on the network — refuse to start instead of warning.
- */
-export function assertHttpAuthBindAllowed(host: string, authEnabled: boolean): void {
-  if (authEnabled || isLocalhostBind(host)) {
-    return;
-  }
-  throw new HttpAuthBindSecurityError(
-    `Refusing to bind HTTP on non-loopback address "${host}" with authentication disabled ` +
-      '(ABBENAY_HTTP_AUTH=0). Re-enable auth, or bind to 127.0.0.1 / ::1 / localhost.',
-  );
 }
 
 /**
@@ -513,7 +487,7 @@ export function createCorsMiddleware(allowlist: string[]) {
 /**
  * Auth + CSRF middleware for protected HTTP routes.
  *
- * When `authEnabled` is false (ABBENAY_HTTP_AUTH disable escape hatch), all
+ * When `authEnabled` is false (ABBENAY_HTTP_AUTH opt-out), all
  * requests pass through without checking credentials.
  *
  * Accepts:

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -1783,8 +1783,8 @@ export async function startEmbeddedWebServer(
 
   if (!security.authEnabled) {
     const scope = isLocalhostBind(bindHost)
-      ? 'Any local process (and any site that can reach this loopback bind)'
-      : `Bind is ${bindHost} (beyond loopback) — any host/process that can reach this address`;
+      ? 'Any local process (and any site that can reach this loopback port)'
+      : `Listening on ${bindHost}:${port} (beyond loopback) — any host/process that can reach this port`;
     console.warn(
       '[Web] WARNING: HTTP authentication is DISABLED (ABBENAY_HTTP_AUTH). ' +
       `${scope} can read/write secrets, config, chat, MCP, and sessions. ` +

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -38,7 +38,6 @@ import {
   shouldRedirectDashboardToLogin,
   mayAutoEstablishDashboardSession,
   requestDashboardHost,
-  assertHttpAuthBindAllowed,
   type WebSecurityOptions,
   type ResolvedHttpSecurity,
   type RequestWithOwner,
@@ -105,7 +104,7 @@ const STATIC_PATH = resolveStaticPath();
  *
  * Used both for production (embedded in daemon) and testing.
  * All /api/*, /v1/*, and /mcp routes require Bearer (or cookie) auth unless
- * ABBENAY_HTTP_AUTH disables authentication for local development.
+ * ABBENAY_HTTP_AUTH disables authentication (explicit opt-out).
  */
 export function createWebApp(state: DaemonState, options?: WebSecurityOptions): Express {
   const app = express();
@@ -1766,7 +1765,6 @@ export async function startEmbeddedWebServer(
 
   const security = resolveHttpSecurity(port, host, options);
   const bindHost = security.host || DEFAULT_HTTP_HOST;
-  assertHttpAuthBindAllowed(bindHost, security.authEnabled);
   const app = createWebApp(state, {
     ...options,
     apiToken: security.apiToken,
@@ -1784,15 +1782,18 @@ export async function startEmbeddedWebServer(
   _webHost = bindHost;
 
   if (!security.authEnabled) {
+    const scope = isLocalhostBind(bindHost)
+      ? 'Any local process (and any site that can reach this loopback bind)'
+      : `Bind is ${bindHost} (beyond loopback) — any host/process that can reach this address`;
     console.warn(
       '[Web] WARNING: HTTP authentication is DISABLED (ABBENAY_HTTP_AUTH). ' +
-      'Any local process (and any site that can reach this bind address) can ' +
-      'read/write secrets, config, chat, MCP, and sessions. ' +
-      'Re-enable auth for anything beyond throwaway local development.',
+      `${scope} can read/write secrets, config, chat, MCP, and sessions. ` +
+      'Use only when that is intentional (e.g. cluster-internal Service, or ' +
+      'a reverse proxy that already authenticates callers).',
     );
   }
 
-  if (!isLocalhostBind(bindHost)) {
+  if (!isLocalhostBind(bindHost) && security.authEnabled) {
     console.warn(
       `[Web] WARNING: HTTP server is bound to ${bindHost} — accessible beyond loopback. ` +
       'Ensure ABBENAY_API_TOKEN (or server.api_token) is set and CORS origins are restricted. ' +

--- a/packages/daemon/tests/integration/http-security.test.ts
+++ b/packages/daemon/tests/integration/http-security.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as http from 'node:http';
+import * as net from 'node:net';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -20,6 +21,23 @@ import { SessionStore } from '../../src/core/session-store.js';
 import { DEFAULT_HTTP_HOST } from '../../src/core/constants.js';
 
 const TEST_TOKEN = 'test-http-api-token-secure-defaults';
+
+/** Allocate an ephemeral TCP port on loopback; fail fast on listen/address errors. */
+function getEphemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (typeof addr !== 'object' || addr === null || !addr.port) {
+        server.close(() => reject(new Error('Failed to allocate ephemeral port on 127.0.0.1')));
+        return;
+      }
+      const port = addr.port;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
 
 const mockSecretStore: SecretStore = {
   async get() { return null; },
@@ -279,14 +297,7 @@ describe('ABBENAY_HTTP_AUTH disable opt-out', () => {
   it('allows auth-disabled start on a non-loopback bind', async () => {
     await stopEmbeddedWebServer();
     const state = createMockState();
-    const probe = http.createServer();
-    const freePort = await new Promise<number>((resolve) => {
-      probe.listen(0, '127.0.0.1', () => {
-        const addr = probe.address();
-        resolve(typeof addr === 'object' && addr ? addr.port : 0);
-      });
-    });
-    await new Promise<void>((resolve) => probe.close(() => resolve()));
+    const freePort = await getEphemeralPort();
 
     const started = await startEmbeddedWebServer(state, freePort, '0.0.0.0', {
       authEnabled: false,
@@ -315,14 +326,7 @@ describe('ABBENAY_HTTP_AUTH disable opt-out', () => {
   it('allows auth-disabled start on loopback', async () => {
     await stopEmbeddedWebServer();
     const state = createMockState();
-    const probe = http.createServer();
-    const freePort = await new Promise<number>((resolve) => {
-      probe.listen(0, '127.0.0.1', () => {
-        const addr = probe.address();
-        resolve(typeof addr === 'object' && addr ? addr.port : 0);
-      });
-    });
-    await new Promise<void>((resolve) => probe.close(() => resolve()));
+    const freePort = await getEphemeralPort();
 
     const started = await startEmbeddedWebServer(state, freePort, '127.0.0.1', {
       authEnabled: false,
@@ -494,15 +498,8 @@ describe('bind address default', () => {
     // port 0 may not work with our listen — use a high free port instead
     await stopEmbeddedWebServer();
 
-    // Pick an ephemeral port via a probe, then start embedded on that port
-    const probe = http.createServer();
-    const freePort = await new Promise<number>((resolve) => {
-      probe.listen(0, '127.0.0.1', () => {
-        const addr = probe.address();
-        resolve(typeof addr === 'object' && addr ? addr.port : 0);
-      });
-    });
-    await new Promise<void>((resolve) => probe.close(() => resolve()));
+    // Pick an ephemeral port, then start embedded on that port
+    const freePort = await getEphemeralPort();
 
     const started = await startEmbeddedWebServer(state, freePort, undefined, {
       apiToken: TEST_TOKEN,

--- a/packages/daemon/tests/integration/http-security.test.ts
+++ b/packages/daemon/tests/integration/http-security.test.ts
@@ -22,15 +22,18 @@ import { DEFAULT_HTTP_HOST } from '../../src/core/constants.js';
 
 const TEST_TOKEN = 'test-http-api-token-secure-defaults';
 
-/** Allocate an ephemeral TCP port on loopback; fail fast on listen/address errors. */
-function getEphemeralPort(): Promise<number> {
+/**
+ * Allocate an ephemeral TCP port on `host` (default loopback).
+ * Fail fast on listen/address errors — never return port 0.
+ */
+function getEphemeralPort(host = '127.0.0.1'): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, host, () => {
       const addr = server.address();
       if (typeof addr !== 'object' || addr === null || !addr.port) {
-        server.close(() => reject(new Error('Failed to allocate ephemeral port on 127.0.0.1')));
+        server.close(() => reject(new Error(`Failed to allocate ephemeral port on ${host}`)));
         return;
       }
       const port = addr.port;
@@ -297,7 +300,8 @@ describe('ABBENAY_HTTP_AUTH disable opt-out', () => {
   it('allows auth-disabled start on a non-loopback bind', async () => {
     await stopEmbeddedWebServer();
     const state = createMockState();
-    const freePort = await getEphemeralPort();
+    // Probe on the same bind host the server will use so the port is known free there.
+    const freePort = await getEphemeralPort('0.0.0.0');
 
     const started = await startEmbeddedWebServer(state, freePort, '0.0.0.0', {
       authEnabled: false,

--- a/packages/daemon/tests/integration/http-security.test.ts
+++ b/packages/daemon/tests/integration/http-security.test.ts
@@ -218,7 +218,7 @@ describe('HTTP auth', () => {
   });
 });
 
-describe('ABBENAY_HTTP_AUTH disable escape hatch', () => {
+describe('ABBENAY_HTTP_AUTH disable opt-out', () => {
   let disabledServer: http.Server;
   let disabledBase: string;
 
@@ -276,15 +276,39 @@ describe('ABBENAY_HTTP_AUTH disable escape hatch', () => {
     expect(status).toBe(200);
   });
 
-  it('refuses to start when auth is disabled on a non-loopback bind', async () => {
+  it('allows auth-disabled start on a non-loopback bind', async () => {
     await stopEmbeddedWebServer();
     const state = createMockState();
-    await expect(
-      startEmbeddedWebServer(state, 18787, '0.0.0.0', {
-        authEnabled: false,
-        skipConfig: true,
-      }),
-    ).rejects.toThrow(/authentication disabled|ABBENAY_HTTP_AUTH/);
+    const probe = http.createServer();
+    const freePort = await new Promise<number>((resolve) => {
+      probe.listen(0, '127.0.0.1', () => {
+        const addr = probe.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : 0);
+      });
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+    const started = await startEmbeddedWebServer(state, freePort, '0.0.0.0', {
+      authEnabled: false,
+      skipConfig: true,
+    });
+    expect(started.security.authEnabled).toBe(false);
+    expect(started.security.host).toBe('0.0.0.0');
+
+    // Prove the contract: unauthenticated API access works (not only that listen succeeds).
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        `http://127.0.0.1:${freePort}/api/health`,
+        { method: 'GET' },
+        (res) => {
+          res.resume();
+          res.on('end', () => resolve(res.statusCode || 0));
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(status).toBe(200);
     await stopEmbeddedWebServer();
   });
 


### PR DESCRIPTION
## Summary

- Auth remains **on by default**. `ABBENAY_HTTP_AUTH=0` is an explicit opt-out that now works on any bind (including `--host 0.0.0.0` / container networking), instead of refusing to start.
- Removes the fail-closed `assertHttpAuthBindAllowed` / `HttpAuthBindSecurityError` path; startup still logs a loud warning (scoped for loopback vs non-loopback).
- Documents legitimate shapes: **cluster-internal Service** (ClusterIP + NetworkPolicy sketch) and **auth at the proxy** (oauth2-proxy / gateway; Abbenay trusts the private hop). Clarifies that auth-off does not validate proxy identity headers — isolation is network who-can-connect.
- Updates DR-030, CONFIGURATION / CONTAINER / GETTING_STARTED / README; integration test proves unauthenticated `/api/health` after auth-off + `0.0.0.0` start.

ProdSec ([AAP-82788](https://redhat.atlassian.net/browse/AAP-82788) / Thomas Eagle on AAP-80944) required secure **defaults**, not a permanent ban on intentional disable when the platform or proxy is the security boundary.

## Test plan

- [x] `vitest` `http-security` unit + integration (auth-off on `0.0.0.0` starts; unauthenticated `/api/health` → 200)
- [x] `eslint` on daemon `src` (no new errors)
- [ ] Manual: `ABBENAY_HTTP_AUTH=0 aby web --host 0.0.0.0` starts with warning; `curl http://127.0.0.1:8787/api/health` without Bearer → 200
- [ ] Manual: default (auth on) + `--host 0.0.0.0` still requires Bearer / login