### PR TITLE
fix(web): show config location modal (unclosed wizard div)

### DIFF
--- a/packages/daemon/static/index.html
+++ b/packages/daemon/static/index.html
@@ -1188,6 +1188,7 @@
                 :disabled="wizardStep === 1 && !wizardEngine">Next</button>
         <!-- Save — show in wizard flow (step 3, not editing model) OR from Models tab when editing a model -->
         <button class="btn btn-primary" x-show="(wizardStep === 3 && !wizardEditingModel && !wizardFromModelsTab) || (wizardFromModelsTab && wizardEditingModel)" @click="wizardSave()">Save</button>
+      </div>
     </div>
   </div>
 
@@ -1691,11 +1692,21 @@ function dashboard() {
     
     // ── Config location modal ──
     async openConfigModal() {
+      // Show first so existing radios bind to the current selection. Updating
+      // connectedWorkspaces can recreate name="cfg" radios; the browser may
+      // auto-check the first option ("all") and Alpine would sync that into
+      // configLocation. Capture selection immediately before that assignment
+      // (not before the await) so an intentional click during fetch is kept.
+      this.showConfigModal = true;
       try {
         const resp = await apiFetch('/api/workspaces');
-        this.connectedWorkspaces = (await resp.json()).workspaces || [];
-      } catch { this.connectedWorkspaces = []; }
-      this.showConfigModal = true;
+        const workspaces = (await resp.json()).workspaces || [];
+        const selected = this.configLocation;
+        this.connectedWorkspaces = workspaces;
+        this.configLocation = selected;
+      } catch {
+        this.connectedWorkspaces = [];
+      }
     },
     async applyConfigLocation() {
       await this.loadConfig();


### PR DESCRIPTION
## Summary
- Fix missing `</div>` on the Add Provider wizard so the "Save config to" modal is no longer nested under a `display: none` backdrop (rendered at 0×0 after `/api/workspaces`).
- Preserve the selected config location when workspaces load, so the radio group does not flip User → All.
- Closes #97

## Test plan
- [ ] `aby start` (or local `tsx` daemon) with ≥1 VS Code workspace connected
- [ ] Click header All/User → "Save config to" modal is visible and clickable
- [ ] Select User → Apply → + Add Provider is enabled
- [ ] Select All → Apply → + Add Provider stays disabled (expected)
- [ ] Open wizard (Add Provider) → Cancel/close still works; no leftover overlay
- [ ] Hard refresh; confirm modal still works (not serving extension SEA static)