### PR TITLE
chore(ci): add ack workflow for PR label verification

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -1,0 +1,21 @@
+---
+# See https://github.com/ansible/team-devtools/blob/main/.github/workflows/ack.yml
+name: ack
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+# Caller must grant at least the permissions required by team-devtools ack.yml.
+permissions:
+  checks: write # required-labels / status checks
+  contents: write # needed to update release draft
+  pull-requests: write # PR approval, labels, and merge
+
+jobs:
+  ack:
+    uses: ansible/team-devtools/.github/workflows/ack.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ack.yml` reusing `ansible/team-devtools/.github/workflows/ack.yml@main`
- Enforces conventional-commit labels (`breaking`, `chore`, `feat`, `fix`) on PRs via release-drafter autolabeler
- Matches ansible-creator and other ansible devtools repos

## Commits

- `chore(ci): add ack workflow for PR label verification` — wire up team-devtools ack on pull_request_target

## Test plan

- [x] Workflow YAML matches ansible-creator upstream
- [x] `release-drafter.yml` already extends team-devtools (required for autolabeling)
- [ ] After merge: open test PR without label → ack fails; add `feat:` title → label applied → ack passes