### PR TITLE
chore(daemon): remove dead ChatChunk approval_* types

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,25 +23,21 @@ All three tiers are enforced. The default for tools matching no tier is
 
 ### What needs to happen
 
-1. **New chat chunk type: `approval_request`**
-   Add a `{ type: 'approval_request', toolName, args, requestId }` chunk to the
-   `ChatChunk` union. When the executor encounters a tool matching `require_approval`,
-   it yields this chunk instead of executing and waits for a response.
+1. **Approval via `onToolApprovalNeeded` (not a ChatChunk)** — done
+   Chat tool approval is gated by AI SDK `toolApproval` (DR-042), which awaits
+   Abbenay's `createToolValidator` / `onToolApprovalNeeded`. Transports emit an
+   out-of-band SSE/CLI prompt; they do not yield `approval_*` on `ChatChunk`.
 
-2. **Approval callback in `ToolExecutor`**
-   Extend `buildExecutor()` (or wrap it) with an `approvalCallback`:
-   ```
-   (tool: RegisteredTool, args: Record<string, any>) => Promise<'allow' | 'deny'>
-   ```
-   For web: the callback resolves when the client sends a POST to a new
-   `/api/chat/:requestId/approve` endpoint.
-   For CLI: the callback resolves from an interactive `readline` prompt.
-   For VS Code: the callback delegates through the gRPC backchannel.
+2. **Approval callback wired per transport** — done (web + CLI); VS Code pending
+   For web: `onToolApprovalNeeded` writes an `approval_request` SSE event and
+   resolves when the client POSTs `/api/chat/:chatId/approve`.
+   For CLI: interactive `readline` prompt.
+   For VS Code: gRPC `PromptChunk` backchannel (M3).
 
-3. **Web chat UI: approval prompt**
-   When the SSE stream emits an `approval_request` chunk, render an inline card
-   with the tool name, arguments, and Allow / Deny buttons. On click, POST to
-   `/api/chat/:requestId/approve` which unblocks the callback.
+3. **Web chat UI: approval prompt** — done
+   When the SSE stream emits an `approval_request` **event** (from the callback),
+   render an inline card with Allow / Deny. On click, POST to
+   `/api/chat/:chatId/approve` which unblocks the callback.
 
 4. **CLI chat command** (see section 2 below)
    The CLI `aby chat` command needs an interactive `readline` prompt for approvals.
@@ -57,7 +53,7 @@ All three tiers are enforced. The default for tools matching no tier is
 
 ### Milestones
 
-- **M1**: Enforce `require_approval` in web chat (approval_request chunk + REST callback) — **done**
+- **M1**: Enforce `require_approval` in web chat (approval_request SSE event + REST callback) — **done**
 - **M2**: CLI `aby chat` with interactive approval — **done**
 - **M3**: VS Code backchannel approval flow
 - **M4**: `max_tool_iterations` enforcement — **done**

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -695,4 +695,7 @@ WorkflowAgent, HMAC-signed approvals.
 longer supported by the SDK. Total-only timeouts preserve prior budgets and
 avoid aborting human approval waits. Opt-in telemetry avoids surprise prompt
 export. Bridging `toolApproval` keeps DR-019 policy tiers without rewriting
-transport UX around SDK `user-approval` stream pauses.
+transport UX around SDK `user-approval` stream pauses. Transport approval
+notifications are out-of-band SSE/CLI events via `onToolApprovalNeeded`; they
+are not `ChatChunk` variants (unused `approval_request` / `approval_result`
+chunk types were removed after the bridge landed).

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -650,8 +650,6 @@ export type ToolValidationCallback = (
 export type ChatChunk =
   | { type: 'text'; text: string }
   | { type: 'tool'; name: string; state: string; status?: string; call?: { params: unknown; result: unknown }; done: boolean }
-  | { type: 'approval_request'; requestId: string; toolName: string; args: unknown }
-  | { type: 'approval_result'; requestId: string; decision: 'allow' | 'deny' | 'abort' }
   | { type: 'error'; error: string }
   | { type: 'done'; finishReason: string };
 

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -100,7 +100,7 @@ export interface ChatToolOptions {
   toolMode?: string;
   /** Client-provided tool definitions (overrides registry when present) */
   tools?: ToolDefinition[];
-  /** Max tool execution rounds (0 = unlimited, default 10) */
+  /** Max tool execution rounds (default 10; must be a positive integer when set) */
   maxToolIterations?: number;
   /** Only expose these tools to the LLM (empty = all). Matches namespaced names. */
   toolFilter?: string[];

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -205,11 +205,6 @@ describe('buildStreamChunk', () => {
       const chunk: ChatChunk = { type: 'error', error: 'boom' };
       expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
     });
-
-    it('returns null for approval_request chunks', () => {
-      const chunk: ChatChunk = { type: 'approval_request', requestId: 'r1', toolName: 'x', args: {} };
-      expect(buildStreamChunk(chunk, opts, 0, false)).toBeNull();
-    });
   });
 });
 

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -239,7 +239,7 @@ export function buildStreamChunk(
     };
   }
 
-  // approval_request, approval_result, tool results, errors — not mapped to OpenAI streaming
+  // tool results, errors, and other non-OpenAI chunk types — not mapped
   return null;
 }
 

--- a/packages/daemon/src/daemon/web/server.ts
+++ b/packages/daemon/src/daemon/web/server.ts
@@ -1011,8 +1011,8 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
    * POST /api/chat - Stream chat via Server-Sent Events
    *
    * Calls state.chat() directly — no gRPC in the loop.
-   * When a tool matches require_approval, an approval_request SSE event is
-   * emitted and the stream pauses until POST /api/chat/:chatId/approve resolves it.
+   * When a tool needs approval, onToolApprovalNeeded writes an approval_request
+   * SSE event (not a ChatChunk) and pauses until POST /api/chat/:chatId/approve.
    */
   app.post('/api/chat', (req, res) => {
     const parsed = parseRequestBody(PostChatBodySchema, req.body);
@@ -1131,10 +1131,6 @@ export function createWebApp(state: DaemonState, options?: WebSecurityOptions): 
               toolData.call = { params: chunk.call.params, result: chunk.call.result };
             }
             safeWrite(`data: ${JSON.stringify(toolData)}\n\n`);
-          } else if (chunk.type === 'approval_request') {
-            safeWrite(`data: ${JSON.stringify({ type: 'approval_request', chatId, requestId: chunk.requestId, toolName: chunk.toolName, args: chunk.args })}\n\n`);
-          } else if (chunk.type === 'approval_result') {
-            safeWrite(`data: ${JSON.stringify({ type: 'approval_result', requestId: chunk.requestId, decision: chunk.decision })}\n\n`);
           } else if (chunk.type === 'error') {
             safeWrite(`data: ${JSON.stringify({ type: 'error', error: chunk.error })}\n\n`);
           } else if (chunk.type === 'done') {

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -2316,11 +2316,16 @@ function dashboard() {
       if (!this.pendingApproval || !this.activeChatId) return;
       const { chatId, requestId } = this.pendingApproval;
       try {
-        await apiFetch(`/api/chat/${chatId}/approve`, {
+        const res = await apiFetch(`/api/chat/${chatId}/approve`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ requestId, decision }),
         });
+        // fetch() does not throw on HTTP errors — only clear the card on success.
+        if (!res.ok) {
+          console.error('Failed to send approval:', res.status, await res.text().catch(() => ''));
+          return;
+        }
         // Clear the card here — approvals are no longer echoed as approval_result SSE.
         const label = decision === 'allow' ? 'allowed' : decision === 'deny' ? 'denied' : 'aborted';
         const icon = decision === 'allow' ? '✅' : '❌';

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -2292,10 +2292,6 @@ function dashboard() {
                     args: data.args,
                   };
                   this.chatMessages[idx].content += `\n\n⏸️ **Waiting for approval:** \`${data.toolName}\`\n`;
-                } else if (data.type === 'approval_result') {
-                  const icon = data.decision === 'allow' ? '✅' : '❌';
-                  this.chatMessages[idx].content += `${icon} Tool ${data.decision}ed\n`;
-                  this.pendingApproval = null;
                 } else if (data.type === 'error') {
                   this.chatMessages[idx].content += `\n\n**Error:** ${data.error}\n`;
                 } else if (data.type === 'done') {

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -2322,10 +2322,11 @@ function dashboard() {
           body: JSON.stringify({ requestId, decision }),
         });
         // Clear the card here — approvals are no longer echoed as approval_result SSE.
+        const label = decision === 'allow' ? 'allowed' : decision === 'deny' ? 'denied' : 'aborted';
         const icon = decision === 'allow' ? '✅' : '❌';
         const idx = this.chatMessages.length - 1;
         if (idx >= 0 && this.chatMessages[idx]) {
-          this.chatMessages[idx].content += `${icon} Tool ${decision}ed\n`;
+          this.chatMessages[idx].content += `${icon} Tool ${label}\n`;
         }
         this.pendingApproval = null;
       } catch (e) {

--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -2321,6 +2321,13 @@ function dashboard() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ requestId, decision }),
         });
+        // Clear the card here — approvals are no longer echoed as approval_result SSE.
+        const icon = decision === 'allow' ? '✅' : '❌';
+        const idx = this.chatMessages.length - 1;
+        if (idx >= 0 && this.chatMessages[idx]) {
+          this.chatMessages[idx].content += `${icon} Tool ${decision}ed\n`;
+        }
+        this.pendingApproval = null;
       } catch (e) {
         console.error('Failed to send approval:', e);
       }


### PR DESCRIPTION
## Summary
- Remove unused `ChatChunk` variants `approval_request` / `approval_result` (never yielded by `streamChat` after the DR-042 `toolApproval` bridge).
- Drop unreachable ChatChunk→SSE mappers and the dead dashboard `approval_result` SSE handler.
- Clear `pendingApproval` after Allow/Deny POST so the approval card does not stick without `approval_result`.
- Keep live dashboard approvals: `onToolApprovalNeeded` still writes SSE `{ type: 'approval_request', ... }` and `POST /api/chat/:chatId/approve`.
- Align ROADMAP / DR-042 and fix `maxToolIterations` JSDoc (`0 = unlimited` was wrong).

## Test plan
- [x] `npx vitest run` openai-compat + engines-aisdk7 + tool-approval
- [x] `npm run lint -w packages/daemon` (0 errors; pre-existing warnings only)
- [x] CI green on prior push
- [ ] Optional: dashboard ask-tier tool — card dismisses on Allow/Deny

## References
- Follow-up to #87 / DR-042