### PR TITLE
feat: add win32-x64 platform support

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -38,7 +38,8 @@ locally-runnable scripts; CI just calls them.
 | `npm run lint` | Lint all workspace packages | Quality gate |
 | `npm run check:no-query-secrets` | Ban query-secret URL patterns in sources (DR-035) | Quality gate |
 | `npm test` | Test all workspace packages | Quality gate |
-| `npm run ci:build` | Full build with `--skip-proto` (SEA + VSIX + tar.gz) | Build artifacts |
+| `npm run ci:build` | Full build with `--skip-proto` (SEA + VSIX + archive) | Build artifacts |
+| `npm run ci:smoke-win32-ipc` | Start Windows SEA, HealthCheck over loopback TCP | Windows build smoke |
 | `npm run ci:package-python` | Build Python wheel via `uvx hatch build` | Python artifact |
 | `npm run ci:publish-vscode` | Publish VSIXes to Marketplace + OpenVSX | Release only |
 
@@ -48,9 +49,10 @@ The CI workflow (`.github/workflows/ci.yml`) has three jobs:
 
 - **lint-and-test**: runs on ubuntu-latest with xvfb (for VS Code extension
   tests), gates all other jobs
-- **build**: matrix across linux-x64, linux-arm64, macos-arm64; produces SEA
-  binaries, platform-specific VSIXes, and distribution tar.gz archives; runs
-  `@abbenay/core` smoke test on all runners
+- **build**: matrix across linux-x64, linux-arm64, macos-arm64, win32-x64;
+  produces SEA binaries, platform-specific VSIXes, and distribution archives
+  (`.tar.gz` on Unix, `.zip` on Windows); runs `@abbenay/core` smoke test on
+  all runners and `npm run ci:smoke-win32-ipc` on Windows
 - **package-python**: produces the Python client wheel
 
 ## Rules for modifications

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
           - runner: macos-latest
             platform: darwin
             arch: arm64
+          - runner: windows-latest
+            platform: win32
+            arch: x64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -81,6 +84,7 @@ jobs:
           key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
+        shell: bash
         run: ./bootstrap.sh
 
       - name: Cache npm
@@ -99,6 +103,10 @@ jobs:
       - name: Smoke test @abbenay/core
         run: node --input-type=module -e "import { CoreState } from './index.js'"
         working-directory: packages/daemon/dist/core
+
+      - name: Smoke test Windows daemon IPC
+        if: matrix.platform == 'win32'
+        run: npm run ci:smoke-win32-ipc
 
       - name: Upload SEA artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
           - runner: macos-latest
             platform: darwin
             arch: arm64
+          - runner: windows-latest
+            platform: win32
+            arch: x64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +41,7 @@ jobs:
           key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.node-version', 'bootstrap.sh') }}
 
       - name: Bootstrap
+        shell: bash
         run: ./bootstrap.sh
 
       - name: Cache npm
@@ -51,6 +55,7 @@ jobs:
         run: npm ci
 
       - name: Inject version from tag
+        shell: bash
         run: node scripts/set-version.js "${GITHUB_REF_NAME#v}"
 
       - name: Build
@@ -59,6 +64,10 @@ jobs:
       - name: Smoke test @abbenay/core
         run: node --input-type=module -e "import { CoreState } from './index.js'" 
         working-directory: packages/daemon/dist/core
+
+      - name: Smoke test Windows daemon IPC
+        if: matrix.platform == 'win32'
+        run: npm run ci:smoke-win32-ipc
 
       - name: Pack @abbenay/core
         if: matrix.platform == 'linux' && matrix.arch == 'x64'
@@ -71,11 +80,19 @@ jobs:
           name: abbenay-daemon-${{ matrix.platform }}-${{ matrix.arch }}
           path: dist/${{ matrix.platform }}-${{ matrix.arch }}/
 
-      - name: Upload distribution archive
+      - name: Upload distribution archive (Unix)
+        if: matrix.platform != 'win32'
         uses: actions/upload-artifact@v7
         with:
           name: abbenay-archive-${{ matrix.platform }}-${{ matrix.arch }}
           path: dist/*.tar.gz
+
+      - name: Upload distribution archive (Windows)
+        if: matrix.platform == 'win32'
+        uses: actions/upload-artifact@v7
+        with:
+          name: abbenay-archive-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/*.zip
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7
@@ -158,6 +175,7 @@ jobs:
 
           assets=(
             release-assets/abbenay-archive-*/*.tar.gz
+            release-assets/abbenay-archive-*/*.zip
             release-assets/abbenay-vsix-*/*.vsix
             release-assets/abbenay-core/*.tgz
             release-assets/abbenay-client-python/*.whl
@@ -175,9 +193,11 @@ jobs:
           | \`abbenay-*-linux-x64.tar.gz\` | Daemon + sidecars (Linux x64) | Extract and run \`./abbenay-daemon\` |
           | \`abbenay-*-linux-arm64.tar.gz\` | Daemon + sidecars (Linux arm64) | Extract and run \`./abbenay-daemon\` |
           | \`abbenay-*-darwin-arm64.tar.gz\` | Daemon + sidecars (macOS Apple Silicon) | Extract and run \`./abbenay-daemon\` |
+          | \`abbenay-*-win32-x64.zip\` | Daemon + sidecars (Windows x64) | Extract and run \`abbenay-daemon-win32-x64.exe\` |
           | \`abbenay-provider-linux-x64-${vsix_ver}.vsix\` | VS Code extension (Linux x64) | \`code --install-extension <file>\` |
           | \`abbenay-provider-linux-arm64-${vsix_ver}.vsix\` | VS Code extension (Linux arm64) | \`code --install-extension <file>\` |
           | \`abbenay-provider-darwin-arm64-${vsix_ver}.vsix\` | VS Code extension (macOS arm64) | \`code --install-extension <file>\` |
+          | \`abbenay-provider-win32-x64-${vsix_ver}.vsix\` | VS Code extension (Windows x64) | \`code --install-extension <file>\` |
           | \`abbenay-core-${ver}.tgz\` | \`@abbenay/core\` npm package | \`npm install <file>\` |
           | \`abbenay_client-*.whl\` | Python gRPC client | \`pip install <file>\` |
           | \`abbenay_client-*.tar.gz\` | Python client sdist | \`pip install <file>\` |
@@ -185,7 +205,7 @@ jobs:
           ### Which do I need?
 
           - **VS Code user**: Download the \`.vsix\` for your platform. It includes the daemon.
-          - **CLI / standalone daemon**: Download the \`.tar.gz\` archive for your platform.
+          - **CLI / standalone daemon**: Download the archive for your platform (\`.tar.gz\` or Windows \`.zip\`).
           - **Node.js library consumer**: Download \`abbenay-core-*.tgz\`.
           - **Python gRPC client**: Download the \`.whl\` file.
           BODY

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,58 +14,95 @@ NODE_VERSION="$(tr -d '[:space:]' < "$NODE_VERSION_FILE")"
 # ── Platform detection ────────────────────────────────────────────────────
 
 detect_platform() {
-  local os arch
-  os="$(uname -s)"
-  arch="$(uname -m)"
+  local uname_s uname_m
+  uname_s="$(uname -s 2>/dev/null || echo unknown)"
+  uname_m="$(uname -m 2>/dev/null || echo unknown)"
 
-  case "$os" in
-    Linux)  OS="linux" ;;
-    Darwin) OS="darwin" ;;
+  # Use HOST_OS (not OS) — Windows sets OS=Windows_NT in the environment.
+  case "$uname_s" in
+    Linux)  HOST_OS="linux" ;;
+    Darwin) HOST_OS="darwin" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      HOST_OS="win"
+      ;;
     *)
-      echo "ERROR: Unsupported OS: $os" >&2
+      if [ "${OS:-}" = "Windows_NT" ] || [ -n "${WINDIR:-}" ]; then
+        HOST_OS="win"
+      else
+        echo "ERROR: Unsupported OS: $uname_s" >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  case "$uname_m" in
+    x86_64|x64|amd64) ARCH="x64" ;;
+    aarch64|arm64)    ARCH="arm64" ;;
+    *)
+      echo "ERROR: Unsupported architecture: $uname_m" >&2
       exit 1
       ;;
   esac
 
-  case "$arch" in
-    x86_64)       ARCH="x64" ;;
-    aarch64|arm64) ARCH="arm64" ;;
-    *)
-      echo "ERROR: Unsupported architecture: $arch" >&2
-      exit 1
-      ;;
-  esac
+  # Official Node.js Windows archives use "win", not "win32"
+  if [ "$HOST_OS" = "win" ] && [ "$ARCH" != "x64" ]; then
+    echo "ERROR: Windows bootstrap currently supports x64 only (got ${ARCH})" >&2
+    exit 1
+  fi
 }
 
 detect_platform
 
 # ── Node.js ───────────────────────────────────────────────────────────────
 
-NODE_DIR="node-v${NODE_VERSION}-${OS}-${ARCH}"
-NODE_BIN_DIR="${TOOLS_DIR}/${NODE_DIR}/bin"
-NODE_TARBALL="${NODE_DIR}.tar.xz"
-NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}"
+if [ "$HOST_OS" = "win" ]; then
+  NODE_DIR="node-v${NODE_VERSION}-win-${ARCH}"
+  NODE_BIN_DIR="${TOOLS_DIR}/${NODE_DIR}"
+  NODE_ARCHIVE="${NODE_DIR}.zip"
+  NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_ARCHIVE}"
+  NODE_BIN="${NODE_BIN_DIR}/node.exe"
+else
+  NODE_DIR="node-v${NODE_VERSION}-${HOST_OS}-${ARCH}"
+  NODE_BIN_DIR="${TOOLS_DIR}/${NODE_DIR}/bin"
+  NODE_ARCHIVE="${NODE_DIR}.tar.xz"
+  NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_ARCHIVE}"
+  NODE_BIN="${NODE_BIN_DIR}/node"
+fi
 
 install_node() {
-  if [ -x "${NODE_BIN_DIR}/node" ]; then
+  if [ -x "$NODE_BIN" ] || [ -f "$NODE_BIN" ]; then
     echo "Node.js ${NODE_VERSION} already installed"
     return
   fi
 
-  echo "Downloading Node.js ${NODE_VERSION} (${OS}-${ARCH})..."
+  echo "Downloading Node.js ${NODE_VERSION} (${HOST_OS}-${ARCH})..."
   mkdir -p "$TOOLS_DIR"
-  curl -fsSL "$NODE_URL" | tar xJ -C "$TOOLS_DIR"
 
-  if [ ! -x "${NODE_BIN_DIR}/node" ]; then
-    echo "ERROR: Node.js download failed — ${NODE_BIN_DIR}/node not found" >&2
+  if [ "$HOST_OS" = "win" ]; then
+    local archive_path="${TOOLS_DIR}/${NODE_ARCHIVE}"
+    curl -fsSL "$NODE_URL" -o "$archive_path"
+    # Prefer unzip (Git Bash); fall back to PowerShell Expand-Archive
+    if command -v unzip >/dev/null 2>&1; then
+      unzip -q -o "$archive_path" -d "$TOOLS_DIR"
+    else
+      powershell.exe -NoProfile -Command \
+        "Expand-Archive -Path '$archive_path' -DestinationPath '$TOOLS_DIR' -Force"
+    fi
+    rm -f "$archive_path"
+  else
+    curl -fsSL "$NODE_URL" | tar xJ -C "$TOOLS_DIR"
+  fi
+
+  if [ ! -x "$NODE_BIN" ] && [ ! -f "$NODE_BIN" ]; then
+    echo "ERROR: Node.js download failed — ${NODE_BIN} not found" >&2
     exit 1
   fi
 
-  echo "  Installed: ${NODE_BIN_DIR}/node"
+  echo "  Installed: ${NODE_BIN}"
 }
 
 validate_sea_fuse() {
-  local node_bin="${NODE_BIN_DIR}/node"
+  local node_bin="$NODE_BIN"
   if grep -q 'NODE_SEA_FUSE' "$node_bin" 2>/dev/null; then
     echo "  NODE_SEA_FUSE sentinel: OK"
   else
@@ -80,6 +117,26 @@ validate_sea_fuse() {
 UV_BIN_DIR="${TOOLS_DIR}/bin"
 
 install_uv() {
+  if [ "$HOST_OS" = "win" ]; then
+    local uv_exe="${UV_BIN_DIR}/uv.exe"
+    if [ -f "$uv_exe" ]; then
+      echo "uv already installed"
+      return
+    fi
+    echo "Downloading uv (Windows)..."
+    mkdir -p "$UV_BIN_DIR"
+    # Install into our tools dir (no PATH mutation)
+    UV_INSTALL_DIR="$(cygpath -w "$UV_BIN_DIR" 2>/dev/null || echo "$UV_BIN_DIR")" \
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
+      "irm https://astral.sh/uv/install.ps1 | iex"
+    if [ ! -f "$uv_exe" ]; then
+      echo "ERROR: uv install failed — ${uv_exe} not found" >&2
+      exit 1
+    fi
+    echo "  Installed: ${uv_exe}"
+    return
+  fi
+
   if [ -x "${UV_BIN_DIR}/uv" ]; then
     echo "uv already installed"
     return
@@ -99,6 +156,39 @@ PREK_BIN_DIR="${TOOLS_DIR}/prek/bin"
 PREK_VERSION="0.3.5"
 
 install_prek() {
+  if [ "$HOST_OS" = "win" ]; then
+    local prek_exe="${PREK_BIN_DIR}/prek.exe"
+    if [ -f "$prek_exe" ]; then
+      echo "prek already installed"
+      return
+    fi
+    echo "Downloading prek ${PREK_VERSION} (Windows)..."
+    mkdir -p "${PREK_BIN_DIR}"
+    local prek_url="https://github.com/j178/prek/releases/download/v${PREK_VERSION}/prek-x86_64-pc-windows-msvc.zip"
+    local prek_zip="${TOOLS_DIR}/prek.zip"
+    curl -fsSL "$prek_url" -o "$prek_zip"
+    if command -v unzip >/dev/null 2>&1; then
+      unzip -q -o "$prek_zip" -d "${PREK_BIN_DIR}"
+    else
+      powershell.exe -NoProfile -Command \
+        "Expand-Archive -Path '$prek_zip' -DestinationPath '${PREK_BIN_DIR}' -Force"
+    fi
+    rm -f "$prek_zip"
+    if [ ! -f "$prek_exe" ]; then
+      # Zip may place binary at top level with different layout
+      local found
+      found="$(find "${PREK_BIN_DIR}" -name 'prek.exe' -type f 2>/dev/null | head -n 1 || true)"
+      if [ -n "$found" ]; then
+        cp "$found" "$prek_exe"
+      else
+        echo "ERROR: prek download failed — prek.exe not found" >&2
+        exit 1
+      fi
+    fi
+    echo "  Installed: ${prek_exe}"
+    return
+  fi
+
   if [ -x "${PREK_BIN_DIR}/prek" ]; then
     echo "prek already installed"
     return
@@ -123,10 +213,17 @@ ENVEOF
 
   echo ""
   echo "Build tools ready:"
-  echo "  node $(${NODE_BIN_DIR}/node --version)"
-  echo "  npm  $(PATH="${NODE_BIN_DIR}:${PATH}" "${NODE_BIN_DIR}/npm" --version)"
-  echo "  uv   $(${UV_BIN_DIR}/uv --version 2>/dev/null || echo '(version unknown)')"
-  echo "  prek $(${PREK_BIN_DIR}/prek --version 2>/dev/null || echo '(version unknown)')"
+  if [ "$HOST_OS" = "win" ]; then
+    echo "  node $(PATH="${NODE_BIN_DIR}:${PATH}" "${NODE_BIN}" --version)"
+    echo "  npm  $(PATH="${NODE_BIN_DIR}:${PATH}" npm --version 2>/dev/null || echo '(see npm.cmd)')"
+    echo "  uv   $(PATH="${UV_BIN_DIR}:${PATH}" uv --version 2>/dev/null || echo '(version unknown)')"
+    echo "  prek $(PATH="${PREK_BIN_DIR}:${PATH}" prek --version 2>/dev/null || echo '(version unknown)')"
+  else
+    echo "  node $(${NODE_BIN_DIR}/node --version)"
+    echo "  npm  $(PATH="${NODE_BIN_DIR}:${PATH}" "${NODE_BIN_DIR}/npm" --version)"
+    echo "  uv   $(${UV_BIN_DIR}/uv --version 2>/dev/null || echo '(version unknown)')"
+    echo "  prek $(${PREK_BIN_DIR}/prek --version 2>/dev/null || echo '(version unknown)')"
+  fi
 }
 
 persist_ci_path() {

--- a/build.js
+++ b/build.js
@@ -253,13 +253,17 @@ function createDistribution() {
 
     ensureDir(PLATFORM_DIR);
 
-    // Copy SEA binary
+    // Copy SEA binary (Windows SEA build emits a .exe suffix)
     const seaDir = path.join(DAEMON_ROOT, 'dist', 'sea');
-    const seaBinaryName = `abbenay-daemon-${PLATFORM}-${ARCH}`;
+    const seaBinaryName = IS_WIN
+        ? `abbenay-daemon-${PLATFORM}-${ARCH}.exe`
+        : `abbenay-daemon-${PLATFORM}-${ARCH}`;
     const seaBinary = path.join(seaDir, seaBinaryName);
     if (fs.existsSync(seaBinary)) {
         fs.copyFileSync(seaBinary, path.join(PLATFORM_DIR, seaBinaryName));
-        fs.chmodSync(path.join(PLATFORM_DIR, seaBinaryName), 0o755);
+        if (!IS_WIN) {
+            fs.chmodSync(path.join(PLATFORM_DIR, seaBinaryName), 0o755);
+        }
     }
 
     // Copy keytar.node sidecar

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Abbenay is a unified AI daemon and library written in TypeScript/Node.js that pr
 │           └────────────────────┼────────────────────────┘               │
 │                                │                                         │
 └────────────────────────────────┼─────────────────────────────────────────┘
-                                 │ gRPC over Unix Socket (or named pipe)
+                                 │ gRPC over Unix Socket (or loopback TCP on Windows)
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                     abbenay daemon (TypeScript)                          │
@@ -96,15 +96,15 @@ The core TypeScript/Node.js process that runs as a background daemon.
 
 **Subcommands:**
 - `abbenay start` - Start all services (daemon, web dashboard, OpenAI API, MCP server)
-- `abbenay daemon` - Start the gRPC server on Unix socket (or named pipe on Windows)
+- `abbenay daemon` - Start the gRPC server (Unix socket on Linux/macOS; loopback TCP on Windows)
 - `abbenay web` - Start the web dashboard (embedded in daemon or started via gRPC if daemon already running)
 - `abbenay serve` - Start the OpenAI-compatible API server (same as `web` but framed for API use)
 - `abbenay status` - Check if daemon is running
 - `abbenay stop` - Stop the running daemon
 
-**Socket location:**
-- Linux/macOS: `$XDG_RUNTIME_DIR/abbenay/daemon.sock` or `/run/user/{uid}/abbenay/daemon.sock`
-- Windows: `\\.\pipe\abbenay-daemon`
+**Local IPC:**
+- Linux/macOS: Unix socket at `$XDG_RUNTIME_DIR/abbenay/daemon.sock` or `/run/user/{uid}/abbenay/daemon.sock`
+- Windows: loopback TCP (`127.0.0.1` + ephemeral port); address in `%TEMP%/abbenay/daemon.addr` (DR-043)
 
 ### Web Dashboard (Embedded)
 
@@ -480,9 +480,9 @@ internal MCP tool for cross-session retrieval.
 
 | File | Path | Purpose |
 |------|------|---------|
-| Socket (Linux/macOS) | `$XDG_RUNTIME_DIR/abbenay/daemon.sock` | gRPC server socket |
-| Socket (Windows) | `\\.\pipe\abbenay-daemon` | gRPC named pipe |
-| PID file | `$XDG_RUNTIME_DIR/abbenay/abbenay.pid` | Daemon process ID |
+| Socket (Linux/macOS) | `$XDG_RUNTIME_DIR/abbenay/daemon.sock` | gRPC Unix socket |
+| Address (Windows) | `%TEMP%/abbenay/daemon.addr` | `host:port` for loopback TCP gRPC |
+| PID file | `<runtimeDir>/abbenay.pid` | Daemon process ID |
 | User Config | `~/.config/abbenay/config.yaml` | User-level provider config |
 | Workspace Config | `<ws>/.config/abbenay/config.yaml` | Workspace-level config |
 | Session Data | `$XDG_DATA_HOME/abbenay/sessions/` | Persisted chat sessions |
@@ -491,7 +491,8 @@ internal MCP tool for cross-session retrieval.
 ## Security
 
 - **Secrets**: Stored in system keychain via keytar when available; never in config files
-- **Socket**: Unix socket (or named pipe) with user-only permissions (local IPC)
+- **Local IPC**: Unix socket with user-only permissions on Linux/macOS; loopback
+  TCP + `daemon.addr` on Windows (DR-043)
 - **Web dashboard / HTTP API**: Binds to `127.0.0.1` by default; Bearer (or
   cookie + CSRF) auth required; CORS allowlist only (never `*`) — DR-030
 - **gRPC TCP**: Loopback plaintext OK for local DX; non-loopback requires

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,12 +38,17 @@ The bootstrap is idempotent -- re-running it is a no-op if the tools are already
 
 The bootstrap auto-detects your OS and architecture:
 
-| OS | Architecture | Node.js tarball | Tested in CI |
+| OS | Architecture | Node.js archive | Tested in CI |
 |----|-------------|-----------------|-------------|
 | Linux | x86_64 (x64) | `node-v22.x.x-linux-x64.tar.xz` | Yes |
 | Linux | aarch64 (arm64) | `node-v22.x.x-linux-arm64.tar.xz` | Yes |
 | macOS | arm64 (Apple Silicon) | `node-v22.x.x-darwin-arm64.tar.xz` | Yes |
 | macOS | x86_64 (Intel) | `node-v22.x.x-darwin-x64.tar.xz` | No (not in CI matrix) |
+| Windows | x86_64 (x64) | `node-v22.x.x-win-x64.zip` | Yes |
+
+On Windows, run `./bootstrap.sh` from Git Bash (same as GitHub Actions
+`windows-latest`). Local IPC uses loopback TCP and `%TEMP%/abbenay/daemon.addr`
+(see DR-043); Unix platforms keep `daemon.sock`.
 
 ### Pinning the Node.js version
 
@@ -238,9 +243,10 @@ lint-and-test (ubuntu-latest)
   └─ ./bootstrap.sh → npm ci → npm run lint
   └─ apt install xvfb → xvfb-run -a npm test
 
-build (matrix: linux-x64, linux-arm64, macos-arm64)
+build (matrix: linux-x64, linux-arm64, macos-arm64, windows-x64)
   └─ ./bootstrap.sh → npm ci → npm run ci:build
-  └─ uploads: SEA binary, VSIX, distribution zip
+  └─ Windows also runs npm run ci:smoke-win32-ipc
+  └─ uploads: SEA binary, VSIX, distribution archive (.tar.gz or .zip)
 
 package-python (ubuntu-latest)
   └─ ./bootstrap.sh → npm run ci:package-python
@@ -260,6 +266,7 @@ Every CI run produces downloadable artifacts:
 | `abbenay-daemon-linux-x64` | SEA binary + sidecars (Linux x64) |
 | `abbenay-daemon-linux-arm64` | SEA binary + sidecars (Linux arm64) |
 | `abbenay-daemon-darwin-arm64` | SEA binary + sidecars (macOS Apple Silicon) |
+| `abbenay-daemon-win32-x64` | SEA binary (`.exe`) + sidecars (Windows x64) |
 | `abbenay-vsix-{platform}-{arch}` | VS Code extension (per platform) |
 | `abbenay-client-python` | Python wheel (platform-independent) |
 
@@ -285,9 +292,11 @@ Each release produces these artifacts:
 | `abbenay-VERSION-linux-x64.tar.gz` | Standalone daemon binary + sidecars (proto, static, keytar) for Linux x64 | Standalone / CLI users on Linux x64 |
 | `abbenay-VERSION-linux-arm64.tar.gz` | Same, for Linux arm64 | Standalone / CLI users on Linux arm64 |
 | `abbenay-VERSION-darwin-arm64.tar.gz` | Same, for macOS Apple Silicon | Standalone / CLI users on macOS |
+| `abbenay-VERSION-win32-x64.zip` | Same, for Windows x64 (`abbenay-daemon-win32-x64.exe`) | Standalone / CLI users on Windows |
 | `abbenay-provider-linux-x64-VERSION.vsix` | VS Code extension with embedded daemon (Linux x64) | VS Code users on Linux x64 |
 | `abbenay-provider-linux-arm64-VERSION.vsix` | Same, for Linux arm64 | VS Code users on Linux arm64 |
 | `abbenay-provider-darwin-arm64-VERSION.vsix` | Same, for macOS arm64 | VS Code users on macOS |
+| `abbenay-provider-win32-x64-VERSION.vsix` | Same, for Windows x64 | VS Code users on Windows |
 | `abbenay-core-VERSION.tgz` | `@abbenay/core` npm package (platform-independent) | Node.js consumers building on the core library |
 | `abbenay_client-VERSION-py3-none-any.whl` | Python gRPC client wheel (platform-independent) | Python consumers of the gRPC API |
 | `abbenay_client-VERSION.tar.gz` | Python client sdist | Alternative to the wheel |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -128,7 +128,8 @@ keychain libraries -- libsecret on Linux, Keychain.framework on macOS). Neither
 can run on a different OS or architecture. A "universal" VSIX would need to
 bundle all platform variants (tripling size) or would silently fail on
 non-matching platforms. Platform-specific VSIXes ensure the marketplace and
-manual installs deliver the correct binaries for each user's system.
+manual installs deliver the correct binaries for each user's system.  
+**Superseded by:** DR-043
 
 ---
 
@@ -161,7 +162,9 @@ without producing redundant artifacts. All 3 must pass to gate the release.
 **Date:** 2026-03-11  
 **Decision:** Use `.tar.gz` instead of `.zip` for daemon distribution archives.  
 **Rationale:** Smaller file size. tar.gz is the standard for Linux/macOS binary
-distribution and is natively supported on both platforms.
+distribution and is natively supported on both platforms.  
+**Note:** DR-043 adds `.zip` archives for Windows (`win32-x64`) only; Unix
+platforms keep `.tar.gz`.
 
 ---
 
@@ -699,3 +702,21 @@ transport UX around SDK `user-approval` stream pauses. Transport approval
 notifications are out-of-band SSE/CLI events via `onToolApprovalNeeded`; they
 are not `ChatChunk` variants (unused `approval_request` / `approval_result`
 chunk types were removed after the bridge landed).
+
+## DR-043: win32-x64 platform + loopback TCP local IPC
+
+**Date:** 2026-07-23  
+**Decision:** Add `win32-x64` as a fourth supported platform (CI, release,
+Marketplace VSIX). On Windows, local daemon IPC uses loopback TCP
+(`127.0.0.1` + ephemeral port) with `host:port` written to
+`<runtimeDir>/daemon.addr` (runtime dir = `%TEMP%/abbenay`). Do **not** use
+named-pipe gRPC for local IPC in this release. Linux/macOS keep Unix sockets.
+Windows distribution archives are `.zip`; Unix remains `.tar.gz` (DR-013).
+`bootstrap.sh` downloads the official `node-v*-win-x64.zip` layout on Windows.
+**Supersedes:** DR-010 (platform list expands from 3 to 4).  
+**Rationale:** `@grpc/grpc-js` already supports TCP (used for containers via
+`--grpc-port`); named-pipe gRPC was stubbed but unproven. Loopback plaintext is
+already allowed by DR-029. Shipping `win32-x64` unblocks making Abbenay a hard
+`extensionDependency` of vscode-ansible on Windows (AAP-82840 / AAP-82970).
+Authenticode signing, `darwin-x64`, Python Windows paths, and named-pipe gRPC
+remain out of scope.

--- a/package-lock.json
+++ b/package-lock.json
@@ -541,6 +541,40 @@
       "version": "2.11.0",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
@@ -815,6 +849,8 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -826,9 +862,7 @@
       ],
       "engines": {
         "node": ">=18"
-      },
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="
+      }
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.1",
@@ -1681,6 +1715,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -1721,7 +1774,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1776,8 +1831,163 @@
       "version": "1.1.1",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -1792,7 +2002,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -1806,8 +2018,80 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2083,6 +2367,17 @@
       "license": "MIT",
       "dependencies": {
         "@textlint/ast-node-types": "15.5.2"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -2766,6 +3061,90 @@
         "@vscode/vsce-sign-win32-x64": "2.0.6"
       }
     },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@vscode/vsce-sign-linux-x64": {
       "version": "2.0.6",
       "cpu": [
@@ -2776,6 +3155,34 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@vscode/vsce/node_modules/@isaacs/cliui": {
@@ -4702,6 +5109,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -5571,6 +5993,153 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
       "cpu": [
@@ -5600,6 +6169,48 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -6125,7 +6736,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6710,7 +7323,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -6728,7 +7343,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7067,11 +7682,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -7081,21 +7698,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/router": {
@@ -8221,14 +8838,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -8245,7 +8864,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -8297,7 +8916,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8735,6 +9356,7 @@
         "tsx": "^4.22.4",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.57.0",
+        "vite": "^8.1.5",
         "vitest": "^4.1.9"
       },
       "engines": {
@@ -8879,609 +9501,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@vscode/vsce-sign-alpine-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
-      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "alpine"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-alpine-x64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
-      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "alpine"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-darwin-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
-      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-darwin-x64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
-      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-linux-arm": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
-      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-linux-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
-      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-win32-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
-      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@vscode/vsce-sign-win32-x64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
-      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "check:no-query-secrets": "node scripts/check-no-query-secrets.js",
     "ci:build": "node build.js --skip-proto",
     "ci:package-python": "cd packages/python && uvx hatch build",
-    "ci:publish-vscode": "node scripts/publish-vscode.js"
+    "ci:publish-vscode": "node scripts/publish-vscode.js",
+    "ci:smoke-win32-ipc": "node scripts/smoke-win32-ipc.js"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -63,6 +63,7 @@
     "tsx": "^4.22.4",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.57.0",
+    "vite": "^8.1.5",
     "vitest": "^4.1.9"
   },
   "engines": {

--- a/packages/daemon/src/core/index.ts
+++ b/packages/daemon/src/core/index.ts
@@ -191,6 +191,7 @@ export {
   getConfigDir,
   getWorkspaceConfigDir,
   getSocketPath,
+  getAddressPath,
   getPidPath,
 } from './paths.js';
 

--- a/packages/daemon/src/core/paths.test.ts
+++ b/packages/daemon/src/core/paths.test.ts
@@ -8,11 +8,13 @@ import {
   getSessionsDir,
   getWorkspaceConfigDir,
   getSocketPath,
+  getAddressPath,
   getPidPath,
   getUserConfigPath,
   getWorkspaceConfigPath,
   getUserPoliciesPath,
 } from './paths.js';
+import * as os from 'node:os';
 import { DEFAULT_WEB_PORT, DEFAULT_HTTP_HOST } from './constants.js';
 
 // ── DEFAULT_WEB_PORT / DEFAULT_HTTP_HOST ─────────────────────────────────────
@@ -59,6 +61,13 @@ describe('getRuntimeDir', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' });
     const result = getRuntimeDir();
     expect(result).toMatch(/\babbenay$/);
+  });
+
+  it('should use os.tmpdir() on win32 when XDG_RUNTIME_DIR is unset', () => {
+    delete process.env.XDG_RUNTIME_DIR;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const result = getRuntimeDir();
+    expect(result).toBe(path.join(os.tmpdir(), 'abbenay'));
   });
 });
 
@@ -132,6 +141,12 @@ describe('getSocketPath', () => {
     if (process.platform !== 'win32') {
       expect(getSocketPath()).toMatch(/daemon\.sock$/);
     }
+  });
+});
+
+describe('getAddressPath', () => {
+  it('should end with daemon.addr under the runtime dir', () => {
+    expect(getAddressPath()).toBe(path.join(getRuntimeDir(), 'daemon.addr'));
   });
 });
 

--- a/packages/daemon/src/core/paths.ts
+++ b/packages/daemon/src/core/paths.ts
@@ -5,11 +5,15 @@
  * consistent file placement across Linux, macOS, and Windows.
  *
  * Conventions:
- *   Runtime dir  (ephemeral: PID, socket, lock)
+ *   Runtime dir  (ephemeral: PID, socket/address, lock)
  *     Linux:   $XDG_RUNTIME_DIR/abbenay  → /run/user/<uid>/abbenay
  *     macOS:   os.tmpdir()/abbenay        → /var/folders/.../abbenay
- *     Windows: named pipe (no dir needed for socket)
+ *     Windows: os.tmpdir()/abbenay        → %TEMP%/abbenay (PID + daemon.addr)
  *     Fallback: /tmp/abbenay
+ *
+ *   Local IPC:
+ *     Linux/macOS: Unix socket at <runtimeDir>/daemon.sock
+ *     Windows:     loopback TCP; host:port written to <runtimeDir>/daemon.addr
  *
  *   Config dir   (persistent user config)
  *     Linux:   $XDG_CONFIG_HOME/abbenay   → ~/.config/abbenay
@@ -28,11 +32,12 @@ const APP_NAME = 'abbenay';
 // ── Runtime directory ────────────────────────────────────────────────
 
 /**
- * Get the platform runtime directory (for ephemeral files: PID, socket, lock).
+ * Get the platform runtime directory (for ephemeral files: PID, socket/address, lock).
  *
- * - Linux:  XDG_RUNTIME_DIR  → /run/user/<uid>
- * - macOS:  os.tmpdir()      → /var/folders/...
- * - Other:  /tmp
+ * - Linux:   XDG_RUNTIME_DIR  → /run/user/<uid>
+ * - macOS:   os.tmpdir()      → /var/folders/...
+ * - Windows: os.tmpdir()      → %TEMP%
+ * - Other:   /tmp
  */
 export function getRuntimeDir(): string {
     // 1. Respect XDG_RUNTIME_DIR (standard on Linux)
@@ -45,17 +50,20 @@ export function getRuntimeDir(): string {
         return path.join(os.tmpdir(), APP_NAME);
     }
 
-    // 3. Linux without XDG_RUNTIME_DIR — try /run/user/<uid>
-    if (process.platform !== 'win32') {
-        try {
-            const uid = os.userInfo().uid;
-            return path.join(`/run/user/${uid}`, APP_NAME);
-        } catch {
-            // os.userInfo() can fail in some sandboxes
-        }
+    // 3. Windows — %TEMP%/abbenay (PID + daemon.addr for loopback TCP IPC)
+    if (process.platform === 'win32') {
+        return path.join(os.tmpdir(), APP_NAME);
     }
 
-    // 4. Fallback
+    // 4. Linux without XDG_RUNTIME_DIR — try /run/user/<uid>
+    try {
+        const uid = os.userInfo().uid;
+        return path.join(`/run/user/${uid}`, APP_NAME);
+    } catch {
+        // os.userInfo() can fail in some sandboxes
+    }
+
+    // 5. Fallback
     return path.join('/tmp', APP_NAME);
 }
 
@@ -124,12 +132,21 @@ export function getWorkspaceConfigDir(workspacePath: string): string {
 
 // ── Derived helpers ──────────────────────────────────────────────────
 
-/** Socket path:  <runtimeDir>/daemon.sock  (or Windows named pipe) */
+/**
+ * Socket path: <runtimeDir>/daemon.sock on Unix.
+ * On Windows a named-pipe stub remains for compatibility but is not used for IPC
+ * (local IPC uses loopback TCP + daemon.addr).
+ */
 export function getSocketPath(): string {
     if (process.platform === 'win32') {
         return '\\\\.\\pipe\\abbenay-daemon';
     }
     return path.join(getRuntimeDir(), 'daemon.sock');
+}
+
+/** Address file (Windows loopback TCP):  <runtimeDir>/daemon.addr */
+export function getAddressPath(): string {
+    return path.join(getRuntimeDir(), 'daemon.addr');
 }
 
 /** PID file:  <runtimeDir>/abbenay.pid */

--- a/packages/daemon/src/daemon/daemon.ts
+++ b/packages/daemon/src/daemon/daemon.ts
@@ -11,10 +11,14 @@ import { fileURLToPath } from 'node:url';
 import {
   getDefaultSocketPath,
   ensureSocketDir,
+  ensureRuntimeDir,
   cleanupSocket,
+  cleanupIpcArtifacts,
   writePidFile,
   removePidFile,
   readPidFile,
+  writeAddressFile,
+  readAddressFile,
   isDaemonRunningSync,
   killDaemon,
   isProcessRunning,
@@ -125,126 +129,113 @@ export async function startDaemon(opts?: DaemonOptions): Promise<DaemonState> {
   const { initAiSdkTelemetry } = await import('./telemetry.js');
   await initAiSdkTelemetry();
   
-  // Ensure directories exist
-  ensureSocketDir();
-  
-  // Clean up stale socket
-  cleanupSocket();
-  
+  // Ensure directories exist and clean stale IPC artifacts
+  const isWin32 = process.platform === 'win32';
+  if (isWin32) {
+    ensureRuntimeDir();
+    cleanupIpcArtifacts();
+  } else {
+    ensureSocketDir();
+    cleanupSocket();
+  }
+
   // Write PID file
   writePidFile();
-  
+
   // Create state
   state = new DaemonState();
+
+  // On Windows, local IPC is always loopback TCP (port may be ephemeral / 0).
+  const localTcpHost = opts?.grpcHost ?? '127.0.0.1';
+  const localTcpPort = isWin32 ? (opts?.grpcPort ?? 0) : opts?.grpcPort;
 
   // Register known listen ports before MCP init so self-connections are blocked
   state.mcpClientPool.setListenEndpoints({
     httpPorts: opts?.httpPort != null ? [opts.httpPort] : [],
-    grpcPorts: opts?.grpcPort != null ? [opts.grpcPort] : [],
+    grpcPorts: localTcpPort != null && localTcpPort > 0 ? [localTcpPort] : [],
   });
 
   // Load proto and create server
   const proto = loadProto();
   const abbenayProto = (proto as unknown as { abbenay: { v1: { Abbenay: { service: grpc.ServiceDefinition } } } }).abbenay.v1;
-  
+
   server = new grpc.Server();
 
   const allowOpenAuth = resolveAllowOpenAuth({
     allowOpenAuth: opts?.allowOpenAuth,
     insecure: opts?.grpcTls?.insecure,
   });
+  // Windows local IPC is always loopback TCP; omit port when ephemeral so auth stays loopback-only.
   const authContext = buildConsumerAuthContext({
-    grpcHost: opts?.grpcHost,
-    grpcPort: opts?.grpcPort,
+    grpcHost: isWin32 ? localTcpHost : opts?.grpcHost,
+    grpcPort: isWin32
+      ? (localTcpPort && localTcpPort > 0 ? localTcpPort : undefined)
+      : opts?.grpcPort,
     allowOpenAuth,
   });
 
   // Add Abbenay service
   const abbenayService = createAbbenayService(state, authContext);
   server.addService(abbenayProto.Abbenay.service, abbenayService);
-  
+
   const socketPath = getDefaultSocketPath();
 
   try {
-    // Unix socket / named pipe: local IPC only (filesystem permissions).
-    // TLS is not used here — the TCP listener below is the network exposure path (C2).
-    await new Promise<void>((resolve, reject) => {
-      server!.bindAsync(
-        `unix://${socketPath}`,
-        grpc.ServerCredentials.createInsecure(),
-        (error, _port) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve();
-          }
-        }
+    if (isWin32) {
+      // Windows local IPC: bind loopback TCP (ephemeral port by default) and write daemon.addr.
+      // Named-pipe gRPC is out of scope; reuse the existing TCP bind path.
+      const boundPort = await bindTcpGrpc(
+        server,
+        localTcpHost,
+        localTcpPort ?? 0,
+        opts?.grpcTls ?? {},
+        allowOpenAuth,
+        authContext.loopbackOnly,
       );
-    });
-    
-    console.log(`Abbenay daemon listening on ${socketPath}`);
-
-    // Optionally bind gRPC to a TCP port for remote / container access
-    if (opts?.grpcPort) {
-      const grpcHost = opts.grpcHost ?? '127.0.0.1';
-      const tlsOpts: GrpcTlsOptions = opts.grpcTls ?? {};
-      const resolved = resolveTcpGrpcBind(grpcHost, tlsOpts);
-
-      // DR-037: non-loopback binds require consumers (or explicit open auth)
-      assertConsumersConfiguredForBind(grpcHost, loadConfig(), { allowOpenAuth });
-
-      if (!resolved.tlsEnabled && tlsOpts.insecure) {
-        console.warn(
-          `[Daemon] WARNING: gRPC is bound to ${grpcHost} with --insecure (plaintext). ` +
-          'API keys, chat, and provider config travel unencrypted. Prefer --grpc-tls.',
-        );
-      }
-      // Only warn when open auth is actually active (empty consumers + escape hatch).
-      // When consumers are configured, RPCs remain gated even with --allow-open-auth/--insecure.
-      if (
-        allowOpenAuth
-        && !authContext.loopbackOnly
-        && !hasConfiguredConsumers(loadConfig())
-      ) {
-        console.warn(
-          `[Daemon] WARNING: gRPC on ${grpcHost} allows open consumer auth ` +
-          '(--allow-open-auth / --insecure). Sensitive RPCs are not gated by consumers.',
-        );
-      } else if (resolved.tlsEnabled && (grpcHost === '0.0.0.0' || grpcHost === '::')) {
-        console.warn(
-          `[Daemon] gRPC TLS is enabled on ${grpcHost} — accessible from any network interface. ` +
-          'Consumer authentication is required for sensitive RPCs.',
-        );
-      }
-
+      writeAddressFile(localTcpHost, boundPort);
+      state.mcpClientPool.setListenEndpoints({
+        httpPorts: opts?.httpPort != null ? [opts.httpPort] : [],
+        grpcPorts: [boundPort],
+      });
+    } else {
+      // Unix socket: local IPC only (filesystem permissions).
+      // TLS is not used here — the TCP listener below is the network exposure path (C2).
       await new Promise<void>((resolve, reject) => {
         server!.bindAsync(
-          `${grpcHost}:${opts.grpcPort}`,
-          resolved.serverCredentials,
-          (error, boundPort) => {
+          `unix://${socketPath}`,
+          grpc.ServerCredentials.createInsecure(),
+          (error, _port) => {
             if (error) {
               reject(error);
             } else {
-              const mode = resolved.tlsEnabled ? 'TLS' : 'plaintext';
-              console.log(`Abbenay gRPC listening on ${grpcHost}:${boundPort} (${mode})`);
-              if (resolved.tlsEnabled && resolved.caPath) {
-                console.log(
-                  `  TLS: auto-generated self-signed cert; clients should trust ${resolved.caPath}`,
-                );
-              }
               resolve();
             }
           }
         );
       });
+
+      console.log(`Abbenay daemon listening on ${socketPath}`);
+
+      // Optionally bind gRPC to a TCP port for remote / container access
+      if (opts?.grpcPort) {
+        const grpcHost = opts.grpcHost ?? '127.0.0.1';
+        await bindTcpGrpc(
+          server,
+          grpcHost,
+          opts.grpcPort,
+          opts.grpcTls ?? {},
+          allowOpenAuth,
+          authContext.loopbackOnly,
+        );
+      }
     }
   } catch (err) {
-    // Clean up PID file, socket, and server on bind failure
+    // Clean up PID file, IPC artifacts, and server on bind failure
     await new Promise<void>((resolve) => {
       server!.tryShutdown(() => resolve());
     });
     server = null;
-    cleanupSocket();
+    cleanupIpcArtifacts();
     removePidFile();
     state = null;
     throw err;
@@ -299,7 +290,7 @@ async function stopDaemonInternal(): Promise<void> {
     server = null;
   }
   
-  cleanupSocket();
+  cleanupIpcArtifacts();
   removePidFile();
   state = null;
 }
@@ -309,30 +300,30 @@ async function stopDaemonInternal(): Promise<void> {
  */
 export async function stopDaemon(): Promise<void> {
   const pid = readPidFile();
-  
+
   if (!pid) {
-    // No PID file, but maybe stale socket exists
-    cleanupSocket();
+    // No PID file, but maybe stale IPC artifacts exist
+    cleanupIpcArtifacts();
     throw new Error('No daemon PID file found');
   }
-  
+
   if (!isProcessRunning(pid)) {
     // Process not running, clean up
     removePidFile();
-    cleanupSocket();
+    cleanupIpcArtifacts();
     throw new Error('Daemon process not running (cleaned up stale files)');
   }
-  
+
   // Kill the process
   const killed = killDaemon();
-  
+
   if (killed) {
     // Wait for cleanup
     await new Promise((resolve) => setTimeout(resolve, 500));
-    
+
     // Clean up files if process didn't
     removePidFile();
-    cleanupSocket();
+    cleanupIpcArtifacts();
   } else {
     throw new Error('Failed to stop daemon');
   }
@@ -341,17 +332,90 @@ export async function stopDaemon(): Promise<void> {
 /**
  * Get daemon status
  */
-export function getDaemonStatus(): { 
-  running: boolean; 
-  pid: number | null; 
+export function getDaemonStatus(): {
+  running: boolean;
+  pid: number | null;
   socketPath: string;
+  address?: string;
 } {
   const pid = readPidFile();
+
+  if (process.platform === 'win32') {
+    const addr = readAddressFile();
+    const address = addr ? `${addr.host}:${addr.port}` : '';
+    if (pid && isProcessRunning(pid)) {
+      return { running: true, pid, socketPath: address, address };
+    }
+    return { running: false, pid: null, socketPath: address, address };
+  }
+
   const socketPath = getDefaultSocketPath();
-  
+
   if (pid && isProcessRunning(pid)) {
     return { running: true, pid, socketPath };
   }
-  
+
   return { running: false, pid: null, socketPath };
+}
+
+/**
+ * Bind gRPC on TCP and return the actual bound port.
+ */
+async function bindTcpGrpc(
+  grpcServer: grpc.Server,
+  grpcHost: string,
+  grpcPort: number,
+  tlsOpts: GrpcTlsOptions,
+  allowOpenAuth: boolean,
+  loopbackOnly: boolean,
+): Promise<number> {
+  const resolved = resolveTcpGrpcBind(grpcHost, tlsOpts);
+
+  // DR-037: non-loopback binds require consumers (or explicit open auth)
+  assertConsumersConfiguredForBind(grpcHost, loadConfig(), { allowOpenAuth });
+
+  if (!resolved.tlsEnabled && tlsOpts.insecure) {
+    console.warn(
+      `[Daemon] WARNING: gRPC is bound to ${grpcHost} with --insecure (plaintext). ` +
+      'API keys, chat, and provider config travel unencrypted. Prefer --grpc-tls.',
+    );
+  }
+  // Only warn when open auth is actually active (empty consumers + escape hatch).
+  // When consumers are configured, RPCs remain gated even with --allow-open-auth/--insecure.
+  if (
+    allowOpenAuth
+    && !loopbackOnly
+    && !hasConfiguredConsumers(loadConfig())
+  ) {
+    console.warn(
+      `[Daemon] WARNING: gRPC on ${grpcHost} allows open consumer auth ` +
+      '(--allow-open-auth / --insecure). Sensitive RPCs are not gated by consumers.',
+    );
+  } else if (resolved.tlsEnabled && (grpcHost === '0.0.0.0' || grpcHost === '::')) {
+    console.warn(
+      `[Daemon] gRPC TLS is enabled on ${grpcHost} — accessible from any network interface. ` +
+      'Consumer authentication is required for sensitive RPCs.',
+    );
+  }
+
+  return new Promise<number>((resolve, reject) => {
+    grpcServer.bindAsync(
+      `${grpcHost}:${grpcPort}`,
+      resolved.serverCredentials,
+      (error, boundPort) => {
+        if (error) {
+          reject(error);
+        } else {
+          const mode = resolved.tlsEnabled ? 'TLS' : 'plaintext';
+          console.log(`Abbenay gRPC listening on ${grpcHost}:${boundPort} (${mode})`);
+          if (resolved.tlsEnabled && resolved.caPath) {
+            console.log(
+              `  TLS: auto-generated self-signed cert; clients should trust ${resolved.caPath}`,
+            );
+          }
+          resolve(boundPort);
+        }
+      }
+    );
+  });
 }

--- a/packages/daemon/src/daemon/daemon.ts
+++ b/packages/daemon/src/daemon/daemon.ts
@@ -182,8 +182,10 @@ export async function startDaemon(opts?: DaemonOptions): Promise<DaemonState> {
 
   try {
     if (isWin32) {
-      // Windows local IPC: bind loopback TCP (ephemeral port by default) and write daemon.addr.
-      // Named-pipe gRPC is out of scope; reuse the existing TCP bind path.
+      // Windows local IPC: loopback TCP with ephemeral port (DR-044).
+      // Unlike Unix sockets, TCP does not enforce kernel-level access control;
+      // consumer auth (DR-037) gates sensitive RPCs, and daemon.addr lives
+      // under per-user %TEMP%. Nonce-based hardening tracked as a follow-up.
       const boundPort = await bindTcpGrpc(
         server,
         localTcpHost,

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -107,7 +107,11 @@ program
       if (status.pid) {
         console.log(`  PID: ${status.pid}`);
       }
-      console.log(`  Socket: ${status.socketPath}`);
+      console.log(
+        process.platform === 'win32'
+          ? `  Address: ${status.socketPath}`
+          : `  Socket: ${status.socketPath}`,
+      );
     } else {
       console.log('Abbenay daemon is not running');
       process.exit(1);

--- a/packages/daemon/src/daemon/select-model.test.ts
+++ b/packages/daemon/src/daemon/select-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { DaemonState } from './state.js';
 
 vi.mock('./transport.js', () => ({
   isDaemonRunningSync: vi.fn(() => true),
@@ -15,6 +16,13 @@ vi.mock('./daemon.js', () => ({
 vi.mock('./chat.js', () => ({
   promptModelPicker: vi.fn(),
 }));
+
+/** Minimal DaemonState stand-in for selectModel unit tests. */
+function mockDaemonState(models: unknown[] = []): DaemonState {
+  return {
+    listModels: vi.fn().mockResolvedValue(models),
+  } as unknown as DaemonState;
+}
 
 // ── selectModel ──────────────────────────────────────────────────────
 
@@ -33,7 +41,7 @@ describe('selectModel', () => {
   it('returns null and prints guidance when no models are configured', async () => {
     const { DaemonState } = await import('./state.js');
     vi.mocked(DaemonState).mockImplementation(function () {
-      return { listModels: vi.fn().mockResolvedValue([]) } as any;
+      return mockDaemonState([]);
     });
 
     const { selectModel } = await import('./model-picker.js');
@@ -53,7 +61,7 @@ describe('selectModel', () => {
     ];
     const { DaemonState } = await import('./state.js');
     vi.mocked(DaemonState).mockImplementation(function () {
-      return { listModels: vi.fn().mockResolvedValue(models) } as any;
+      return mockDaemonState(models);
     });
 
     const { promptModelPicker } = await import('./chat.js');
@@ -75,7 +83,7 @@ describe('selectModel', () => {
     ];
     const { DaemonState } = await import('./state.js');
     vi.mocked(DaemonState).mockImplementation(function () {
-      return { listModels: vi.fn().mockResolvedValue(models) } as any;
+      return mockDaemonState(models);
     });
 
     const { promptModelPicker } = await import('./chat.js');
@@ -92,8 +100,7 @@ describe('selectModel', () => {
     vi.mocked(isDaemonRunningSync).mockReturnValue(false);
 
     const { startDaemon } = await import('./daemon.js');
-    const fakeState = { listModels: vi.fn().mockResolvedValue([]) };
-    vi.mocked(startDaemon).mockResolvedValue(fakeState as any);
+    vi.mocked(startDaemon).mockResolvedValue(mockDaemonState([]));
 
     const { selectModel } = await import('./model-picker.js');
     await selectModel();
@@ -107,7 +114,7 @@ describe('selectModel', () => {
 
     const { DaemonState } = await import('./state.js');
     vi.mocked(DaemonState).mockImplementation(function () {
-      return { listModels: vi.fn().mockResolvedValue([]) } as any;
+      return mockDaemonState([]);
     });
 
     const { startDaemon } = await import('./daemon.js');

--- a/packages/daemon/src/daemon/transport.address.test.ts
+++ b/packages/daemon/src/daemon/transport.address.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  parseAddressFileContent,
+  writeAddressFile,
+  readAddressFile,
+  removeAddressFile,
+  getTransport,
+} from './transport.js';
+import { getAddressPath, getRuntimeDir } from '../core/paths.js';
+
+describe('parseAddressFileContent', () => {
+  it('parses host:port', () => {
+    expect(parseAddressFileContent('127.0.0.1:54321\n')).toEqual({
+      host: '127.0.0.1',
+      port: 54321,
+    });
+  });
+
+  it('rejects invalid content', () => {
+    expect(parseAddressFileContent('')).toBeNull();
+    expect(parseAddressFileContent('not-an-address')).toBeNull();
+    expect(parseAddressFileContent('127.0.0.1:')).toBeNull();
+    expect(parseAddressFileContent(':8080')).toBeNull();
+    expect(parseAddressFileContent('127.0.0.1:99999')).toBeNull();
+  });
+});
+
+describe('address file helpers', () => {
+  const originalPlatform = process.platform;
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-addr-test-'));
+    // Force runtime dir under our temp by setting XDG_RUNTIME_DIR (used on all platforms when set)
+    process.env.XDG_RUNTIME_DIR = tmpRoot;
+  });
+
+  afterEach(() => {
+    removeAddressFile();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    delete process.env.XDG_RUNTIME_DIR;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes, reads, and removes daemon.addr', () => {
+    writeAddressFile('127.0.0.1', 41234);
+    expect(fs.existsSync(getAddressPath())).toBe(true);
+    expect(readAddressFile()).toEqual({ host: '127.0.0.1', port: 41234 });
+    removeAddressFile();
+    expect(readAddressFile()).toBeNull();
+  });
+
+  it('getTransport returns tcp on win32 when address file exists', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    writeAddressFile('127.0.0.1', 45555);
+    expect(getTransport()).toEqual({
+      type: 'tcp',
+      host: '127.0.0.1',
+      port: 45555,
+    });
+  });
+
+  it('getTransport returns unix on non-win32', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const transport = getTransport();
+    expect(transport.type).toBe('unix');
+    expect(transport.socketPath).toMatch(/daemon\.sock$/);
+    expect(path.dirname(transport.socketPath!)).toBe(getRuntimeDir());
+  });
+});

--- a/packages/daemon/src/daemon/transport.ts
+++ b/packages/daemon/src/daemon/transport.ts
@@ -1,8 +1,8 @@
 /**
  * Transport layer for daemon communication
- * 
- * Handles Unix socket (Linux/macOS) and named pipe (Windows) transport.
- * All paths come from ./paths.ts for platform-aware consistency.
+ *
+ * Handles Unix socket (Linux/macOS) and loopback TCP + address file (Windows).
+ * All paths come from ../core/paths.ts for platform-aware consistency.
  */
 
 import * as fs from 'node:fs';
@@ -12,6 +12,7 @@ import {
   getRuntimeDir,
   getSocketPath,
   getPidPath,
+  getAddressPath,
 } from '../core/paths.js';
 
 export interface Transport {
@@ -19,6 +20,11 @@ export interface Transport {
   socketPath?: string;
   host?: string;
   port?: number;
+}
+
+export interface DaemonAddress {
+  host: string;
+  port: number;
 }
 
 /**
@@ -36,33 +42,43 @@ export function getPidFilePath(): string {
 }
 
 /**
- * Ensure the socket directory exists
+ * Ensure the socket directory exists (Unix only).
+ * On Windows, local IPC uses TCP + daemon.addr under the runtime dir.
  */
 export function ensureSocketDir(): void {
+  if (process.platform === 'win32') {
+    ensureRuntimeDir();
+    return;
+  }
+
   const socketDir = path.dirname(getSocketPath());
-  
+
   if (!fs.existsSync(socketDir)) {
     fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
   }
 }
 
 /**
- * Ensure the runtime directory exists (for PID, socket, lock)
+ * Ensure the runtime directory exists (for PID, socket/address, lock)
  */
 export function ensureRuntimeDir(): void {
   const runtimeDir = getRuntimeDir();
-  
+
   if (!fs.existsSync(runtimeDir)) {
     fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
   }
 }
 
 /**
- * Clean up stale socket file
+ * Clean up stale Unix socket file (no-op on Windows).
  */
 export function cleanupSocket(): void {
+  if (process.platform === 'win32') {
+    return;
+  }
+
   const socketPath = getSocketPath();
-  
+
   if (fs.existsSync(socketPath)) {
     try {
       fs.unlinkSync(socketPath);
@@ -70,6 +86,76 @@ export function cleanupSocket(): void {
       // Ignore errors - socket might be in use
     }
   }
+}
+
+/**
+ * Parse `host:port` from a daemon.addr file contents.
+ */
+export function parseAddressFileContent(content: string): DaemonAddress | null {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // IPv6 would be [host]:port; we only write IPv4 loopback today.
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon <= 0 || lastColon === trimmed.length - 1) {
+    return null;
+  }
+
+  const host = trimmed.slice(0, lastColon).trim();
+  const port = parseInt(trimmed.slice(lastColon + 1).trim(), 10);
+  if (!host || !Number.isFinite(port) || port <= 0 || port > 65535) {
+    return null;
+  }
+
+  return { host, port };
+}
+
+/**
+ * Write host:port to the address file (Windows loopback TCP IPC).
+ */
+export function writeAddressFile(host: string, port: number): void {
+  ensureRuntimeDir();
+  const addrPath = getAddressPath();
+  fs.writeFileSync(addrPath, `${host}:${port}\n`, { mode: 0o600 });
+}
+
+/**
+ * Read host:port from the address file.
+ */
+export function readAddressFile(): DaemonAddress | null {
+  const addrPath = getAddressPath();
+  if (!fs.existsSync(addrPath)) {
+    return null;
+  }
+  try {
+    return parseAddressFileContent(fs.readFileSync(addrPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove the address file.
+ */
+export function removeAddressFile(): void {
+  const addrPath = getAddressPath();
+  if (fs.existsSync(addrPath)) {
+    try {
+      fs.unlinkSync(addrPath);
+    } catch {
+      // Ignore errors
+    }
+  }
+}
+
+/**
+ * Clean up IPC endpoint artifacts (Unix socket and/or address file).
+ */
+export function cleanupIpcArtifacts(): void {
+  cleanupSocket();
+  removeAddressFile();
 }
 
 /**
@@ -86,11 +172,11 @@ export function writePidFile(): void {
  */
 export function readPidFile(): number | null {
   const pidPath = getPidPath();
-  
+
   if (!fs.existsSync(pidPath)) {
     return null;
   }
-  
+
   try {
     const content = fs.readFileSync(pidPath, 'utf-8').trim();
     return parseInt(content, 10);
@@ -104,7 +190,7 @@ export function readPidFile(): number | null {
  */
 export function removePidFile(): void {
   const pidPath = getPidPath();
-  
+
   if (fs.existsSync(pidPath)) {
     try {
       fs.unlinkSync(pidPath);
@@ -128,37 +214,71 @@ export function isProcessRunning(pid: number): boolean {
 }
 
 /**
- * Check if daemon is running by testing socket connection
+ * Probe whether a TCP host:port accepts connections.
  */
-export function isDaemonRunning(): boolean {
-  const socketPath = getSocketPath();
-  
-  // First check PID file
-  const pid = readPidFile();
-  if (pid && isProcessRunning(pid)) {
-    return true;
-  }
-  
-  // Check if socket exists and is connectable
-  if (!fs.existsSync(socketPath)) {
-    return false;
-  }
-  
-  // Try to connect briefly
-  return new Promise<boolean>((resolve) => {
-    const socket = net.createConnection(socketPath);
-    
+export function probeTcpAddress(host: string, port: number, timeoutMs = 1000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+
     const timeout = setTimeout(() => {
       socket.destroy();
       resolve(false);
-    }, 1000);
-    
+    }, timeoutMs);
+
     socket.on('connect', () => {
       clearTimeout(timeout);
       socket.destroy();
       resolve(true);
     });
-    
+
+    socket.on('error', () => {
+      clearTimeout(timeout);
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Check if daemon is running by testing PID + IPC endpoint.
+ * On Windows this probes TCP using daemon.addr; on Unix it checks the socket path.
+ */
+export function isDaemonRunning(): boolean {
+  const pid = readPidFile();
+  if (pid && isProcessRunning(pid)) {
+    return true;
+  }
+
+  if (process.platform === 'win32') {
+    const addr = readAddressFile();
+    if (!addr) {
+      return false;
+    }
+    // Best-effort async probe cast (matches historical Unix helper shape)
+    return probeTcpAddress(addr.host, addr.port) as unknown as boolean;
+  }
+
+  const socketPath = getSocketPath();
+
+  // Check if socket exists and is connectable
+  if (!fs.existsSync(socketPath)) {
+    return false;
+  }
+
+  // Try to connect briefly
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection(socketPath);
+
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, 1000);
+
+    socket.on('connect', () => {
+      clearTimeout(timeout);
+      socket.destroy();
+      resolve(true);
+    });
+
     socket.on('error', () => {
       clearTimeout(timeout);
       resolve(false);
@@ -168,23 +288,23 @@ export function isDaemonRunning(): boolean {
 
 /**
  * Check daemon status synchronously (best effort)
- * 
+ *
  * Only considers the daemon running if:
  * 1. PID file exists AND the process is alive, OR
- * 2. None of the above — if only a stale socket exists, we treat it as not running
+ * 2. None of the above — if only a stale socket/address exists, we treat it as not running
  */
 export function isDaemonRunningSync(): boolean {
   const pid = readPidFile();
   if (pid && isProcessRunning(pid)) {
     return true;
   }
-  
+
   // If PID file has a stale PID, clean up
   if (pid && !isProcessRunning(pid)) {
     removePidFile();
-    cleanupSocket();
+    cleanupIpcArtifacts();
   }
-  
+
   return false;
 }
 
@@ -193,15 +313,15 @@ export function isDaemonRunningSync(): boolean {
  */
 export function killDaemon(): boolean {
   const pid = readPidFile();
-  
+
   if (!pid) {
     return false;
   }
-  
+
   try {
     // Send SIGTERM first
     process.kill(pid, 'SIGTERM');
-    
+
     // Wait briefly then check if still running
     const startTime = Date.now();
     while (Date.now() - startTime < 3000) {
@@ -210,12 +330,12 @@ export function killDaemon(): boolean {
       }
       // Busy wait (not ideal, but simple)
     }
-    
+
     // Force kill if still running
     if (isProcessRunning(pid)) {
       process.kill(pid, 'SIGKILL');
     }
-    
+
     return true;
   } catch {
     return false;
@@ -223,9 +343,18 @@ export function killDaemon(): boolean {
 }
 
 /**
- * Get transport configuration
+ * Get transport configuration for the current platform.
  */
 export function getTransport(): Transport {
+  if (process.platform === 'win32') {
+    const addr = readAddressFile();
+    return {
+      type: 'tcp',
+      host: addr?.host ?? '127.0.0.1',
+      port: addr?.port,
+    };
+  }
+
   return {
     type: 'unix',
     socketPath: getSocketPath(),

--- a/packages/daemon/src/daemon/transport.ts
+++ b/packages/daemon/src/daemon/transport.ts
@@ -118,6 +118,9 @@ export function parseAddressFileContent(content: string): DaemonAddress | null {
 export function writeAddressFile(host: string, port: number): void {
   ensureRuntimeDir();
   const addrPath = getAddressPath();
+  // mode 0o600 is effective on Unix only; on Windows, NTFS ACLs inherited
+  // from per-user %TEMP% provide user-level isolation (icacls hardening
+  // tracked separately).
   fs.writeFileSync(addrPath, `${host}:${port}\n`, { mode: 0o600 });
 }
 
@@ -249,12 +252,11 @@ export function isDaemonRunning(): boolean {
   }
 
   if (process.platform === 'win32') {
+    // Sync check: PID failed above, fall back to address file existence.
+    // Actual TCP liveness requires async probeTcpAddress(); callers that
+    // need a connection guarantee should use an async variant instead.
     const addr = readAddressFile();
-    if (!addr) {
-      return false;
-    }
-    // Best-effort async probe cast (matches historical Unix helper shape)
-    return probeTcpAddress(addr.host, addr.port) as unknown as boolean;
+    return addr !== null;
   }
 
   const socketPath = getSocketPath();

--- a/packages/vscode/scripts/bundle-daemon.js
+++ b/packages/vscode/scripts/bundle-daemon.js
@@ -66,8 +66,11 @@ function bundleDaemon() {
                 copyDirRecursive(src, dest);
             } else {
                 fs.copyFileSync(src, dest);
-                // Preserve executable permission on binaries
-                if (entry.name.startsWith('abbenay-daemon-') || entry.name.endsWith('.node')) {
+                // Preserve executable permission on binaries (Unix)
+                if (
+                    process.platform !== 'win32' &&
+                    (entry.name.startsWith('abbenay-daemon-') || entry.name.endsWith('.node'))
+                ) {
                     fs.chmodSync(dest, 0o755);
                 }
             }

--- a/packages/vscode/src/daemon/client.ts
+++ b/packages/vscode/src/daemon/client.ts
@@ -1,15 +1,12 @@
 /**
  * Abbenay Daemon Client for VS Code Extension
- * 
+ *
  * This module provides the gRPC client for communicating with the Abbenay daemon.
  * The client is generated from proto/abbenay/v1/service.proto
- * 
- * The daemon uses Unix Domain Sockets for local IPC.
- * Runtime paths (PID file, socket) are computed using the same platform-aware
- * logic as the daemon (see packages/daemon/src/paths.ts):
- *   Linux:   $XDG_RUNTIME_DIR/abbenay  → /run/user/<uid>/abbenay
- *   macOS:   os.tmpdir()/abbenay
- *   Windows: named pipe
+ *
+ * Local IPC:
+ *   Linux/macOS: Unix domain socket at <runtimeDir>/daemon.sock
+ *   Windows:     loopback TCP; host:port from <runtimeDir>/daemon.addr
  */
 
 import { createChannel, createClient, Channel } from 'nice-grpc';
@@ -18,52 +15,35 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import * as net from 'net';
 import { getLogger } from '../utils/logger';
+import {
+  getRuntimeDir,
+  getPidFilePath,
+  getSocketFilePath,
+  getAddressFilePath,
+  parseDaemonAddress,
+  getBundledSeaBinaryName,
+  getUnixDaemonAddress,
+} from './runtime-paths';
 
 // Re-export the generated types for convenience
 export * from '../proto/abbenay/v1/service';
+export {
+  getBundledSeaBinaryName,
+  parseDaemonAddress,
+  getAddressFilePath,
+} from './runtime-paths';
 
-const APP_NAME = 'abbenay';
-
-// ── Platform-aware path helpers (mirrors daemon's paths.ts) ─────────
-
-/**
- * Get the platform runtime directory (for ephemeral files: PID, socket, lock).
- */
-function getRuntimeDir(): string {
-    // 1. Respect XDG_RUNTIME_DIR (standard on Linux)
-    if (process.env.XDG_RUNTIME_DIR) {
-        return path.join(process.env.XDG_RUNTIME_DIR, APP_NAME);
-    }
-
-    // 2. macOS — os.tmpdir() returns DARWIN_USER_TEMP_DIR automatically
-    if (process.platform === 'darwin') {
-        return path.join(os.tmpdir(), APP_NAME);
-    }
-
-    // 3. Linux without XDG_RUNTIME_DIR — try /run/user/<uid>
-    if (process.platform !== 'win32') {
-        try {
-            const uid = os.userInfo().uid;
-            return path.join(`/run/user/${uid}`, APP_NAME);
-        } catch {
-            // os.userInfo() can fail in some sandboxes
-        }
-    }
-
-    // 4. Fallback
-    return path.join('/tmp', APP_NAME);
-}
-
-// Daemon paths — PID + socket in runtime dir (matches daemon's paths.ts)
+// Daemon paths — PID + socket/address in runtime dir (matches daemon's paths.ts)
 const RUNTIME_DIR = getRuntimeDir();
-const PID_FILE = path.join(RUNTIME_DIR, `${APP_NAME}.pid`);
-const SOCKET_FILE = process.platform === 'win32'
-    ? '\\\\.\\pipe\\abbenay-daemon'
-    : path.join(RUNTIME_DIR, 'daemon.sock');
+const PID_FILE = getPidFilePath(RUNTIME_DIR);
+const SOCKET_FILE = getSocketFilePath(RUNTIME_DIR);
+const ADDRESS_FILE = getAddressFilePath(RUNTIME_DIR);
+const IS_WIN32 = process.platform === 'win32';
 
-// gRPC address for Unix Domain Socket
-const DEFAULT_DAEMON_ADDRESS = `unix://${SOCKET_FILE}`;
+// gRPC address for Unix Domain Socket (Windows resolves from daemon.addr at connect time)
+const DEFAULT_DAEMON_ADDRESS = IS_WIN32 ? '' : getUnixDaemonAddress(SOCKET_FILE);
 
 // Extension path for finding bundled binaries (set during activation)
 let extensionPath: string | undefined;
@@ -72,556 +52,641 @@ let extensionPath: string | undefined;
  * Set the extension path for finding bundled binaries.
  * Must be called during extension activation before connecting to daemon.
  */
-export function setExtensionPath(path: string): void {
-    extensionPath = path;
+export function setExtensionPath(extPath: string): void {
+  extensionPath = extPath;
 }
 
 /**
- * Check if the daemon is running by verifying PID file and process
+ * Read Windows loopback TCP address from daemon.addr.
+ */
+function readDaemonTcpAddress(): { host: string; port: number } | null {
+  try {
+    if (!fs.existsSync(ADDRESS_FILE)) {
+      return null;
+    }
+    return parseDaemonAddress(fs.readFileSync(ADDRESS_FILE, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the gRPC channel address for the current platform.
+ */
+export function resolveDaemonChannelAddress(): string | null {
+  if (!IS_WIN32) {
+    return DEFAULT_DAEMON_ADDRESS;
+  }
+  const addr = readDaemonTcpAddress();
+  return addr ? `${addr.host}:${addr.port}` : null;
+}
+
+/**
+ * Probe TCP connectivity to host:port.
+ */
+function probeTcp(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+
+    socket.on('connect', () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Check if the daemon is running by verifying PID file and IPC endpoint.
+ * On Windows this is async-friendly via waitForDaemon (TCP probe); the sync
+ * check requires PID + address file.
  */
 export function isDaemonRunning(): boolean {
-    try {
-        if (!fs.existsSync(PID_FILE)) {
-            return false;
-        }
-        
-        const pidStr = fs.readFileSync(PID_FILE, 'utf-8').trim();
-        const pid = parseInt(pidStr, 10);
-        
-        if (isNaN(pid)) {
-            return false;
-        }
-        
-        // Check if process is running (signal 0 just checks existence)
-        process.kill(pid, 0);
-        
-        // Also verify socket exists
-        return fs.existsSync(SOCKET_FILE);
-    } catch (_e) {
-        // process.kill throws if process doesn't exist
-        return false;
+  try {
+    if (!fs.existsSync(PID_FILE)) {
+      return false;
     }
+
+    const pidStr = fs.readFileSync(PID_FILE, 'utf-8').trim();
+    const pid = parseInt(pidStr, 10);
+
+    if (isNaN(pid)) {
+      return false;
+    }
+
+    // Check if process is running (signal 0 just checks existence)
+    process.kill(pid, 0);
+
+    if (IS_WIN32) {
+      return fs.existsSync(ADDRESS_FILE) && readDaemonTcpAddress() !== null;
+    }
+
+    // Also verify socket exists
+    return fs.existsSync(SOCKET_FILE);
+  } catch (_e) {
+    // process.kill throws if process doesn't exist
+    return false;
+  }
+}
+
+/**
+ * Async liveness: PID + TCP connect on Windows, PID + socket on Unix.
+ */
+export async function isDaemonReady(): Promise<boolean> {
+  if (!isDaemonRunning()) {
+    return false;
+  }
+  if (!IS_WIN32) {
+    return true;
+  }
+  const addr = readDaemonTcpAddress();
+  if (!addr) {
+    return false;
+  }
+  return probeTcp(addr.host, addr.port);
 }
 
 /**
  * Wrapper around the generated Abbenay gRPC client
  */
 export class DaemonClient {
-    private channel: Channel | null = null;
-    private client: proto.AbbenayClient | null = null;
-    private clientId: string | null = null;
-    private address: string;
+  private channel: Channel | null = null;
+  private client: proto.AbbenayClient | null = null;
+  private clientId: string | null = null;
+  private address: string;
 
-    constructor(address: string = DEFAULT_DAEMON_ADDRESS) {
-        this.address = address;
+  constructor(address: string = DEFAULT_DAEMON_ADDRESS) {
+    this.address = address;
+  }
+
+  /**
+   * Connect to the daemon.
+   * By default, will auto-start the daemon if it's not running.
+   *
+   * @param options.autoStart - Start daemon if not running (default: true)
+   * @param options.timeout - Timeout waiting for daemon to start (default: 15000ms)
+   */
+  async connect(options: { autoStart?: boolean; timeout?: number } = {}): Promise<void> {
+    if (this.channel) {
+      return; // Already connected
     }
 
-    /**
-     * Connect to the daemon.
-     * By default, will auto-start the daemon if it's not running.
-     * 
-     * @param options.autoStart - Start daemon if not running (default: true)
-     * @param options.timeout - Timeout waiting for daemon to start (default: 15000ms)
-     */
-    async connect(options: { autoStart?: boolean; timeout?: number } = {}): Promise<void> {
-        if (this.channel) {
-            return; // Already connected
-        }
+    const logger = getLogger();
+    const { autoStart = true, timeout = 15000 } = options;
 
-        const logger = getLogger();
-        const { autoStart = true, timeout = 15000 } = options;
+    // Check if daemon is running
+    const running = await isDaemonReady();
+    logger.info(
+      `[Daemon] isDaemonReady=${running}, PID_FILE=${PID_FILE}, ` +
+      `SOCKET=${SOCKET_FILE}, ADDRESS_FILE=${ADDRESS_FILE}`,
+    );
 
-        // Check if daemon is running
-        const running = isDaemonRunning();
-        logger.info(`[Daemon] isDaemonRunning=${running}, PID_FILE=${PID_FILE}, SOCKET=${SOCKET_FILE}`);
-        logger.info(`[Daemon] PID file exists: ${fs.existsSync(PID_FILE)}, Socket exists: ${fs.existsSync(SOCKET_FILE)}`);
-        
-        if (!running) {
-            if (autoStart) {
-                logger.info('[Daemon] Daemon not running, attempting to start...');
-                await this.startDaemon();
-                // Wait for daemon to be ready
-                await this.waitForDaemon(timeout);
-                logger.info('[Daemon] Daemon started and ready');
-            } else {
-                throw new Error(
-                    `Abbenay daemon is not running. ` +
-                    `Expected socket at ${SOCKET_FILE}. ` +
-                    `Start the daemon with: abbenay daemon`
-                );
-            }
-        }
-
-        logger.info(`[Daemon] Creating gRPC channel to ${this.address}`);
-        this.channel = createChannel(this.address);
-        this.client = createClient(proto.AbbenayDefinition, this.channel);
-    }
-
-    /**
-     * Start the daemon process.
-     * 
-     * The daemon is a TypeScript/Node.js application.
-     * Priority: 1) `abbenay` in PATH (global install or SEA binary)
-     *           2) Workspace monorepo packages/daemon/dist/index.js
-     *           3) Bundled daemon JS in extension's bin/ directory
-     * 
-     * Note: For browser-based VS Code (vscode.dev, Codespaces), the daemon must
-     * already be running as a remote service. Process spawning only works on desktop.
-     */
-    private async startDaemon(): Promise<void> {
-        const { spawn } = await import('child_process');
-        const logger = getLogger();
-        
-        // Ensure runtime directory exists (PID + socket live here)
-        if (!fs.existsSync(RUNTIME_DIR)) {
-            fs.mkdirSync(RUNTIME_DIR, { recursive: true, mode: 0o700 });
-        }
-
-        const { cmd, args } = await this.findDaemonCommand();
-        
-        logger.info(`[Daemon] Spawning: ${cmd} ${[...args, 'daemon'].join(' ')}`);
-        
-        // Log daemon stdout/stderr to a file so we can debug
-        const logPath = path.join(os.tmpdir(), 'abbenay-daemon.log');
-        const logFd = fs.openSync(logPath, 'a');
-        logger.info(`[Daemon] Logging to: ${logPath}`);
-
-        const daemon = spawn(cmd, [...args, 'daemon'], {
-            detached: true,
-            stdio: ['ignore', logFd, logFd],
-            env: {
-                ...process.env,
-                ABBENAY_SOCKET: SOCKET_FILE,
-                ABBENAY_PID_FILE: PID_FILE,
-            },
-        });
-        
-        logger.info(`[Daemon] Spawned PID: ${daemon.pid}`);
-        daemon.unref();
-    }
-    
-    /**
-     * Find the daemon command and arguments.
-     * Returns { cmd, args } where the daemon subcommand should be appended.
-     * 
-     * The daemon is always a self-contained SEA (Single Executable Application)
-     * binary — no Node.js dependency needed at runtime.
-     * 
-     * Priority:
-     *   1) `abbenay` in PATH (global install or SEA binary)
-     *   2) Bundled SEA binary in extension's bin/
-     */
-    private async findDaemonCommand(): Promise<{ cmd: string; args: string[] }> {
-        const { execSync } = await import('child_process');
-        const logger = getLogger();
-        
-        // 1) Try to find abbenay in PATH (global npm install, npm link, or SEA binary)
-        try {
-            const cmd = process.platform === 'win32' ? 'where abbenay' : 'which abbenay';
-            const result = execSync(cmd, { encoding: 'utf-8' }).trim().split('\n')[0];
-            if (result && fs.existsSync(result)) {
-                logger.info(`[Daemon] Found abbenay in PATH: ${result}`);
-                return { cmd: result, args: [] };
-            }
-        } catch {
-            logger.info('[Daemon] abbenay not found in PATH');
-        }
-
-        // 2) Bundled SEA binary — self-contained, no node dependency
-        if (extensionPath) {
-            const platform = process.platform === 'win32' ? 'win32' 
-                : process.platform === 'darwin' ? 'darwin' : 'linux';
-            const arch = process.arch;
-            const seaBinary = path.join(extensionPath, 'bin', `abbenay-daemon-${platform}-${arch}`);
-            if (fs.existsSync(seaBinary)) {
-                logger.info(`[Daemon] Found SEA binary: ${seaBinary}`);
-                return { cmd: seaBinary, args: [] };
-            }
-            logger.error(`[Daemon] SEA binary not found at ${seaBinary}`);
-        }
-
+    if (!running) {
+      if (autoStart) {
+        logger.info('[Daemon] Daemon not running, attempting to start...');
+        await this.startDaemon();
+        // Wait for daemon to be ready
+        await this.waitForDaemon(timeout);
+        logger.info('[Daemon] Daemon started and ready');
+      } else {
+        const endpoint = IS_WIN32 ? ADDRESS_FILE : SOCKET_FILE;
         throw new Error(
-            `Abbenay daemon binary not found. ` +
-            `The extension package may be corrupt — try reinstalling.`
+          `Abbenay daemon is not running. ` +
+          `Expected endpoint via ${endpoint}. ` +
+          `Start the daemon with: abbenay daemon`,
         );
+      }
     }
 
-    /**
-     * Wait for daemon to be ready
-     */
-    private async waitForDaemon(timeout: number): Promise<void> {
-        const start = Date.now();
-        const pollInterval = 100;
+    const address = this.address || resolveDaemonChannelAddress();
+    if (!address) {
+      throw new Error(
+        `Abbenay daemon address not found. Expected ${ADDRESS_FILE} with host:port.`,
+      );
+    }
+    this.address = address;
 
-        while (Date.now() - start < timeout) {
-            if (isDaemonRunning()) {
-                // Give it a moment to accept connections
-                await new Promise(r => setTimeout(r, 100));
-                return;
-            }
-            await new Promise(r => setTimeout(r, pollInterval));
-        }
+    logger.info(`[Daemon] Creating gRPC channel to ${this.address}`);
+    this.channel = createChannel(this.address);
+    this.client = createClient(proto.AbbenayDefinition, this.channel);
+  }
 
-        throw new Error(`Daemon did not start within ${timeout}ms`);
+  /**
+   * Start the daemon process.
+   *
+   * The daemon is a TypeScript/Node.js application.
+   * Priority: 1) `abbenay` in PATH (global install or SEA binary)
+   *           2) Workspace monorepo packages/daemon/dist/index.js
+   *           3) Bundled daemon JS in extension's bin/ directory
+   *
+   * Note: For browser-based VS Code (vscode.dev, Codespaces), the daemon must
+   * already be running as a remote service. Process spawning only works on desktop.
+   */
+  private async startDaemon(): Promise<void> {
+    const { spawn } = await import('child_process');
+    const logger = getLogger();
+
+    // Ensure runtime directory exists (PID + socket/address live here)
+    if (!fs.existsSync(RUNTIME_DIR)) {
+      fs.mkdirSync(RUNTIME_DIR, { recursive: true, mode: 0o700 });
     }
 
-    /**
-     * Check if connected
-     */
-    isConnected(): boolean {
-        return this.channel !== null && this.client !== null;
+    const { cmd, args } = await this.findDaemonCommand();
+
+    logger.info(`[Daemon] Spawning: ${cmd} ${[...args, 'daemon'].join(' ')}`);
+
+    // Log daemon stdout/stderr to a file so we can debug
+    const logPath = path.join(os.tmpdir(), 'abbenay-daemon.log');
+    const logFd = fs.openSync(logPath, 'a');
+    logger.info(`[Daemon] Logging to: ${logPath}`);
+
+    const daemon = spawn(cmd, [...args, 'daemon'], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: {
+        ...process.env,
+        ABBENAY_SOCKET: SOCKET_FILE,
+        ABBENAY_PID_FILE: PID_FILE,
+      },
+      // On Windows, hide console window for the detached daemon process
+      windowsHide: true,
+    });
+
+    logger.info(`[Daemon] Spawned PID: ${daemon.pid}`);
+    daemon.unref();
+  }
+
+  /**
+   * Find the daemon command and arguments.
+   * Returns { cmd, args } where the daemon subcommand should be appended.
+   *
+   * The daemon is always a self-contained SEA (Single Executable Application)
+   * binary — no Node.js dependency needed at runtime.
+   *
+   * Priority:
+   *   1) `abbenay` in PATH (global install or SEA binary)
+   *   2) Bundled SEA binary in extension's bin/
+   */
+  private async findDaemonCommand(): Promise<{ cmd: string; args: string[] }> {
+    const { execSync } = await import('child_process');
+    const logger = getLogger();
+
+    // 1) Try to find abbenay in PATH (global npm install, npm link, or SEA binary)
+    try {
+      const cmd = process.platform === 'win32' ? 'where abbenay' : 'which abbenay';
+      const result = execSync(cmd, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
+      if (result && fs.existsSync(result)) {
+        logger.info(`[Daemon] Found abbenay in PATH: ${result}`);
+        return { cmd: result, args: [] };
+      }
+    } catch {
+      logger.info('[Daemon] abbenay not found in PATH');
     }
 
-    /**
-     * Get the raw client for advanced usage
-     */
-    getClient(): proto.AbbenayClient {
-        if (!this.client) {
-            throw new Error('Not connected to daemon. Call connect() first.');
-        }
-        return this.client;
+    // 2) Bundled SEA binary — self-contained, no node dependency
+    if (extensionPath) {
+      const seaBinary = path.join(
+        extensionPath,
+        'bin',
+        getBundledSeaBinaryName(process.platform, process.arch),
+      );
+      if (fs.existsSync(seaBinary)) {
+        logger.info(`[Daemon] Found SEA binary: ${seaBinary}`);
+        return { cmd: seaBinary, args: [] };
+      }
+      logger.error(`[Daemon] SEA binary not found at ${seaBinary}`);
     }
 
-    /**
-     * Register this VS Code extension as a client
-     */
-    async register(): Promise<string> {
-        const client = this.getClient();
-        
-        // Get workspace path from VS Code
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        const workspacePath = workspaceFolders && workspaceFolders.length > 0 
-            ? workspaceFolders[0].uri.fsPath 
-            : '';
-        
-        const logger = getLogger();
-        logger.info('[Daemon] Registering with daemon...');
-        logger.info(`[Daemon] Workspace folders: ${JSON.stringify(workspaceFolders?.map(f => f.uri.fsPath))}`);
-        logger.info(`[Daemon] Workspace path to send: "${workspacePath}"`);
-        
-        const response = await client.register({
-            client: {
-                clientType: proto.ClientType.CLIENT_TYPE_VSCODE,
-                user: process.env.USER || 'unknown',
-            },
-            isSpawner: false,
-            workspacePath: workspacePath,
-        });
-        logger.info(`[Daemon] Registered with client ID: ${response.clientId}`);
-        this.clientId = response.clientId;
-        return this.clientId;
+    throw new Error(
+      `Abbenay daemon binary not found. ` +
+      `The extension package may be corrupt — try reinstalling.`,
+    );
+  }
+
+  /**
+   * Wait for daemon to be ready
+   */
+  private async waitForDaemon(timeout: number): Promise<void> {
+    const start = Date.now();
+    const pollInterval = 100;
+
+    while (Date.now() - start < timeout) {
+      if (await isDaemonReady()) {
+        // Give it a moment to accept connections
+        await new Promise(r => setTimeout(r, 100));
+        return;
+      }
+      await new Promise(r => setTimeout(r, pollInterval));
     }
 
-    /**
-     * Unregister this client
-     */
-    async unregister(): Promise<void> {
-        if (this.clientId && this.client) {
-            try {
-                await this.client.unregister({ clientId: this.clientId });
-            } catch (_e) {
-                // Ignore errors during unregister
-            }
-            this.clientId = null;
-        }
-    }
+    throw new Error(`Daemon did not start within ${timeout}ms`);
+  }
 
-    /**
-     * Close the connection
-     */
-    async close(): Promise<void> {
-        await this.unregister();
-        if (this.channel) {
-            this.channel.close();
-            this.channel = null;
-            this.client = null;
-        }
-    }
+  /**
+   * Check if connected
+   */
+  isConnected(): boolean {
+    return this.channel !== null && this.client !== null;
+  }
 
-    /**
-     * Health check
-     */
-    async healthCheck(): Promise<boolean> {
-        try {
-            const client = this.getClient();
-            const response = await client.healthCheck({});
-            return response.healthy;
-        } catch (_e) {
-            return false;
-        }
+  /**
+   * Get the raw client for advanced usage
+   */
+  getClient(): proto.AbbenayClient {
+    if (!this.client) {
+      throw new Error('Not connected to daemon. Call connect() first.');
     }
+    return this.client;
+  }
 
-    /**
-     * Get daemon status
-     */
-    async getStatus(): Promise<proto.DaemonStatus> {
-        const client = this.getClient();
-        return client.getStatus({});
-    }
+  /**
+   * Register this VS Code extension as a client
+   */
+  async register(): Promise<string> {
+    const client = this.getClient();
 
-    /**
-     * List available models (workspace-aware)
-     */
-    async listModels(): Promise<proto.Model[]> {
-        const client = this.getClient();
-        const folders = vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) || [];
-        const response = await client.listModels({ workspacePaths: folders });
-        return response.models;
-    }
+    // Get workspace path from VS Code
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    const workspacePath = workspaceFolders && workspaceFolders.length > 0
+      ? workspaceFolders[0].uri.fsPath
+      : '';
 
-    /**
-     * List available engines (fixed set of API implementations)
-     */
-    async listEngines(): Promise<proto.Engine[]> {
-        const client = this.getClient();
-        const response = await client.listEngines({});
-        return response.engines;
-    }
+    const logger = getLogger();
+    logger.info('[Daemon] Registering with daemon...');
+    logger.info(`[Daemon] Workspace folders: ${JSON.stringify(workspaceFolders?.map(f => f.uri.fsPath))}`);
+    logger.info(`[Daemon] Workspace path to send: "${workspacePath}"`);
 
-    /**
-     * List available providers
-     */
-    async listProviders(): Promise<proto.Provider[]> {
-        const client = this.getClient();
-        const response = await client.listProviders({});
-        return response.providers;
-    }
+    const response = await client.register({
+      client: {
+        clientType: proto.ClientType.CLIENT_TYPE_VSCODE,
+        user: process.env.USER || process.env.USERNAME || 'unknown',
+      },
+      isSpawner: false,
+      workspacePath: workspacePath,
+    });
+    logger.info(`[Daemon] Registered with client ID: ${response.clientId}`);
+    this.clientId = response.clientId;
+    return this.clientId;
+  }
 
-    /**
-     * Stateless chat - returns an async iterator of chunks
-     */
-    chat(request: proto.DeepPartial<proto.ChatRequest>): AsyncIterable<proto.ChatChunk> {
-        const client = this.getClient();
-        return client.chat(request);
+  /**
+   * Unregister this client
+   */
+  async unregister(): Promise<void> {
+    if (this.clientId && this.client) {
+      try {
+        await this.client.unregister({ clientId: this.clientId });
+      } catch (_e) {
+        // Ignore errors during unregister
+      }
+      this.clientId = null;
     }
+  }
 
-    /**
-     * Session-based chat
-     */
-    sessionChat(request: proto.DeepPartial<proto.SessionChatRequest>): AsyncIterable<proto.ChatChunk> {
-        const client = this.getClient();
-        return client.sessionChat(request);
+  /**
+   * Close the connection
+   */
+  async close(): Promise<void> {
+    await this.unregister();
+    if (this.channel) {
+      this.channel.close();
+      this.channel = null;
+      this.client = null;
     }
+  }
 
-    /**
-     * Create a new session
-     */
-    async createSession(model: string, topic?: string, metadata?: Record<string, string>): Promise<proto.Session> {
-        const client = this.getClient();
-        return client.createSession({ model, topic, metadata: metadata || {} });
+  /**
+   * Health check
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const client = this.getClient();
+      const response = await client.healthCheck({});
+      return response.healthy;
+    } catch (_e) {
+      return false;
     }
+  }
 
-    /**
-     * Get a session by ID
-     */
-    async getSession(sessionId: string, includeMessages: boolean = true): Promise<proto.Session> {
-        const client = this.getClient();
-        return client.getSession({ sessionId, includeMessages });
-    }
+  /**
+   * Get daemon status
+   */
+  async getStatus(): Promise<proto.DaemonStatus> {
+    const client = this.getClient();
+    return client.getStatus({});
+  }
 
-    /**
-     * List all sessions
-     */
-    async listSessions(): Promise<proto.SessionSummary[]> {
-        const client = this.getClient();
-        const response = await client.listSessions({});
-        return response.sessions;
-    }
+  /**
+   * List available models (workspace-aware)
+   */
+  async listModels(): Promise<proto.Model[]> {
+    const client = this.getClient();
+    const folders = vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) || [];
+    const response = await client.listModels({ workspacePaths: folders });
+    return response.models;
+  }
 
-    /**
-     * Delete a session
-     */
-    async deleteSession(sessionId: string): Promise<void> {
-        const client = this.getClient();
-        await client.deleteSession({ sessionId });
-    }
+  /**
+   * List available engines (fixed set of API implementations)
+   */
+  async listEngines(): Promise<proto.Engine[]> {
+    const client = this.getClient();
+    const response = await client.listEngines({});
+    return response.engines;
+  }
 
-    /**
-     * List available tools
-     */
-    async listTools(): Promise<proto.Tool[]> {
-        const client = this.getClient();
-        const response = await client.listTools({});
-        return response.tools;
-    }
+  /**
+   * List available providers
+   */
+  async listProviders(): Promise<proto.Provider[]> {
+    const client = this.getClient();
+    const response = await client.listProviders({});
+    return response.providers;
+  }
 
-    /**
-     * Execute a tool
-     */
-    async executeTool(toolName: string, args: Record<string, unknown>): Promise<proto.ExecuteToolResponse> {
-        const client = this.getClient();
-        return client.executeTool({
-            name: toolName,
-            arguments: JSON.stringify(args),
-        });
-    }
+  /**
+   * Stateless chat - returns an async iterator of chunks
+   */
+  chat(request: proto.DeepPartial<proto.ChatRequest>): AsyncIterable<proto.ChatChunk> {
+    const client = this.getClient();
+    return client.chat(request);
+  }
 
-    /**
-     * Set a secret in the daemon's keychain store
-     */
-    async setSecret(key: string, value: string): Promise<void> {
-        const client = this.getClient();
-        await client.setSecret({ key, value });
-    }
+  /**
+   * Session-based chat
+   */
+  sessionChat(request: proto.DeepPartial<proto.SessionChatRequest>): AsyncIterable<proto.ChatChunk> {
+    const client = this.getClient();
+    return client.sessionChat(request);
+  }
 
-    /**
-     * Delete a secret
-     */
-    async deleteSecret(key: string): Promise<void> {
-        const client = this.getClient();
-        await client.deleteSecret({ key });
-    }
+  /**
+   * Create a new session
+   */
+  async createSession(model: string, topic?: string, metadata?: Record<string, string>): Promise<proto.Session> {
+    const client = this.getClient();
+    return client.createSession({ model, topic, metadata: metadata || {} });
+  }
 
-    /**
-     * List secrets (returns SecretInfo with key, store, hasValue)
-     */
-    async listSecrets(): Promise<proto.SecretInfo[]> {
-        const client = this.getClient();
-        const response = await client.listSecrets({});
-        return response.secrets;
-    }
+  /**
+   * Get a session by ID
+   */
+  async getSession(sessionId: string, includeMessages: boolean = true): Promise<proto.Session> {
+    const client = this.getClient();
+    return client.getSession({ sessionId, includeMessages });
+  }
 
-    /**
-     * Get configuration (user or workspace level)
-     */
-    async getConfig(location?: string): Promise<proto.GetConfigResponse> {
-        const client = this.getClient();
-        return client.getConfig({ location });
-    }
+  /**
+   * List all sessions
+   */
+  async listSessions(): Promise<proto.SessionSummary[]> {
+    const client = this.getClient();
+    const response = await client.listSessions({});
+    return response.sessions;
+  }
 
-    /**
-     * Update configuration (user or workspace level)
-     */
-    async updateConfig(config: proto.Config, location?: string): Promise<proto.GetConfigResponse> {
-        const client = this.getClient();
-        return client.updateConfig({ config, location });
-    }
+  /**
+   * Delete a session
+   */
+  async deleteSession(sessionId: string): Promise<void> {
+    const client = this.getClient();
+    await client.deleteSession({ sessionId });
+  }
 
-    /**
-     * Configure a provider (add or update, with optional API key storage)
-     */
-    async configureProvider(params: {
-        providerId: string;
-        engine?: string;
-        apiKey?: string;
-        envVarName?: string;
-        baseUrl?: string;
-        target?: string;
-        workspacePath?: string;
-    }): Promise<proto.ConfigureProviderResponse> {
-        const client = this.getClient();
-        return client.configureProvider({
-            providerId: params.providerId,
-            engine: params.engine,
-            apiKey: params.apiKey,
-            envVarName: params.envVarName,
-            baseUrl: params.baseUrl,
-            target: params.target,
-            workspacePath: params.workspacePath,
-        });
-    }
+  /**
+   * List available tools
+   */
+  async listTools(): Promise<proto.Tool[]> {
+    const client = this.getClient();
+    const response = await client.listTools({});
+    return response.tools;
+  }
 
-    /**
-     * Remove a provider configuration
-     */
-    async removeProvider(providerId: string, target?: string, workspacePath?: string): Promise<void> {
-        const client = this.getClient();
-        await client.removeProvider({ providerId, target, workspacePath });
-    }
+  /**
+   * Execute a tool
+   */
+  async executeTool(toolName: string, args: Record<string, unknown>): Promise<proto.ExecuteToolResponse> {
+    const client = this.getClient();
+    return client.executeTool({
+      name: toolName,
+      arguments: JSON.stringify(args),
+    });
+  }
 
-    /**
-     * Get predefined provider templates for the add-provider wizard
-     */
-    async getProviderTemplates(): Promise<proto.ProviderTemplate[]> {
-        const client = this.getClient();
-        const response = await client.getProviderTemplates({});
-        return response.templates;
-    }
+  /**
+   * Set a secret in the daemon's keychain store
+   */
+  async setSecret(key: string, value: string): Promise<void> {
+    const client = this.getClient();
+    await client.setSecret({ key, value });
+  }
 
-    /**
-     * Discover models with optional credential resolution from provider config
-     */
-    async discoverModels(engineId: string, options?: { apiKey?: string; baseUrl?: string; providerId?: string }): Promise<proto.Model[]> {
-        const client = this.getClient();
-        const response = await client.discoverModels({
-            engineId,
-            apiKey: options?.apiKey,
-            baseUrl: options?.baseUrl,
-            providerId: options?.providerId,
-        });
-        return response.models;
-    }
+  /**
+   * Delete a secret
+   */
+  async deleteSecret(key: string): Promise<void> {
+    const client = this.getClient();
+    await client.deleteSecret({ key });
+  }
 
-    /**
-     * Check if a specific key is available (keychain or env)
-     */
-    async getKeyStatus(source: string, name: string): Promise<boolean> {
-        const client = this.getClient();
-        const response = await client.getKeyStatus({ source, name });
-        return response.exists;
-    }
+  /**
+   * List secrets (returns SecretInfo with key, store, hasValue)
+   */
+  async listSecrets(): Promise<proto.SecretInfo[]> {
+    const client = this.getClient();
+    const response = await client.listSecrets({});
+    return response.secrets;
+  }
 
-    /**
-     * List configured MCP servers with connection status
-     */
-    async listMcpServerConfigs(): Promise<proto.McpServerStatusEntry[]> {
-        const client = this.getClient();
-        const response = await client.listMcpServerConfigs({});
-        return response.mcpServers;
-    }
+  /**
+   * Get configuration (user or workspace level)
+   */
+  async getConfig(location?: string): Promise<proto.GetConfigResponse> {
+    const client = this.getClient();
+    return client.getConfig({ location });
+  }
 
-    /**
-     * Reconnect a failed MCP server
-     */
-    async reconnectMcpServer(serverId: string): Promise<void> {
-        const client = this.getClient();
-        await client.reconnectMcpServer({ serverId });
-    }
+  /**
+   * Update configuration (user or workspace level)
+   */
+  async updateConfig(config: proto.Config, location?: string): Promise<proto.GetConfigResponse> {
+    const client = this.getClient();
+    return client.updateConfig({ config, location });
+  }
 
-    /**
-     * Create or update a custom policy
-     */
-    async createPolicy(name: string, config: proto.PolicyConfig): Promise<void> {
-        const client = this.getClient();
-        await client.createPolicy({ name, config });
-    }
+  /**
+   * Configure a provider (add or update, with optional API key storage)
+   */
+  async configureProvider(params: {
+    providerId: string;
+    engine?: string;
+    apiKey?: string;
+    envVarName?: string;
+    baseUrl?: string;
+    target?: string;
+    workspacePath?: string;
+  }): Promise<proto.ConfigureProviderResponse> {
+    const client = this.getClient();
+    return client.configureProvider({
+      providerId: params.providerId,
+      engine: params.engine,
+      apiKey: params.apiKey,
+      envVarName: params.envVarName,
+      baseUrl: params.baseUrl,
+      target: params.target,
+      workspacePath: params.workspacePath,
+    });
+  }
 
-    /**
-     * Delete a custom policy
-     */
-    async deletePolicy(name: string): Promise<void> {
-        const client = this.getClient();
-        await client.deletePolicy({ name });
-    }
+  /**
+   * Remove a provider configuration
+   */
+  async removeProvider(providerId: string, target?: string, workspacePath?: string): Promise<void> {
+    const client = this.getClient();
+    await client.removeProvider({ providerId, target, workspacePath });
+  }
 
-    /**
-     * Start the embedded web server (dashboard) via gRPC.
-     * Returns the URL to open in the browser.
-     */
-    async startWebServer(port: number = 8787): Promise<proto.StartWebServerResponse> {
-        const client = this.getClient();
-        return client.startWebServer({ port });
-    }
+  /**
+   * Get predefined provider templates for the add-provider wizard
+   */
+  async getProviderTemplates(): Promise<proto.ProviderTemplate[]> {
+    const client = this.getClient();
+    const response = await client.getProviderTemplates({});
+    return response.templates;
+  }
 
-    /**
-     * Stop the embedded web server via gRPC.
-     */
-    async stopWebServer(): Promise<void> {
-        const client = this.getClient();
-        await client.stopWebServer({});
-    }
+  /**
+   * Discover models with optional credential resolution from provider config
+   */
+  async discoverModels(engineId: string, options?: { apiKey?: string; baseUrl?: string; providerId?: string }): Promise<proto.Model[]> {
+    const client = this.getClient();
+    const response = await client.discoverModels({
+      engineId,
+      apiKey: options?.apiKey,
+      baseUrl: options?.baseUrl,
+      providerId: options?.providerId,
+    });
+    return response.models;
+  }
 
-    /**
-     * Register MCP server (VS Code extension registers itself)
-     */
-    async registerMcpServer(serverId: string, transport: proto.McpTransport, toolFilter?: string[]): Promise<proto.RegisterMcpServerResponse> {
-        const client = this.getClient();
-        return client.registerMcpServer({
-            serverId,
-            transport,
-            toolFilter,
-        });
-    }
+  /**
+   * Check if a specific key is available (keychain or env)
+   */
+  async getKeyStatus(source: string, name: string): Promise<boolean> {
+    const client = this.getClient();
+    const response = await client.getKeyStatus({ source, name });
+    return response.exists;
+  }
+
+  /**
+   * List configured MCP servers with connection status
+   */
+  async listMcpServerConfigs(): Promise<proto.McpServerStatusEntry[]> {
+    const client = this.getClient();
+    const response = await client.listMcpServerConfigs({});
+    return response.mcpServers;
+  }
+
+  /**
+   * Reconnect a failed MCP server
+   */
+  async reconnectMcpServer(serverId: string): Promise<void> {
+    const client = this.getClient();
+    await client.reconnectMcpServer({ serverId });
+  }
+
+  /**
+   * Create or update a custom policy
+   */
+  async createPolicy(name: string, config: proto.PolicyConfig): Promise<void> {
+    const client = this.getClient();
+    await client.createPolicy({ name, config });
+  }
+
+  /**
+   * Delete a custom policy
+   */
+  async deletePolicy(name: string): Promise<void> {
+    const client = this.getClient();
+    await client.deletePolicy({ name });
+  }
+
+  /**
+   * Start the embedded web server (dashboard) via gRPC.
+   * Returns the URL to open in the browser.
+   */
+  async startWebServer(port: number = 8787): Promise<proto.StartWebServerResponse> {
+    const client = this.getClient();
+    return client.startWebServer({ port });
+  }
+
+  /**
+   * Stop the embedded web server via gRPC.
+   */
+  async stopWebServer(): Promise<void> {
+    const client = this.getClient();
+    await client.stopWebServer({});
+  }
+
+  /**
+   * Register MCP server (VS Code extension registers itself)
+   */
+  async registerMcpServer(serverId: string, transport: proto.McpTransport, toolFilter?: string[]): Promise<proto.RegisterMcpServerResponse> {
+    const client = this.getClient();
+    return client.registerMcpServer({
+      serverId,
+      transport,
+      toolFilter,
+    });
+  }
 }
 
 // Singleton instance
@@ -631,20 +696,20 @@ let _instance: DaemonClient | null = null;
  * Get the shared daemon client instance
  */
 export function getDaemonClient(): DaemonClient {
-    if (!_instance) {
-        _instance = new DaemonClient();
-    }
-    return _instance;
+  if (!_instance) {
+    _instance = new DaemonClient();
+  }
+  return _instance;
 }
 
 /**
  * Reset the daemon client (used internally by shutdownDaemon)
  */
 function resetDaemonClient(): void {
-    if (_instance) {
-        _instance.close().catch(() => {});
-        _instance = null;
-    }
+  if (_instance) {
+    _instance.close().catch(() => {});
+    _instance = null;
+  }
 }
 
 /**
@@ -653,16 +718,40 @@ function resetDaemonClient(): void {
  * 1. Start the daemon if not running
  * 2. Connect to the daemon
  * 3. Register as a VS Code client
- * 
+ *
  * Call this during extension activation.
+ *
+ * @param options.timeoutMs Overall deadline for connect+register (default 20s)
  */
-export async function initializeDaemon(): Promise<DaemonClient> {
-    const client = getDaemonClient();
-    
-    await client.connect({ autoStart: true });
+export async function initializeDaemon(
+  options: { timeoutMs?: number } = {},
+): Promise<DaemonClient> {
+  const { timeoutMs = 20000 } = options;
+  const client = getDaemonClient();
+
+  const work = (async () => {
+    // Leave headroom for register() after waitForDaemon.
+    const connectTimeout = Math.max(5_000, timeoutMs - 5_000);
+    await client.connect({ autoStart: true, timeout: connectTimeout });
     await client.register();
-    
     return client;
+  })();
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`Daemon initialization timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 /**
@@ -670,7 +759,7 @@ export async function initializeDaemon(): Promise<DaemonClient> {
  * Call this during extension deactivation.
  */
 export async function shutdownDaemon(): Promise<void> {
-    const client = getDaemonClient();
-    await client.close();
-    resetDaemonClient();
+  const client = getDaemonClient();
+  await client.close();
+  resetDaemonClient();
 }

--- a/packages/vscode/src/daemon/index.ts
+++ b/packages/vscode/src/daemon/index.ts
@@ -1,27 +1,28 @@
 /**
  * Abbenay Daemon Client
- * 
- * The daemon uses Unix Domain Sockets for local IPC:
- * - Socket: <runtimeDir>/daemon.sock   (Linux: /run/user/<uid>/abbenay/)
+ *
+ * Local IPC:
+ * - Linux/macOS: Unix socket at <runtimeDir>/daemon.sock
+ * - Windows: loopback TCP; host:port in <runtimeDir>/daemon.addr
  * - PID file: <runtimeDir>/abbenay.pid
- * - Config: <configDir>/config.yaml    (Linux: ~/.config/abbenay/)
- * 
+ * - Config: <configDir>/config.yaml
+ *
  * Architecture:
  * - VS Code → Daemon: gRPC client for chat, sessions, config, etc.
  * - Daemon → VS Code: Bidirectional stream for tool invocation, Copilot access
- * 
+ *
  * Usage:
- * 
+ *
  * ```typescript
  * import { initializeDaemon, getDaemonClient, BackchannelHandler } from './daemon';
- * 
+ *
  * // Initialize (auto-starts daemon, connects, registers)
  * const client = await initializeDaemon();
- * 
+ *
  * // Start backchannel for daemon callbacks
  * const backchannel = new BackchannelHandler(client, context);
  * await backchannel.start();
- * 
+ *
  * // Chat with streaming
  * for await (const chunk of client.chat({ messages: [...], modelId: 'gpt-4' })) {
  *     console.log(chunk.content);

--- a/packages/vscode/src/daemon/runtime-paths.ts
+++ b/packages/vscode/src/daemon/runtime-paths.ts
@@ -1,0 +1,103 @@
+/**
+ * Platform-aware runtime paths for the VS Code daemon client.
+ * Mirrors packages/daemon/src/core/paths.ts for PID / IPC discovery.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+
+const APP_NAME = 'abbenay';
+
+/**
+ * Get the platform runtime directory (for ephemeral files: PID, socket/address).
+ */
+export function getRuntimeDir(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  tmpdir: string = os.tmpdir(),
+): string {
+  if (env.XDG_RUNTIME_DIR) {
+    return path.join(env.XDG_RUNTIME_DIR, APP_NAME);
+  }
+
+  if (platform === 'darwin') {
+    return path.join(tmpdir, APP_NAME);
+  }
+
+  if (platform === 'win32') {
+    return path.join(tmpdir, APP_NAME);
+  }
+
+  try {
+    const uid = os.userInfo().uid;
+    return path.join(`/run/user/${uid}`, APP_NAME);
+  } catch {
+    // os.userInfo() can fail in some sandboxes
+  }
+
+  return path.join('/tmp', APP_NAME);
+}
+
+/** PID file under the runtime dir. */
+export function getPidFilePath(runtimeDir: string = getRuntimeDir()): string {
+  return path.join(runtimeDir, `${APP_NAME}.pid`);
+}
+
+/** Unix socket path (not used for IPC on Windows). */
+export function getSocketFilePath(
+  runtimeDir: string = getRuntimeDir(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === 'win32') {
+    return '\\\\.\\pipe\\abbenay-daemon';
+  }
+  return path.join(runtimeDir, 'daemon.sock');
+}
+
+/** Address file for Windows loopback TCP IPC. */
+export function getAddressFilePath(runtimeDir: string = getRuntimeDir()): string {
+  return path.join(runtimeDir, 'daemon.addr');
+}
+
+/**
+ * Parse `host:port` from daemon.addr contents.
+ */
+export function parseDaemonAddress(content: string): { host: string; port: number } | null {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon <= 0 || lastColon === trimmed.length - 1) {
+    return null;
+  }
+
+  const host = trimmed.slice(0, lastColon).trim();
+  const port = parseInt(trimmed.slice(lastColon + 1).trim(), 10);
+  if (!host || !Number.isFinite(port) || port <= 0 || port > 65535) {
+    return null;
+  }
+
+  return { host, port };
+}
+
+/**
+ * Bundled SEA binary filename for the given platform/arch.
+ */
+export function getBundledSeaBinaryName(
+  platform: NodeJS.Platform | string = process.platform,
+  arch: string = process.arch,
+): string {
+  const normalized =
+    platform === 'win32' ? 'win32' : platform === 'darwin' ? 'darwin' : 'linux';
+  const base = `abbenay-daemon-${normalized}-${arch}`;
+  return normalized === 'win32' ? `${base}.exe` : base;
+}
+
+/**
+ * Default gRPC channel address for Unix platforms.
+ */
+export function getUnixDaemonAddress(socketFile: string): string {
+  return `unix://${socketFile}`;
+}

--- a/packages/vscode/src/test/daemon/runtime-paths.test.ts
+++ b/packages/vscode/src/test/daemon/runtime-paths.test.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import {
+  getRuntimeDir,
+  getAddressFilePath,
+  parseDaemonAddress,
+  getBundledSeaBinaryName,
+  getUnixDaemonAddress,
+  getSocketFilePath,
+} from '../../daemon/runtime-paths';
+
+suite('runtime-paths', () => {
+  test('getRuntimeDir uses tmpdir on win32', () => {
+    const dir = getRuntimeDir('win32', {}, '/tmp/fake-temp');
+    assert.strictEqual(dir, path.join('/tmp/fake-temp', 'abbenay'));
+  });
+
+  test('getRuntimeDir uses XDG_RUNTIME_DIR when set', () => {
+    const dir = getRuntimeDir('linux', { XDG_RUNTIME_DIR: '/run/user/1000' }, '/unused');
+    assert.strictEqual(dir, path.join('/run/user/1000', 'abbenay'));
+  });
+
+  test('getAddressFilePath ends with daemon.addr', () => {
+    assert.strictEqual(
+      getAddressFilePath('/tmp/abbenay'),
+      path.join('/tmp/abbenay', 'daemon.addr'),
+    );
+  });
+
+  test('getSocketFilePath returns named pipe stub on win32', () => {
+    assert.strictEqual(
+      getSocketFilePath('/tmp/abbenay', 'win32'),
+      '\\\\.\\pipe\\abbenay-daemon',
+    );
+  });
+
+  test('parseDaemonAddress parses host:port', () => {
+    assert.deepStrictEqual(parseDaemonAddress('127.0.0.1:54321\n'), {
+      host: '127.0.0.1',
+      port: 54321,
+    });
+  });
+
+  test('parseDaemonAddress rejects invalid input', () => {
+    assert.strictEqual(parseDaemonAddress(''), null);
+    assert.strictEqual(parseDaemonAddress('nope'), null);
+    assert.strictEqual(parseDaemonAddress('127.0.0.1:99999'), null);
+  });
+
+  test('getBundledSeaBinaryName appends .exe on win32', () => {
+    assert.strictEqual(
+      getBundledSeaBinaryName('win32', 'x64'),
+      'abbenay-daemon-win32-x64.exe',
+    );
+    assert.strictEqual(
+      getBundledSeaBinaryName('linux', 'x64'),
+      'abbenay-daemon-linux-x64',
+    );
+    assert.strictEqual(
+      getBundledSeaBinaryName('darwin', 'arm64'),
+      'abbenay-daemon-darwin-arm64',
+    );
+  });
+
+  test('getUnixDaemonAddress prefixes unix://', () => {
+    assert.strictEqual(
+      getUnixDaemonAddress('/run/user/1000/abbenay/daemon.sock'),
+      'unix:///run/user/1000/abbenay/daemon.sock',
+    );
+  });
+});

--- a/packages/vscode/src/test/extension.test.ts
+++ b/packages/vscode/src/test/extension.test.ts
@@ -1,9 +1,28 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 suite('Extension Smoke Tests', () => {
   suiteSetup(async function () {
-    this.timeout(30000);
+    // Activation may auto-start the bundled SEA and wait for IPC readiness.
+    this.timeout(60000);
+
+    // Clear stale runtime artifacts so a dead PID / leftover socket cannot
+    // confuse liveness checks or leave activate() waiting on a bad endpoint.
+    const runtimeDir = path.join(os.tmpdir(), 'abbenay');
+    for (const name of ['abbenay.pid', 'daemon.sock', 'daemon.addr']) {
+      const p = path.join(runtimeDir, name);
+      try {
+        if (fs.existsSync(p)) {
+          fs.unlinkSync(p);
+        }
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
     const ext = vscode.extensions.getExtension('redhat.abbenay-provider');
     if (ext && !ext.isActive) {
       try {

--- a/scripts/smoke-win32-ipc.js
+++ b/scripts/smoke-win32-ipc.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Windows IPC smoke test: start the SEA daemon, read daemon.addr, HealthCheck over TCP.
+ *
+ * Usage (after ci:build on Windows):
+ *   node scripts/smoke-win32-ipc.js
+ *
+ * Exit 0 on success.
+ */
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const SEA_DIR = path.join(ROOT, 'dist', 'win32-x64');
+const SEA_NAME = 'abbenay-daemon-win32-x64.exe';
+const RUNTIME_DIR = path.join(os.tmpdir(), 'abbenay');
+const ADDR_FILE = path.join(RUNTIME_DIR, 'daemon.addr');
+const PID_FILE = path.join(RUNTIME_DIR, 'abbenay.pid');
+const PROTO = path.join(ROOT, 'proto', 'abbenay', 'v1', 'service.proto');
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function parseAddress(content) {
+  const trimmed = content.trim();
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon <= 0) {
+    return null;
+  }
+  const host = trimmed.slice(0, lastColon).trim();
+  const port = parseInt(trimmed.slice(lastColon + 1).trim(), 10);
+  if (!host || !Number.isFinite(port)) {
+    return null;
+  }
+  return { host, port };
+}
+
+async function waitForAddress(timeoutMs = 20000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (fs.existsSync(ADDR_FILE)) {
+      const addr = parseAddress(fs.readFileSync(ADDR_FILE, 'utf8'));
+      if (addr) {
+        return addr;
+      }
+    }
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${ADDR_FILE}`);
+}
+
+function healthCheck(host, port) {
+  const packageDefinition = protoLoader.loadSync(PROTO, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+    includeDirs: [path.join(ROOT, 'proto')],
+  });
+  const proto = grpc.loadPackageDefinition(packageDefinition);
+  const Abbenay = proto.abbenay.v1.Abbenay;
+  const client = new Abbenay(
+    `${host}:${port}`,
+    grpc.credentials.createInsecure(),
+  );
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      client.close();
+      reject(new Error('HealthCheck timed out'));
+    }, 10000);
+
+    client.HealthCheck({}, (err, response) => {
+      clearTimeout(timer);
+      client.close();
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(response);
+    });
+  });
+}
+
+function stopDaemon(child) {
+  return new Promise((resolve) => {
+    if (!child || child.killed) {
+      resolve();
+      return;
+    }
+    child.once('exit', () => resolve());
+    child.kill();
+    setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // ignore
+      }
+      resolve();
+    }, 3000);
+  });
+}
+
+async function main() {
+  if (process.platform !== 'win32') {
+    console.log('smoke-win32-ipc: skipping (not win32)');
+    return;
+  }
+
+  const seaPath = path.join(SEA_DIR, SEA_NAME);
+  if (!fs.existsSync(seaPath)) {
+    throw new Error(`SEA binary not found: ${seaPath}`);
+  }
+
+  // Clean stale IPC files from prior runs
+  for (const f of [ADDR_FILE, PID_FILE]) {
+    try {
+      if (fs.existsSync(f)) {
+        fs.unlinkSync(f);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  fs.mkdirSync(RUNTIME_DIR, { recursive: true });
+
+  console.log(`Starting ${seaPath} daemon...`);
+  const child = spawn(seaPath, ['daemon'], {
+    detached: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  let logs = '';
+  child.stdout?.on('data', (d) => {
+    logs += d.toString();
+  });
+  child.stderr?.on('data', (d) => {
+    logs += d.toString();
+  });
+
+  child.on('exit', (code, signal) => {
+    if (code !== null && code !== 0) {
+      console.error(`Daemon exited early code=${code} signal=${signal}`);
+      console.error(logs);
+    }
+  });
+
+  try {
+    const addr = await waitForAddress();
+    console.log(`daemon.addr -> ${addr.host}:${addr.port}`);
+
+    const response = await healthCheck(addr.host, addr.port);
+    if (!response?.healthy) {
+      throw new Error(`HealthCheck failed: ${JSON.stringify(response)}`);
+    }
+    console.log(`HealthCheck OK (version=${response.version ?? 'unknown'})`);
+  } finally {
+    await stopDaemon(child);
+    for (const f of [ADDR_FILE, PID_FILE]) {
+      try {
+        if (fs.existsSync(f)) {
+          fs.unlinkSync(f);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds `win32-x64` as the fourth supported platform for Abbenay, unblocking Windows CI and end-user installs.

Closes #64 and [AAP-82970](https://redhat.atlassian.net/browse/AAP-82970)

### Windows local transport (IPC)

- `getRuntimeDir()` returns `%TEMP%/abbenay` on Windows (PID + address file)
- Daemon binds gRPC on loopback TCP (`127.0.0.1` + ephemeral port) instead of Unix socket on win32
- Writes `host:port` to `<runtimeDir>/daemon.addr`; VS Code client reads it at connect time
- Liveness check uses PID file + TCP connect probe (not `fs.existsSync` on a pipe path)
- Extracted `bindTcpGrpc()` helper shared by win32 local IPC and Unix remote/container TCP
- Linux/macOS Unix socket behavior unchanged

### Packaging / discovery

- SEA binary name appends `.exe` on win32 (`abbenay-daemon-win32-x64.exe`)
- `build.js` skips `chmod` on Windows; `bundle-daemon.js` gates `chmod` behind platform check
- New `runtime-paths.ts` module in the VS Code extension with `getBundledSeaBinaryName()`, `parseDaemonAddress()`, and platform-aware path helpers

### Bootstrap + CI/Release

- `bootstrap.sh` extended for Windows: detects MINGW/MSYS/CYGWIN + `OS=Windows_NT`, downloads `node-v*-win-x64.zip`, extracts via `unzip` or PowerShell `Expand-Archive`, validates `node.exe` SEA fuse, and installs `uv` + `prek` for Windows
- CI (`ci.yml`) and release (`release.yml`) workflows add `windows-latest / win32 / x64` matrix entry
- Release uploads `.zip` archives for Windows (Unix keeps `.tar.gz` per DR-013)
- Release notes table updated with `win32-x64` rows for daemon archive and VSIX

### Acceptance / smoke test

- New `scripts/smoke-win32-ipc.js`: starts the SEA daemon, waits for `daemon.addr`, sends a gRPC `HealthCheck`, asserts `SERVING` status
- Runs as `npm run ci:smoke-win32-ipc` on `windows-latest` in both CI and release workflows

### Documentation

- DR-044 (renumbered; main claimed DR-043 for stdio spawn policy): documents win32-x64 platform + loopback TCP local IPC decision
- DR-010 superseded by DR-044 (platform list 3 → 4)
- `ARCHITECTURE.md`, `DEVELOPMENT.md`, lean-ci `SKILL.md` updated for 4 platforms

## Test plan

- [x] CI green on all 4 matrix runners (linux-x64, linux-arm64, macos-arm64, **win32-x64**)
- [ ] `ci:smoke-win32-ipc` passes on `windows-latest` (daemon starts, HealthCheck over TCP succeeds)
- [ ] `npm test` passes (new tests: `transport.address.test.ts`, `paths.test.ts` win32 cases, `runtime-paths.test.ts`)
- [ ] `npm run lint` clean
- [ ] `npm run ci:build` produces `dist/win32-x64/abbenay-daemon-win32-x64.exe` and `*.vsix`

## Next steps (post-merge)

1. **First release tag push** — triggers release workflow, publishes `win32-x64` VSIX to Marketplace + OpenVSX
2. **Verify keytar.node sidecar** — confirm Credential Manager integration works on Windows after CI green
3. **Unblock AAP-82840** — land the vscode-ansible hard `extensionDependency` PR once the win32 VSIX is published
