### PR TITLE
ci: publish VS Code extension on alpha tags as pre-release

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -133,13 +133,13 @@ public registries (uses the `release` GitHub environment):
 
 | Job | Target | Trigger condition | Auth mechanism |
 |-----|--------|-------------------|----------------|
-| `publish-vscode` | VS Code Marketplace + OpenVSX | All tags except `*alpha*` | `VSCODE_MARKETPLACE_TOKEN`, `OVSX_MARKETPLACE_TOKEN` |
+| `publish-vscode` | VS Code Marketplace + OpenVSX | All release tags | `VSCODE_MARKETPLACE_TOKEN`, `OVSX_MARKETPLACE_TOKEN` |
 
 - **VS Code Marketplace + OpenVSX**: `scripts/publish-vscode.js` finds all
   `.vsix` files in the downloaded artifacts and publishes each with
-  `vsce publish -p <token>` and `ovsx publish -p <token>`. Beta/RC tags are
-  published with `--pre-release`. Alpha tags are excluded entirely.
-  Follows the Red Hat convention from `redhat-developer/vscode-yaml`.
+  `vsce publish -p <token>` and `ovsx publish -p <token>`. Alpha/beta/RC
+  tags are published with `--pre-release`. Follows the Red Hat convention
+  from `redhat-developer/vscode-yaml`.
 
 ### One-time setup for publishing
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,6 @@ jobs:
     needs: [build, release]
     runs-on: ubuntu-latest
     environment: release
-    if: ${{ !contains(github.ref_name, 'alpha') }}
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -401,15 +401,15 @@ architecture clean and benefits all gRPC clients (CLI, Python, future editors).
 as part of the release workflow. VS Code Marketplace uses
 `VSCODE_MARKETPLACE_TOKEN` and OpenVSX uses `OVSX_MARKETPLACE_TOKEN`, both
 passed to `scripts/publish-vscode.js` which handles multi-platform VSIX
-publishing. The publish job uses the `release` GitHub environment. Alpha releases
-are excluded from publishing; beta/rc go as pre-release. The extension publisher
-is changed from `abbenay` to `redhat`. This follows the Red Hat convention
-established by `redhat-developer/vscode-yaml`.
+publishing. The publish job uses the `release` GitHub environment. Alpha/beta/rc
+tags are published with `--pre-release`. The extension publisher is changed from
+`abbenay` to `redhat`. This follows the Red Hat convention established by
+`redhat-developer/vscode-yaml`.
 **Rationale:** GitHub Release assets require manual download and sideloading —
 fine for early adopters but a barrier to organic adoption. Publishing to both
 VS Code Marketplace and OpenVSX ensures coverage for VS Code and compatible
-editors (Eclipse Theia, VSCodium, Gitpod). Gating alpha releases prevents
-incomplete builds from reaching end users.
+editors (Eclipse Theia, VSCodium, Gitpod). Pre-release flags keep alpha/beta/rc
+builds out of the stable channel while still allowing Marketplace installs.
 
 ---
 

--- a/scripts/publish-vscode.js
+++ b/scripts/publish-vscode.js
@@ -10,9 +10,9 @@
  * Environment variables:
  *   VSCODE_MARKETPLACE_TOKEN  — PAT for VS Code Marketplace (required)
  *   OVSX_MARKETPLACE_TOKEN    — PAT for OpenVSX Registry (optional, skipped if unset)
- *   GITHUB_REF_NAME           — used to detect pre-release tags (beta/rc)
+ *   GITHUB_REF_NAME           — used to detect pre-release tags (alpha/beta/rc)
  *
- * Pre-release versions (tags containing beta/rc) are published with --pre-release.
+ * Pre-release versions (tags containing alpha/beta/rc) are published with --pre-release.
  * Follows the Red Hat convention from redhat-developer/vscode-yaml.
  */
 
@@ -50,7 +50,7 @@ if (vsixFiles.length === 0) {
   process.exit(1);
 }
 
-const isPreRelease = (process.env.GITHUB_REF_NAME || '').match(/(beta|rc)/);
+const isPreRelease = (process.env.GITHUB_REF_NAME || '').match(/(alpha|beta|rc)/);
 const preReleaseFlag = isPreRelease ? ' --pre-release' : '';
 const vsceToken = process.env.VSCODE_MARKETPLACE_TOKEN;
 const ovsxToken = process.env.OVSX_MARKETPLACE_TOKEN;


### PR DESCRIPTION
## Summary
- Remove the `publish-vscode` job skip for tags containing `alpha`, so Marketplace/OpenVSX publishing runs for alpha releases too
- Treat `alpha` like `beta`/`rc` in `scripts/publish-vscode.js` and publish with `--pre-release` so alphas stay off the stable channel
- Update DR-028 and lean-ci docs to match

## Test plan
- [ ] Confirm `publish-vscode` is no longer skipped on an `*-alpha` tag release run
- [ ] Confirm the publish step uses `--pre-release` for alpha/beta/rc tags
- [ ] Confirm non-prerelease tags still publish without `--pre-release`

Related JIRA - [AAP-82970](https://redhat.atlassian.net/browse/AAP-82970)


Made with [Cursor](https://cursor.com)