### PR TITLE
docs: fix product name, npm install path, and MaaS URL clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Abbenay produces two packages from a single source tree:
 ## Features
 
 - **20 LLM engines** via [Vercel AI SDK 7](https://sdk.vercel.ai/) with dynamic provider loading (Node.js 22.12+ required for npm/`tsx` development; SEA binaries bundle their own runtime)
-- **Red Hat AI** — Inference Server or OpenShift AI MaaS via dedicated `redhat` engine
+- **Red Hat AI** — Red Hat AI Inference or OpenShift AI MaaS via dedicated `redhat` engine
 - **OpenAI-compatible API**: Drop-in `/v1/chat/completions` for Cursor, Continue, aider, etc.
 - **CLI chat**: Interactive terminal chat with tool approval and session persistence
 - **Session management**: Persistent conversations with periodic LLM-generated summaries

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Abbenay produces two packages from a single source tree:
 ## Features
 
 - **20 LLM engines** via [Vercel AI SDK 7](https://sdk.vercel.ai/) with dynamic provider loading (Node.js 22.12+ required for npm/`tsx` development; SEA binaries bundle their own runtime)
-- **Red Hat AI** — Red Hat AI Inference or OpenShift AI MaaS via dedicated `redhat` engine
+- **Red Hat AI** — Inference or OpenShift AI MaaS via dedicated `redhat` engine
 - **OpenAI-compatible API**: Drop-in `/v1/chat/completions` for Cursor, Continue, aider, etc.
 - **CLI chat**: Interactive terminal chat with tool approval and session persistence
 - **Session management**: Persistent conversations with periodic LLM-generated summaries

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -574,10 +574,10 @@ providers:
       claude-sonnet-4-20250514: {}
 ```
 
-### Red Hat AI (Inference Server / MaaS)
+### Red Hat AI (Inference / MaaS)
 
 ```yaml
-# Profile A — Inference Server (local or OpenShift-hosted vLLM)
+# Profile A — Red Hat AI Inference (local or OpenShift-hosted vLLM)
 providers:
   redhat-inference:
     engine: redhat
@@ -593,7 +593,7 @@ providers:
       llama-3.1-8b-instruct: {}
 ```
 
-Inference Server auth is optional (depends on `--api-key` flag); MaaS
+Red Hat AI Inference auth is optional (depends on `--api-key` flag); MaaS
 typically requires an API key. Default endpoint: `http://127.0.0.1:8000/v1`.
 See [REDHAT_AI.md](REDHAT_AI.md) for full setup including both profiles.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -577,7 +577,7 @@ providers:
 ### Red Hat AI (Inference / MaaS)
 
 ```yaml
-# Profile A — Red Hat AI Inference (local or OpenShift-hosted vLLM)
+# Profile A — Inference Server (local or OpenShift-hosted vLLM)
 providers:
   redhat-inference:
     engine: redhat

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -19,8 +19,12 @@ It has **zero transport dependencies** — no gRPC, no Express, no CLI. Just the
 
 ## Install
 
+Download the `abbenay-core-*.tgz` tarball from the
+[latest GitHub release](https://github.com/redhat-developer/abbenay/releases)
+and install it locally:
+
 ```bash
-npm install @abbenay/core
+npm install abbenay-core-<version>.tgz
 ```
 
 Then install only the AI SDK provider packages you need:
@@ -312,7 +316,7 @@ bridged to Abbenay's secure-by-default policy (DR-019 / DR-042).
 | LM Studio | `lmstudio` | No | `@ai-sdk/openai-compatible` | Local models |
 | Cerebras | `cerebras` | Yes | `@ai-sdk/openai-compatible` | Fast inference |
 | Meta (Llama) | `meta` | Yes | `@ai-sdk/openai-compatible` | Llama API |
-| Red Hat AI | `redhat` | No | `@ai-sdk/openai-compatible` | Inference Server or OpenShift AI MaaS |
+| Red Hat AI | `redhat` | No | `@ai-sdk/openai-compatible` | Red Hat AI Inference or OpenShift AI MaaS |
 | Mock | `mock` | No | *(built-in)* | Testing only |
 
 ## Policies

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,7 +12,8 @@ Download the latest release for your platform. The binary is a
 [Node.js Single Executable Application (SEA)](https://nodejs.org/api/single-executables.html) —
 no Node.js installation required.
 
-Release artifacts are named `abbenay-daemon-<platform>-<arch>`:
+Release artifacts are named `abbenay-daemon-<platform>-<arch>`. Rename
+or symlink to `aby` for convenience:
 
 ```bash
 # Linux / macOS — rename and move to PATH

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,17 +12,13 @@ Download the latest release for your platform. The binary is a
 [Node.js Single Executable Application (SEA)](https://nodejs.org/api/single-executables.html) —
 no Node.js installation required.
 
-Release artifacts are named `abbenay-daemon-<platform>-<arch>`. Rename
-or symlink to `aby` for convenience:
+Release artifacts are named `abbenay-daemon-<platform>-<arch>`:
 
 ```bash
 # Linux / macOS — rename and move to PATH
 chmod +x abbenay-daemon-linux-x64
 sudo mv abbenay-daemon-linux-x64 /usr/local/bin/aby
 ```
-
-If you install via npm (`npm install -g @abbenay/daemon`), both `aby`
-and `abbenay` are available on PATH automatically.
 
 All examples in this guide use `aby`.
 
@@ -127,7 +123,7 @@ providers:
 
 Ollama must be running at `http://localhost:11434` (the default).
 
-### Red Hat AI (Inference Server or MaaS)
+### Red Hat AI (Inference or MaaS)
 
 ```yaml
 providers:
@@ -137,7 +133,7 @@ providers:
       RedHatAI/Llama-3.2-1B-Instruct-FP8: {}
 ```
 
-The Inference Server must be running at `http://127.0.0.1:8000/v1`. For
+Red Hat AI Inference must be running at `http://127.0.0.1:8000/v1`. For
 OpenShift AI MaaS, set `base_url` and `api_key_env_var_name`. See
 [REDHAT_AI.md](REDHAT_AI.md) for both profiles.
 

--- a/docs/PRODUCT_OVERVIEW.md
+++ b/docs/PRODUCT_OVERVIEW.md
@@ -334,9 +334,9 @@ session sidebar, context window compression.
 - Model IDs prefixed with provider
 
 ### Red Hat AI
-- Dedicated `redhat` engine — Inference Server or OpenShift AI MaaS
-- Default endpoint `http://127.0.0.1:8000/v1` (Inference Server); MaaS users override `base_url`
-- API key optional for Inference Server; typically required for MaaS
+- Dedicated `redhat` engine — Red Hat AI Inference or OpenShift AI MaaS
+- Default endpoint `http://127.0.0.1:8000/v1` (Inference profile); MaaS users override `base_url`
+- API key optional for Inference profile; typically required for MaaS
 - See [REDHAT_AI.md](REDHAT_AI.md) for full setup
 
 ### vLLM / TGI

--- a/docs/REDHAT_AI.md
+++ b/docs/REDHAT_AI.md
@@ -21,8 +21,8 @@ secures the daemon — see [SECURITY.md](./SECURITY.md).
 
 ## Profile A — Inference Server
 
-Red Hat AI Inference Server is a standalone vLLM instance running locally,
-on a RHEL AI host, or in an OpenShift container.
+Red Hat AI Inference is a standalone vLLM-based inference stack running
+locally, on a RHEL AI host, or in an OpenShift container.
 
 ### Quick start
 
@@ -131,6 +131,11 @@ providers:
 ```bash
 export REDHAT_AI_API_KEY="your-maas-api-key"
 ```
+
+> **Note:** The `base_url` must point to the OpenAI-compatible inference
+> endpoint (`/v1`), not the native MaaS management API (`/maas-api/v1`).
+> The `/maas-api/v1` prefix is used for token generation and
+> subscription-level model listing — Abbenay does not use it.
 
 ### Key differences from Inference Server
 


### PR DESCRIPTION
## Summary

Fixes three documentation inaccuracies identified during the downstream docs review for [AAP-81972](https://redhat.atlassian.net/browse/AAP-81972) (Documentation for Abbenay unified AI daemon).

- **Remove phantom npm install path** — `npm install -g @abbenay/daemon` was documented in GETTING_STARTED.md but the package is not published to npmjs.com (the monorepo is `private: true`, there is no npm publish step in CI, and the version is `0.0.0-dev`). Also fix CORE.md to reference the `.tgz` tarball from GitHub Releases instead of a non-existent registry entry.
- **Rename "Red Hat AI Inference Server" → "Red Hat AI Inference"** — the product was officially renamed in the [v3.4 release notes](https://docs.redhat.com/en/documentation/red_hat_ai_inference/3.4/html-single/release_notes/index). Updated across docs where the full product name appeared. Profile labels ("Profile A — Inference Server") are kept as Abbenay-internal shorthand since the product column already shows the correct name.
- **Add MaaS URL clarification** — added a note in REDHAT_AI.md clarifying that `base_url` must point to the OpenAI-compatible inference endpoint (`/v1`), not the native MaaS management API (`/maas-api/v1`) which is used for token generation and subscription-level model listing. This prevents a confusion that surfaced during the docs review.

## Changes

- `docs/GETTING_STARTED.md` — drop phantom global npm install; restore rename/symlink prose; update RHAI section wording
- `docs/CORE.md` — install `@abbenay/core` from GitHub release `.tgz`; update RHAI engine table text
- `docs/REDHAT_AI.md` — product rename in Profile A prose; MaaS `/v1` vs `/maas-api/v1` note
- `docs/CONFIGURATION.md`, `docs/PRODUCT_OVERVIEW.md`, `README.md` — align RHAI product naming (keep Profile A shorthand)
- Follow-up nits: README feature bullet phrasing; keep CONFIGURATION Profile A label consistent with REDHAT_AI.md

## Test plan

- [x] Confirm `abbenay-core-*.tgz` exists on latest GitHub Release assets
- [x] Confirm RHAI rename against [v3.4 release notes](https://docs.redhat.com/en/documentation/red_hat_ai_inference/3.4/html-single/release_notes/index)
- [x] Grep docs for remaining inaccurate `npm install -g @abbenay/daemon` / `npm install @abbenay/core` registry install paths
- [x] CI green on PR (`lint-and-test`, builds, container, package-python)
- [ ] Spot-check rendered docs links (RHAI release notes, MaaS `/v1` note reads clearly)

### Related document

- https://docs.google.com/document/d/1q2U1qm876iEkrwRGTpGFgddS7VXa4MNBX-kvkGd00XE/edit?usp=sharing
- JIRA - [AAP-84578](https://redhat.atlassian.net/browse/AAP-84578)