### PR TITLE
chore(vscode): remove redundant view/title menu contribution

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -83,19 +83,6 @@
         }
       ]
     },
-    "menus": {
-      "view/title": [
-        {
-          "command": "abbenay.configureProvider",
-          "when": "view == abbenay.chatView",
-          "group": "navigation"
-        },
-        {
-          "command": "abbenay.openDashboard",
-          "when": "view == abbenay.chatView"
-        }
-      ]
-    },
     "configuration": {
       "title": "Abbenay Provider",
       "properties": {


### PR DESCRIPTION
## Summary
- Removes the `menus.view/title` contribution from `package.json` that added "Configure Providers" and "Open Dashboard" icons to the chat view's native title bar
- These entries are not rendered when the chat view is in the `secondarySidebar` (moved there in #95)
- Both actions remain accessible via the in-webview gear dropdown in the chat input area
## Test plan
- [ ] Verify the chat view gear menu still shows "Configure Providers" and "Open Dashboard"
- [ ] Confirm no regressions in the secondary sidebar chat layout