### PR TITLE
ci: add release-drafter for automated changelog generation

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -91,12 +91,35 @@ Right (logic in npm script):
   run: npm run ci:docs
 ```
 
+## Release drafter workflow
+
+`.github/workflows/push.yml` triggers on every push to `main` (i.e. each PR
+merge) and on `workflow_dispatch`. It calls the shared reusable workflow from
+`ansible/team-devtools/.github/workflows/push.yml@main`, which runs
+`release-drafter/release-drafter@v7`. This:
+
+1. Auto-labels the merged PR based on its conventional commit title prefix
+   (`feat:` -> `feat`, `fix:` -> `fix`, `chore:` / `build:` / `ci:` -> `chore`, etc.).
+2. Updates a **draft** GitHub Release with categorized changelog entries
+   (Features, Fixes, Maintenance).
+3. The draft accumulates across merges until a maintainer publishes a release.
+
+Configuration lives in `.github/release-drafter.yml` (not in the workflows
+directory). It uses `_extends` to inherit the shared config from
+`ansible/team-devtools`, matching the pattern used by other Ansible DevTools projects.
+
+The release workflow (below) merges the draft changelog into the final release
+body when a tag is pushed, then deletes the consumed draft.
+
 ## Release workflow
 
 `.github/workflows/release.yml` triggers on `v*` tags. It injects the version
 from the tag into all `package.json` files via `scripts/set-version.js`, builds
 all platforms, then creates a GitHub Release with the artifacts attached. Tags
 containing `alpha`, `beta`, or `rc` are automatically marked as prereleases.
+
+If a release-drafter draft exists, its changelog body is prepended above the
+artifacts table in the final release notes, and the draft is deleted.
 
 Release assets: platform-specific `.vsix` files, `.tar.gz` daemon archives
 (with version in filename), `@abbenay/core` npm tarball, and Python wheel.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+---
+_extends: ansible/team-devtools:/.github/release-drafter.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,16 @@
+---
+name: push
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  ack:
+    uses: ansible/team-devtools/.github/workflows/push.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,12 @@ jobs:
 
           # Retrieve changelog from the release-drafter draft (if one exists)
           changelog=""
-          draft_body="$(gh release list --json tagName,body,isDraft \
-            --jq '.[] | select(.isDraft) | .body' 2>/dev/null | head -1)" || true
+          draft_tag="$(gh release list --json tagName,isDraft \
+            --jq '.[] | select(.isDraft) | .tagName' 2>/dev/null | head -1)" || true
+          draft_body=""
+          if [ -n "$draft_tag" ]; then
+            draft_body="$(gh release view "$draft_tag" --json body --jq '.body' 2>/dev/null)" || true
+          fi
           if [ -n "$draft_body" ]; then
             changelog="${draft_body}"$'\n\n'
           fi
@@ -213,12 +217,8 @@ jobs:
           fi
 
           # Clean up the draft release now that its changelog is merged
-          if [ -n "$draft_body" ]; then
-            draft_tag="$(gh release list --json tagName,isDraft \
-              --jq '.[] | select(.isDraft) | .tagName' 2>/dev/null | head -1)" || true
-            if [ -n "$draft_tag" ]; then
-              gh release delete "$draft_tag" --yes 2>/dev/null || true
-            fi
+          if [ -n "$draft_tag" ]; then
+            gh release delete "$draft_tag" --yes 2>/dev/null || true
           fi
 
   publish-vscode:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,16 @@ jobs:
           # Strip pre-release suffix for the VSIX version (vsce requires pure semver)
           vsix_ver="${ver%%-*}"
 
+          # Retrieve changelog from the release-drafter draft (if one exists)
+          changelog=""
+          draft_body="$(gh release list --json tagName,body,isDraft \
+            --jq '.[] | select(.isDraft) | .body' 2>/dev/null | head -1)" || true
+          if [ -n "$draft_body" ]; then
+            changelog="${draft_body}"$'\n\n'
+          fi
+
           body="$(cat <<BODY
-          ## Artifacts
+          ${changelog}## Artifacts
 
           | File | What it is | Install |
           |------|-----------|---------|
@@ -202,6 +210,15 @@ jobs:
               --notes "${body}" \
               $prerelease_flag \
               "${assets[@]}"
+          fi
+
+          # Clean up the draft release now that its changelog is merged
+          if [ -n "$draft_body" ]; then
+            draft_tag="$(gh release list --json tagName,isDraft \
+              --jq '.[] | select(.isDraft) | .tagName' 2>/dev/null | head -1)" || true
+            if [ -n "$draft_tag" ]; then
+              gh release delete "$draft_tag" --yes 2>/dev/null || true
+            fi
           fi
 
   publish-vscode:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
           fi
 
           # Clean up the draft release now that its changelog is merged
-          if [ -n "$draft_tag" ]; then
+          if [ -n "$draft_tag" ] && [ "$draft_tag" != "$tag" ]; then
             gh release delete "$draft_tag" --yes 2>/dev/null || true
           fi
 


### PR DESCRIPTION
## Summary

- Add release-drafter to automatically generate categorised changelog entries (Features, Fixes, Maintenance) from merged PRs matching the pattern followed for other Devtools repo.
- Reuse the shared config and workflow from [ansible/team-devtools](https://github.com/ansible/team-devtools).
- Update the release workflow to merge the draft changelog into the final release body when a tag is pushed, giving published releases both a changelog and the existing artifacts table.

## How it works

1. A PR is merged to `main` → `push.yml` triggers
2. Release-drafter auto-labels the PR from its conventional commit title (`feat:` → `feat`, `fix:` → `fix`, `chore:`/`build:`/`ci:` → `chore`, etc.)
3. The PR is added to a Draft GitHub Release under the appropriate category
4. The draft accumulates across merges
5. When a `v*` tag is pushed, `release.yml` merges the draft changelog into the published release notes (above the artifacts table) and deletes the draft

## Test plan

- [ ] `push.yml` workflow appears in Actions tab after merge
- [ ] Merging a subsequent PR to `main` creates a draft release at `/releases`
- [ ] Draft groups the PR under the correct category based on its title prefix
- [ ] Pushing a `v*` tag produces a release with both changelog and artifacts table
- [ ] Draft is cleaned up after the tag-triggered release publishes