### PR TITLE
feat(openai-compat): honor tool_choice on /v1 passthrough

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,6 +77,19 @@ providers:
         openai_compat_tools: passthrough   # Open WebUI Native FC for this model only
 ```
 
+When passthrough is enabled, OpenAI `tool_choice` is honored (DR-046):
+
+| `tool_choice` | Behavior |
+|---------------|----------|
+| omitted / `auto` | Model may call tools (AI SDK default) |
+| `none` | Tools are offered but the model must not call them |
+| `required` | Model must call at least one tool |
+| `{ "type": "function", "function": { "name": "…" } }` | Model must call that function (must appear in `tools`) |
+
+Invalid `tool_choice`, `required`/specific-function without usable `tools`, or a
+function name not in `tools` returns `400 invalid_request_error`. When tools
+mode is `off`, `tool_choice` is ignored like `tools`.
+
 **Security tradeoff:** Passthrough trusts the client’s tool list and does not
 use Abbenay’s approval UI. Prefer enabling it only on models you use with
 trusted clients. For Abbenay-executed / approval-gated tools, use the dashboard,

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -811,3 +811,20 @@ the right without programmatic workarounds. Deferring chat provider routing
 to the consumer avoids duplication with vscode-ansible's existing
 `chatProvider.ts` pattern. `<dialog>` was chosen over a custom overlay for
 built-in accessibility, focus trapping, and `::backdrop` support.
+
+---
+
+## DR-046: Honor OpenAI `tool_choice` on `/v1` passthrough
+
+**Date:** 2026-08-03
+**Decision:** When `openai_compat` tools mode is `passthrough` (DR-032), map
+OpenAI `tool_choice` (`auto` / `none` / `required` / specific function) to the
+AI SDK `toolChoice` and forward it through `ChatToolOptions` → `streamChat` →
+`streamText`. Reject invalid shapes and `required`/specific-function without a
+matching request tool with `400`. When tools mode is `off`, ignore
+`tool_choice` the same way `tools` are ignored. Passthrough keeps
+`maxToolIterations: 1` so forced tool choice cannot open an executor loop.
+**Rationale:** Clients such as Open WebUI Native function calling send
+`tool_choice` to force or suppress tool use; dropping it silently made
+passthrough incomplete versus a real OpenAI-compatible endpoint (issue #77).
+Numbered DR-046 because main already shipped VS Code webview UX as DR-045.

--- a/packages/daemon/src/core/engines-aisdk7.test.ts
+++ b/packages/daemon/src/core/engines-aisdk7.test.ts
@@ -139,6 +139,51 @@ describe('streamText AI SDK 7 wiring', () => {
     expect(msgs.some((m) => m.role === 'user')).toBe(true);
   });
 
+  it('forwards toolChoice to streamText when tools are present', async () => {
+    const openai = getEngine('openai');
+    expect(openai).toBeDefined();
+    const originalCreate = openai!.createModel;
+    openai!.createModel = vi.fn(async () => ({
+      modelId: 'gpt-test',
+      provider: 'openai',
+      specificationVersion: 'v3',
+      supportedUrls: {},
+      doGenerate: async () => ({
+        content: [],
+        finishReason: 'stop',
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: new ReadableStream(),
+      }),
+    })) as typeof originalCreate;
+
+    try {
+      for await (const _chunk of streamChat(
+        'openai',
+        'gpt-test',
+        [{ role: 'user', content: 'hi' }],
+        'sk-test',
+        undefined,
+        undefined,
+        [{ name: 'web_search', description: 'search', inputSchema: '{"type":"object","properties":{}}' }],
+        undefined,
+        undefined,
+        1,
+        false,
+        'required',
+      )) {
+        // drain
+      }
+    } finally {
+      openai!.createModel = originalCreate;
+    }
+
+    const callArg = streamTextMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArg.toolChoice).toBe('required');
+  });
+
   it('passes isStepCount, stream, maxOutputTokens, nested timeout, reasoning, and toolApproval', async () => {
     const openai = getEngine('openai');
     expect(openai).toBeDefined();

--- a/packages/daemon/src/core/engines.ts
+++ b/packages/daemon/src/core/engines.ts
@@ -638,6 +638,16 @@ export interface ChatParams {
   reasoning?: ReasoningLevel;
 }
 
+/**
+ * AI SDK `toolChoice` values (DR-046).
+ * Mapped from OpenAI `tool_choice` on `/v1` passthrough.
+ */
+export type ChatToolChoice =
+  | 'auto'
+  | 'none'
+  | 'required'
+  | { type: 'tool'; toolName: string };
+
 // ── Tool definitions (passed from proto/config to AI SDK tools) ────────
 
 /**
@@ -939,6 +949,7 @@ export async function* streamChat(
   toolValidator?: ToolValidationCallback,
   maxSteps: number = 10,
   jsonMode: boolean = false,
+  toolChoice?: ChatToolChoice,
 ): AsyncGenerator<ChatChunk> {
   // Mock engine — no network, no key, deterministic
   if (engineId === 'mock') {
@@ -1026,6 +1037,8 @@ export async function* streamChat(
       // Always bound tool loops when tools are registered — including passthrough
       // (effectiveMaxSteps === 1) so we do not rely on AI SDK defaults alone.
       ...(aiTools ? { stopWhen: isStepCount(effectiveMaxSteps) } : {}),
+      // OpenAI tool_choice → AI SDK toolChoice (DR-046). Only meaningful with tools.
+      ...(aiTools && toolChoice != null ? { toolChoice } : {}),
       // Bridge Abbenay policy validator into SDK-native toolApproval (DR-042).
       // Awaits toolValidator (which may prompt via onToolApprovalNeeded).
       // Only when Abbenay executes tools (executor present) — not passthrough.

--- a/packages/daemon/src/core/index.ts
+++ b/packages/daemon/src/core/index.ts
@@ -55,7 +55,7 @@ export type { ProviderTemplate } from './engines.js';
 export type { ChatChunk } from './engines.js';
 
 /** Per-request chat parameters (temperature, maxTokens, etc.) */
-export type { ChatParams, ReasoningLevel } from './engines.js';
+export type { ChatParams, ReasoningLevel, ChatToolChoice } from './engines.js';
 
 /** Map Abbenay flat timeout ms → AI SDK 7 TimeoutConfiguration */
 export { toSdkTimeout } from './engines.js';

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -34,6 +34,7 @@ import {
   type ToolDefinition,
   type ToolExecutor,
   type ToolValidationCallback,
+  type ChatToolChoice,
 } from './engines.js';
 import type { ToolRegistry } from './tool-registry.js';
 import { createToolValidator } from './tool-approval.js';
@@ -112,6 +113,11 @@ export interface ChatToolOptions {
   toolFilter?: string[];
   /** Session ID for session-scoped tool visibility */
   sessionId?: string;
+  /**
+   * AI SDK toolChoice (DR-046). Used by `/v1` passthrough when OpenAI
+   * `tool_choice` is present; ignored when no tools are registered.
+   */
+  toolChoice?: ChatToolChoice;
   /**
    * Called when a tool matches `require_approval` patterns and needs user confirmation.
    * The implementation is transport-specific: the web server writes an SSE event and
@@ -688,24 +694,30 @@ export class CoreState {
     const isJsonStrict = flatPolicy?.outputFormat === 'json_only';
     const shouldRetryJson = isJsonStrict && flatPolicy?.retryOnInvalidJson;
 
+    const toolChoice = toolOptions?.toolChoice;
+
     if (isJsonStrict && !shouldRetryJson) {
       yield* streamChat(
         providerCfg.engine, engineModelId, processedMessages,
         apiKey || undefined, providerCfg.base_url, mergedParams,
         tools, resolvedExecutor, toolValidator, maxSteps,
         true,
+        toolChoice,
       );
     } else if (shouldRetryJson) {
       yield* streamChatWithJsonRetry(
         providerCfg.engine, engineModelId, processedMessages,
         apiKey || undefined, providerCfg.base_url, mergedParams,
         tools, resolvedExecutor, toolValidator, maxSteps,
+        toolChoice,
       );
     } else {
       yield* streamChat(
         providerCfg.engine, engineModelId, processedMessages,
         apiKey || undefined, providerCfg.base_url, mergedParams,
         tools, resolvedExecutor, toolValidator, maxSteps,
+        false,
+        toolChoice,
       );
     }
   }
@@ -890,12 +902,13 @@ async function* streamChatWithJsonRetry(
   toolExecutor: ToolExecutor | undefined,
   toolValidator: ToolValidationCallback | undefined,
   maxSteps: number,
+  toolChoice?: ChatToolChoice,
 ): AsyncGenerator<ChatChunk> {
   let fullText = '';
   let finishReason = 'stop';
   const buffered: ChatChunk[] = [];
 
-  for await (const chunk of streamChat(engine, engineModelId, messages, apiKey, baseUrl, params, tools, toolExecutor, toolValidator, maxSteps, true)) {
+  for await (const chunk of streamChat(engine, engineModelId, messages, apiKey, baseUrl, params, tools, toolExecutor, toolValidator, maxSteps, true, toolChoice)) {
     buffered.push(chunk);
     if (chunk.type === 'text') {
       fullText += chunk.text;
@@ -947,5 +960,5 @@ async function* streamChatWithJsonRetry(
     { role: 'user', content: retryPrompt },
   ];
 
-  yield* streamChat(engine, engineModelId, retryMessages, apiKey, baseUrl, params, tools, toolExecutor, toolValidator, maxSteps, true);
+  yield* streamChat(engine, engineModelId, retryMessages, apiKey, baseUrl, params, tools, toolExecutor, toolValidator, maxSteps, true, toolChoice);
 }

--- a/packages/daemon/src/daemon/web/api-schemas.ts
+++ b/packages/daemon/src/daemon/web/api-schemas.ts
@@ -208,6 +208,8 @@ export const PostOpenAIChatCompletionsBodySchema = z
     max_completion_tokens: z.number().optional(),
     // DR-032: optional client tools for opt-in passthrough (validated/mapped in openai-compat).
     tools: z.array(z.unknown()).optional(),
+    // DR-046: OpenAI tool_choice — honored only when tools mode is passthrough.
+    tool_choice: z.unknown().optional(),
   })
   .strip();
 

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -15,6 +15,8 @@ import {
   generateChatId,
   resolveOpenAICompatToolsMode,
   mapOpenAIToolsToDefinitions,
+  mapOpenAIToolChoice,
+  validateToolChoiceAgainstTools,
   normalizeOpenAIToolCalls,
   normalizeOpenAIChatMessage,
   type StreamChunkOptions,
@@ -480,5 +482,76 @@ describe('normalizeOpenAIChatMessage', () => {
       tool_call_id: undefined,
       tool_calls: undefined,
     });
+  });
+});
+
+// ── mapOpenAIToolChoice / validateToolChoiceAgainstTools (DR-046) ──────
+
+describe('mapOpenAIToolChoice', () => {
+  it('maps omitted and null to undefined', () => {
+    expect(mapOpenAIToolChoice(undefined)).toEqual({ ok: true, toolChoice: undefined });
+    expect(mapOpenAIToolChoice(null)).toEqual({ ok: true, toolChoice: undefined });
+  });
+
+  it('maps auto / none / required strings', () => {
+    expect(mapOpenAIToolChoice('auto')).toEqual({ ok: true, toolChoice: 'auto' });
+    expect(mapOpenAIToolChoice('none')).toEqual({ ok: true, toolChoice: 'none' });
+    expect(mapOpenAIToolChoice('required')).toEqual({ ok: true, toolChoice: 'required' });
+  });
+
+  it('maps specific function object to AI SDK tool form', () => {
+    expect(mapOpenAIToolChoice({
+      type: 'function',
+      function: { name: 'web_search' },
+    })).toEqual({
+      ok: true,
+      toolChoice: { type: 'tool', toolName: 'web_search' },
+    });
+  });
+
+  it('trims function name whitespace', () => {
+    expect(mapOpenAIToolChoice({
+      type: 'function',
+      function: { name: '  web_search  ' },
+    })).toEqual({
+      ok: true,
+      toolChoice: { type: 'tool', toolName: 'web_search' },
+    });
+  });
+
+  it('rejects unknown strings and invalid objects', () => {
+    expect(mapOpenAIToolChoice('forced').ok).toBe(false);
+    expect(mapOpenAIToolChoice({ type: 'tool', toolName: 'x' }).ok).toBe(false);
+    expect(mapOpenAIToolChoice({ type: 'function', function: {} }).ok).toBe(false);
+    expect(mapOpenAIToolChoice({ type: 'function', function: { name: '   ' } }).ok).toBe(false);
+    expect(mapOpenAIToolChoice(42).ok).toBe(false);
+  });
+});
+
+describe('validateToolChoiceAgainstTools', () => {
+  it('allows auto/none/undefined without tools', () => {
+    expect(validateToolChoiceAgainstTools(undefined, [])).toBeUndefined();
+    expect(validateToolChoiceAgainstTools('auto', [])).toBeUndefined();
+    expect(validateToolChoiceAgainstTools('none', [])).toBeUndefined();
+  });
+
+  it('requires tools for required and specific function', () => {
+    expect(validateToolChoiceAgainstTools('required', [])).toMatch(/requires tools/);
+    expect(validateToolChoiceAgainstTools(
+      { type: 'tool', toolName: 'web_search' },
+      [],
+    )).toMatch(/requires tools/);
+  });
+
+  it('requires specific function name to be in tools', () => {
+    expect(validateToolChoiceAgainstTools(
+      { type: 'tool', toolName: 'missing' },
+      ['web_search'],
+    )).toMatch(/not in the request tools list/);
+    expect(validateToolChoiceAgainstTools(
+      { type: 'tool', toolName: 'web_search' },
+      ['web_search'],
+    )).toBeUndefined();
+    expect(validateToolChoiceAgainstTools('required', ['web_search'])).toBeUndefined();
   });
 });

--- a/packages/daemon/src/daemon/web/openai-compat.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.ts
@@ -13,7 +13,7 @@ import * as crypto from 'node:crypto';
 import type { Express, Request, Response } from 'express';
 import type { DaemonState } from '../../daemon/state.js';
 import type { ModelInfo, ChatToolOptions } from '../../core/state.js';
-import type { ChatChunk, ToolDefinition } from '../../core/engines.js';
+import type { ChatChunk, ChatToolChoice, ToolDefinition } from '../../core/engines.js';
 import { extractToolCallFields } from '../../core/engines.js';
 import {
   loadConfig,
@@ -109,6 +109,78 @@ export function coerceToolParametersSchema(parameters: unknown): Record<string, 
     };
   }
   return { type: 'object', properties: {} };
+}
+
+export type MapOpenAIToolChoiceResult =
+  | { ok: true; toolChoice: ChatToolChoice | undefined }
+  | { ok: false; error: string };
+
+/**
+ * Map OpenAI `tool_choice` to AI SDK `toolChoice` (DR-046).
+ *
+ * Accepts `"auto" | "none" | "required"` or
+ * `{ type: "function", function: { name } }`.
+ * Omitted / null → `{ ok: true, toolChoice: undefined }` (provider default).
+ */
+export function mapOpenAIToolChoice(toolChoice: unknown): MapOpenAIToolChoiceResult {
+  if (toolChoice == null) {
+    return { ok: true, toolChoice: undefined };
+  }
+  if (typeof toolChoice === 'string') {
+    if (toolChoice === 'auto' || toolChoice === 'none' || toolChoice === 'required') {
+      return { ok: true, toolChoice };
+    }
+    return {
+      ok: false,
+      error: `Invalid tool_choice "${toolChoice}"; expected "auto", "none", "required", or a function object`,
+    };
+  }
+  if (typeof toolChoice === 'object' && !Array.isArray(toolChoice)) {
+    const obj = toolChoice as Record<string, unknown>;
+    if (obj.type === 'function') {
+      const fn = obj.function && typeof obj.function === 'object' && !Array.isArray(obj.function)
+        ? obj.function as Record<string, unknown>
+        : undefined;
+      const name = typeof fn?.name === 'string' ? fn.name.trim() : '';
+      if (!name) {
+        return {
+          ok: false,
+          error: 'tool_choice.function.name must be a non-empty string',
+        };
+      }
+      return { ok: true, toolChoice: { type: 'tool', toolName: name } };
+    }
+    return {
+      ok: false,
+      error: 'Invalid tool_choice object; expected { type: "function", function: { name } }',
+    };
+  }
+  return {
+    ok: false,
+    error: 'Invalid tool_choice; expected string or function object',
+  };
+}
+
+/**
+ * Validate that a mapped toolChoice is usable with the given tool names.
+ * `required` / specific-tool need at least one tool; specific name must be listed.
+ */
+export function validateToolChoiceAgainstTools(
+  toolChoice: ChatToolChoice | undefined,
+  toolNames: string[],
+): string | undefined {
+  if (toolChoice == null || toolChoice === 'auto' || toolChoice === 'none') {
+    return undefined;
+  }
+  if (toolNames.length === 0) {
+    return 'tool_choice requires tools when set to "required" or a specific function';
+  }
+  if (typeof toolChoice === 'object' && toolChoice.type === 'tool') {
+    if (!toolNames.includes(toolChoice.toolName)) {
+      return `tool_choice function "${toolChoice.toolName}" is not in the request tools list`;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -340,7 +412,14 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
       max_tokens,
       max_completion_tokens,
       tools,
+      tool_choice,
     } = parsed.data;
+
+    const mappedChoice = mapOpenAIToolChoice(tool_choice);
+    if (!mappedChoice.ok) {
+      openAIError(res, 400, mappedChoice.error, 'invalid_request_error');
+      return;
+    }
 
     const chatMessages = messages.map((m) => normalizeOpenAIChatMessage(m));
 
@@ -352,17 +431,34 @@ export function registerOpenAIRoutes(app: Express, state: DaemonState): void {
     const hasParams = Object.keys(requestParams).length > 0;
 
     // Secure-by-default (DR-019): tools off unless config opts into passthrough (DR-032).
-    // Skip disk config + tool mapping when the request has no tools (common default path).
+    // Also enter when tool_choice needs tools (required / specific function) so we can 400.
     let toolOptions: ChatToolOptions = { toolMode: 'none', tools: undefined };
-    if (Array.isArray(tools) && tools.length > 0) {
+    const hasTools = Array.isArray(tools) && tools.length > 0;
+    const needsToolsForChoice = mappedChoice.toolChoice != null
+      && mappedChoice.toolChoice !== 'auto'
+      && mappedChoice.toolChoice !== 'none';
+
+    if (hasTools || needsToolsForChoice) {
       const config = loadConfig();
       const mode = resolveOpenAICompatToolsMode(String(model), config);
       if (mode === 'passthrough') {
-        const mappedTools = mapOpenAIToolsToDefinitions(tools);
+        const mappedTools = hasTools ? mapOpenAIToolsToDefinitions(tools) : [];
+        const toolNames = mappedTools.map((t) => t.name);
+        const choiceError = validateToolChoiceAgainstTools(mappedChoice.toolChoice, toolNames);
+        if (choiceError) {
+          openAIError(res, 400, choiceError, 'invalid_request_error');
+          return;
+        }
         if (mappedTools.length > 0) {
-          toolOptions = { toolMode: 'passthrough', tools: mappedTools, maxToolIterations: 1 };
+          toolOptions = {
+            toolMode: 'passthrough',
+            tools: mappedTools,
+            maxToolIterations: 1,
+            ...(mappedChoice.toolChoice != null ? { toolChoice: mappedChoice.toolChoice } : {}),
+          };
         }
       }
+      // When mode is off, ignore tools and tool_choice (DR-019 / DR-032).
     }
 
     const chatId = generateChatId();

--- a/packages/daemon/src/daemon/web/validate-body.test.ts
+++ b/packages/daemon/src/daemon/web/validate-body.test.ts
@@ -123,6 +123,21 @@ describe('parseRequestBody', () => {
       expect('user' in result.data).toBe(false);
     }
   });
+
+  it('keeps OpenAI tools and tool_choice for passthrough mapping', () => {
+    const tools = [{ type: 'function', function: { name: 'web_search', parameters: {} } }];
+    const result = parseRequestBody(PostOpenAIChatCompletionsBodySchema, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools,
+      tool_choice: 'required',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.tools).toEqual(tools);
+      expect(result.data.tool_choice).toBe('required');
+    }
+  });
 });
 
 describe('formatZodError', () => {

--- a/packages/daemon/tests/integration/openai-compat.test.ts
+++ b/packages/daemon/tests/integration/openai-compat.test.ts
@@ -607,6 +607,76 @@ describe('POST /v1/chat/completions — tool calls', () => {
     expect(body.choices[0].message.tool_calls[0].function.name).toBe('web_search');
     expect(body.choices[0].message.tool_calls[0].function.arguments).toBe('{"q":"x"}');
   });
+
+  it('forwards tool_choice none/required/specific in passthrough mode', async () => {
+    mockLoadConfigResult = { openai_compat: { tools: 'passthrough' } };
+
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+      tool_choice: 'none',
+    });
+    expect(lastChatToolOptions?.toolMode).toBe('passthrough');
+    expect(lastChatToolOptions?.toolChoice).toBe('none');
+
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+      tool_choice: 'required',
+    });
+    expect(lastChatToolOptions?.toolChoice).toBe('required');
+
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+      tool_choice: { type: 'function', function: { name: 'web_search' } },
+    });
+    expect(lastChatToolOptions?.toolChoice).toEqual({ type: 'tool', toolName: 'web_search' });
+  });
+
+  it('ignores tool_choice when openai_compat tools mode is off', async () => {
+    await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+      tool_choice: 'required',
+    });
+
+    expect(lastChatToolOptions?.toolMode).toBe('none');
+    expect(lastChatToolOptions?.toolChoice).toBeUndefined();
+  });
+
+  it('rejects invalid tool_choice and required without tools', async () => {
+    mockLoadConfigResult = { openai_compat: { tools: 'passthrough' } };
+
+    const bad = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+      tool_choice: 'forced',
+    });
+    expect(bad.statusCode).toBe(400);
+    expect(bad.body.error.type).toBe('invalid_request_error');
+
+    const missingTools = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tool_choice: 'required',
+    });
+    expect(missingTools.statusCode).toBe(400);
+
+    const unknownFn = await httpRequest('POST', `${baseUrl}/v1/chat/completions`, {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+      tools: sampleTools,
+      tool_choice: { type: 'function', function: { name: 'not_listed' } },
+    });
+    expect(unknownFn.statusCode).toBe(400);
+    expect(unknownFn.body.error.message).toMatch(/not_listed/);
+  });
 });
 
 describe('POST /v1/chat/completions — request params', () => {


### PR DESCRIPTION
## Summary
- Map OpenAI `tool_choice` (`auto` / `none` / `required` / specific function) to AI SDK `toolChoice` when `openai_compat` tools mode is `passthrough` (DR-032 / **DR-046**)
- Reject invalid `tool_choice`, `required`/specific-function without usable `tools`, and unknown function names with `400 invalid_request_error`
- Leave `tool_choice` ignored when tools mode is `off` (same secure default as `tools`)
- Document behavior in `CONFIGURATION.md` and record **DR-046** (renumbered: main already used DR-045 for VS Code webview UX)

Closes #77

## Rebase note
Rebased onto `main` to resolve `docs/decisions.md` conflict (DR number collision). Tool_choice decision is now **DR-046**.

## Test plan
- [x] Unit: `mapOpenAIToolChoice` / `validateToolChoiceAgainstTools` cover all shapes + invalid inputs
- [x] Integration: passthrough forwards `none` / `required` / specific function; off mode ignores `tool_choice`
- [x] Integration: invalid `tool_choice`, `required` without tools, and unknown function → 400
- [x] AI SDK wiring: `streamText` receives `toolChoice` when tools are present
- [ ] Manual (optional): with `openai_compat.tools: passthrough`, call `/v1/chat/completions` from Open WebUI / curl with `tool_choice: "none"` and `"required"` and confirm model behavior