### PR TITLE
fix(daemon): map system chat messages to AI SDK 7 instructions

### DIFF
--- a/packages/daemon/src/core/engines-aisdk7.test.ts
+++ b/packages/daemon/src/core/engines-aisdk7.test.ts
@@ -35,7 +35,7 @@ vi.mock('ai', async (importOriginal) => {
   };
 });
 
-import { streamChat, toSdkTimeout, getEngine } from './engines.js';
+import { streamChat, toSdkTimeout, getEngine, splitSystemMessages } from './engines.js';
 
 describe('toSdkTimeout', () => {
   it('maps flat ms to totalMs only (no step/tool halves)', () => {
@@ -64,6 +64,28 @@ describe('streamChat mock engine (stream contract)', () => {
   });
 });
 
+describe('splitSystemMessages', () => {
+  it('moves system roles into instructions and leaves other roles', () => {
+    const result = splitSystemMessages([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'hi' },
+      { role: 'system', content: 'Be brief.' },
+      { role: 'assistant', content: 'hello' },
+    ]);
+    expect(result.instructions).toBe('You are helpful.\n\nBe brief.');
+    expect(result.messages).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ]);
+  });
+
+  it('omits instructions when there are no system messages', () => {
+    const result = splitSystemMessages([{ role: 'user', content: 'hi' }]);
+    expect(result.instructions).toBeUndefined();
+    expect(result.messages).toHaveLength(1);
+  });
+});
+
 describe('streamText AI SDK 7 wiring', () => {
   beforeEach(() => {
     streamTextMock.mockClear();
@@ -71,6 +93,50 @@ describe('streamText AI SDK 7 wiring', () => {
     toolMock.mockClear();
     jsonSchemaMock.mockClear();
     outputJsonMock.mockClear();
+  });
+
+  it('passes system messages via instructions, not messages', async () => {
+    const openai = getEngine('openai');
+    expect(openai).toBeDefined();
+    const originalCreate = openai!.createModel;
+    openai!.createModel = vi.fn(async () => ({
+      modelId: 'gpt-test',
+      provider: 'openai',
+      specificationVersion: 'v3',
+      supportedUrls: {},
+      doGenerate: async () => ({
+        content: [],
+        finishReason: 'stop',
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: new ReadableStream(),
+      }),
+    })) as typeof originalCreate;
+
+    try {
+      for await (const _chunk of streamChat(
+        'openai',
+        'gpt-test',
+        [
+          { role: 'system', content: 'System prompt from Open WebUI' },
+          { role: 'user', content: 'hi' },
+        ],
+        'sk-test',
+      )) {
+        // drain
+      }
+    } finally {
+      openai!.createModel = originalCreate;
+    }
+
+    expect(streamTextMock).toHaveBeenCalled();
+    const callArg = streamTextMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArg.instructions).toBe('System prompt from Open WebUI');
+    const msgs = callArg.messages as Array<{ role: string; content: unknown }>;
+    expect(msgs.every((m) => m.role !== 'system')).toBe(true);
+    expect(msgs.some((m) => m.role === 'user')).toBe(true);
   });
 
   it('passes isStepCount, stream, maxOutputTokens, nested timeout, reasoning, and toolApproval', async () => {

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -963,8 +963,10 @@ export async function* streamChat(
       baseURL: baseUrl,
     });
 
-    // Convert messages to Vercel AI SDK format
-    const aiMessages = convertMessages(messages);
+    // AI SDK 7 rejects role=system in messages/prompt — peel them into instructions.
+    // Open WebUI (and others) still send system prompts as chat messages.
+    const { instructions, messages: nonSystemMessages } = splitSystemMessages(messages);
+    const aiMessages = convertMessages(nonSystemMessages);
 
     // Convert ToolDefinition[] to Vercel AI SDK tool() objects.
     // With an executor: Abbenay runs tools (auto mode).
@@ -1019,6 +1021,7 @@ export async function* streamChat(
     const result = streamText({
       model,
       messages: aiMessages,
+      ...(instructions ? { instructions } : {}),
       ...(aiTools ? { tools: aiTools } : {}),
       // Always bound tool loops when tools are registered — including passthrough
       // (effectiveMaxSteps === 1) so we do not rely on AI SDK defaults alone.
@@ -1178,13 +1181,40 @@ export function coerceToolCallInput(args: unknown): Record<string, unknown> {
 }
 
 /**
+ * Peel system-role messages into a single instructions string for AI SDK 7+.
+ * Remaining messages are returned without system entries.
+ */
+export function splitSystemMessages(messages: ChatMessage[]): {
+  instructions?: string;
+  messages: ChatMessage[];
+} {
+  const systemParts: string[] = [];
+  const rest: ChatMessage[] = [];
+  for (const m of messages) {
+    if (m.role === 'system') {
+      if (m.content?.trim()) {
+        systemParts.push(m.content);
+      }
+      continue;
+    }
+    rest.push(m);
+  }
+  return {
+    ...(systemParts.length > 0 ? { instructions: systemParts.join('\n\n') } : {}),
+    messages: rest,
+  };
+}
+
+/**
  * Convert our internal message format to Vercel AI SDK ModelMessage format.
+ * System messages must already be removed (see splitSystemMessages).
  */
 function convertMessages(messages: ChatMessage[]): ModelMessage[] {
   return messages.map(m => {
     switch (m.role) {
       case 'system':
-        return { role: 'system' as const, content: m.content };
+        // Should not appear after splitSystemMessages; keep as user text if present.
+        return { role: 'user' as const, content: m.content };
 
       case 'user':
         return { role: 'user' as const, content: m.content };


### PR DESCRIPTION
## Summary
- AI SDK 7 rejects `role: system` in `messages`/`prompt` by default (`InvalidPromptError`), requiring system text via `instructions`.
- Open WebUI (and other OpenAI-compat clients) still send system prompts as chat messages, which broke Abbenay chat after #87.
- Peel system messages into `streamText({ instructions })` before `convertMessages`, and add regression coverage.

## Test plan
- [x] Reproduced on media: OWUI → Abbenay returned `InvalidPromptError: System messages are not allowed...`
- [x] After patch + image rebuild: `curl` `/v1/chat/completions` with system+user messages succeeds
- [x] Unit tests added for `splitSystemMessages` and streamText wiring (`engines-aisdk7.test.ts`)
- [ ] CI on this PR