### PR TITLE
test(web): Add unit tests for daemon web HTTP layer

### DIFF
--- a/packages/daemon/src/daemon/web/api-schemas.test.ts
+++ b/packages/daemon/src/daemon/web/api-schemas.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for HTTP API Zod request-body schemas.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  EmptyBodySchema,
+  LoginBodySchema,
+  PostChatApproveBodySchema,
+  PostChatBodySchema,
+  PostConfigBodySchema,
+  PostMcpApprovalBodySchema,
+  PostMcpConnectionDecisionBodySchema,
+  PostMcpStdioSpawnDecisionBodySchema,
+  PostOpenAIChatCompletionsBodySchema,
+  PostPolicyBodySchema,
+  PostProviderConfigureBodySchema,
+  PostSecretBodySchema,
+  PostSecretByKeyBodySchema,
+  PostSessionBodySchema,
+  PostSessionChatBodySchema,
+  DiscoverModelsBodySchema,
+} from './api-schemas.js';
+
+describe('EmptyBodySchema', () => {
+  it('accepts undefined, null, and empty object', () => {
+    expect(EmptyBodySchema.safeParse(undefined).success).toBe(true);
+    expect(EmptyBodySchema.safeParse(null).success).toBe(true);
+    expect(EmptyBodySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('rejects unexpected fields', () => {
+    expect(EmptyBodySchema.safeParse({ extra: true }).success).toBe(false);
+  });
+});
+
+describe('LoginBodySchema', () => {
+  it('accepts token or api_token', () => {
+    expect(LoginBodySchema.safeParse({ token: 'secret' }).success).toBe(true);
+    expect(LoginBodySchema.safeParse({ api_token: 'secret' }).success).toBe(true);
+  });
+
+  it('rejects unknown fields', () => {
+    expect(LoginBodySchema.safeParse({ token: 'x', password: 'y' }).success).toBe(false);
+  });
+});
+
+describe('PostProviderConfigureBodySchema', () => {
+  it('requires workspacePath when target is workspace', () => {
+    const result = PostProviderConfigureBodySchema.safeParse({
+      target: 'workspace',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('workspacePath'))).toBe(true);
+    }
+  });
+
+  it('accepts workspace target with workspacePath', () => {
+    const result = PostProviderConfigureBodySchema.safeParse({
+      target: 'workspace',
+      workspacePath: '/tmp/ws',
+      engine: 'openai',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('PostPolicyBodySchema', () => {
+  it('requires a valid virtual name and policy config', () => {
+    expect(
+      PostPolicyBodySchema.safeParse({
+        name: 'my-policy',
+        config: { tool: { tool_mode: 'auto' } },
+      }).success,
+    ).toBe(true);
+    expect(PostPolicyBodySchema.safeParse({ name: '', config: {} }).success).toBe(false);
+  });
+});
+
+describe('PostSessionBodySchema', () => {
+  it('requires model and allows optional metadata', () => {
+    const ok = PostSessionBodySchema.safeParse({
+      model: 'openai/gpt-4o',
+      title: 'Test',
+      metadata: { source: 'dashboard' },
+    });
+    expect(ok.success).toBe(true);
+    expect(PostSessionBodySchema.safeParse({ title: 'no model' }).success).toBe(false);
+  });
+});
+
+describe('PostSessionChatBodySchema', () => {
+  it('requires message content', () => {
+    expect(
+      PostSessionChatBodySchema.safeParse({ message: { content: 'hello' } }).success,
+    ).toBe(true);
+    expect(
+      PostSessionChatBodySchema.safeParse({ message: { content: '' } }).success,
+    ).toBe(false);
+  });
+});
+
+describe('PostChatApproveBodySchema', () => {
+  it('accepts allow, deny, and abort decisions', () => {
+    for (const decision of ['allow', 'deny', 'abort'] as const) {
+      expect(
+        PostChatApproveBodySchema.safeParse({ requestId: 'req-1', decision }).success,
+      ).toBe(true);
+    }
+    expect(
+      PostChatApproveBodySchema.safeParse({ requestId: 'req-1', decision: 'maybe' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('secret body schemas', () => {
+  it('PostSecretBodySchema requires key and value', () => {
+    expect(PostSecretBodySchema.safeParse({ key: 'OPENAI_API_KEY', value: 'sk-x' }).success).toBe(true);
+    expect(PostSecretBodySchema.safeParse({ key: '', value: 'x' }).success).toBe(false);
+  });
+
+  it('PostSecretByKeyBodySchema requires non-empty value', () => {
+    expect(PostSecretByKeyBodySchema.safeParse({ value: 'secret' }).success).toBe(true);
+    expect(PostSecretByKeyBodySchema.safeParse({ value: '' }).success).toBe(false);
+  });
+});
+
+describe('MCP decision schemas', () => {
+  it('PostMcpConnectionDecisionBodySchema accepts allow/deny with optional remember', () => {
+    expect(
+      PostMcpConnectionDecisionBodySchema.safeParse({ decision: 'allow', remember: true }).success,
+    ).toBe(true);
+    expect(PostMcpConnectionDecisionBodySchema.safeParse({ decision: 'nope' }).success).toBe(false);
+  });
+
+  it('PostMcpApprovalBodySchema accepts allow, deny, abort', () => {
+    expect(PostMcpApprovalBodySchema.safeParse({ decision: 'abort' }).success).toBe(true);
+  });
+
+  it('PostMcpStdioSpawnDecisionBodySchema accepts allow and deny only', () => {
+    expect(PostMcpStdioSpawnDecisionBodySchema.safeParse({ decision: 'allow' }).success).toBe(true);
+    expect(PostMcpStdioSpawnDecisionBodySchema.safeParse({ decision: 'abort' }).success).toBe(false);
+  });
+});
+
+describe('PostConfigBodySchema', () => {
+  it('accepts user location with valid config', () => {
+    const result = PostConfigBodySchema.safeParse({
+      location: 'user',
+      config: { providers: {} },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('allows omitted optional location (route handler defaults to user)', () => {
+    const result = PostConfigBodySchema.safeParse({
+      config: { providers: {} },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.location).toBeUndefined();
+    }
+  });
+
+  it('rejects invalid provider engine types', () => {
+    const result = PostConfigBodySchema.safeParse({
+      location: 'user',
+      config: { providers: { bad: { engine: 1 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unexpected top-level fields', () => {
+    expect(
+      PostConfigBodySchema.safeParse({
+        location: 'user',
+        config: { providers: {} },
+        extra: true,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('PostChatBodySchema', () => {
+  it('accepts optional generation and tool fields', () => {
+    const result = PostChatBodySchema.safeParse({
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'hello' }],
+      temperature: 0.2,
+      top_p: 0.9,
+      max_tokens: 128,
+      tools: [{ name: 'echo', description: 'echo', input_schema: {} }],
+      tool_mode: 'auto',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('requires at least one message', () => {
+    expect(
+      PostChatBodySchema.safeParse({
+        model: 'openai/gpt-4o',
+        messages: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects invalid tool_mode values', () => {
+    expect(
+      PostChatBodySchema.safeParse({
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'hi' }],
+        tool_mode: 'forced',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('PostOpenAIChatCompletionsBodySchema', () => {
+  it('accepts max_completion_tokens alias', () => {
+    const result = PostOpenAIChatCompletionsBodySchema.safeParse({
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+      max_completion_tokens: 256,
+      stream: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.max_completion_tokens).toBe(256);
+    }
+  });
+
+  it('strips unknown OpenAI client fields', () => {
+    const result = PostOpenAIChatCompletionsBodySchema.safeParse({
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+      user: 'client-1',
+      stop: ['\n'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('user' in result.data).toBe(false);
+      expect('stop' in result.data).toBe(false);
+    }
+  });
+});
+
+describe('DiscoverModelsBodySchema', () => {
+  it('accepts optional apiKey, baseUrl, and providerId', () => {
+    const result = DiscoverModelsBodySchema.safeParse({
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.example.com/v1',
+      providerId: 'openai',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown fields', () => {
+    expect(DiscoverModelsBodySchema.safeParse({ apiKey: 'x', query: 'bad' }).success).toBe(false);
+  });
+});

--- a/packages/daemon/src/daemon/web/grpc-web-control.rpc.test.ts
+++ b/packages/daemon/src/daemon/web/grpc-web-control.rpc.test.ts
@@ -1,0 +1,92 @@
+/**
+ * RPC-level tests for sendStartWebServer / sendStopWebServer (mocked gRPC transport).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockStartWebServer = vi.fn();
+const mockStopWebServer = vi.fn();
+const mockClose = vi.fn();
+
+vi.mock('@grpc/grpc-js', () => {
+  class MockAbbenay {
+    StartWebServer(...args: unknown[]) {
+      return mockStartWebServer(...args);
+    }
+    StopWebServer(...args: unknown[]) {
+      return mockStopWebServer(...args);
+    }
+    close() {
+      mockClose();
+    }
+  }
+  return {
+    loadPackageDefinition: vi.fn(() => ({
+      abbenay: { v1: { Abbenay: MockAbbenay } },
+    })),
+    credentials: {
+      createInsecure: vi.fn(() => ({ type: 'insecure' })),
+    },
+    ChannelCredentials: class {},
+  };
+});
+
+vi.mock('@grpc/proto-loader', () => ({
+  loadSync: vi.fn(() => ({})),
+}));
+
+import { sendStartWebServer, sendStopWebServer } from './grpc-web-control.js';
+
+describe('sendStartWebServer', () => {
+  beforeEach(() => {
+    mockStartWebServer.mockReset();
+    mockStopWebServer.mockReset();
+    mockClose.mockReset();
+  });
+
+  it('returns the gRPC response and closes the client', async () => {
+    const response = {
+      started: true,
+      already_running: false,
+      port: 8787,
+      url: 'http://127.0.0.1:8787',
+    };
+    mockStartWebServer.mockImplementation((_req, cb) => cb(null, response));
+
+    const result = await sendStartWebServer(8787);
+    expect(result).toEqual(response);
+    expect(mockStartWebServer).toHaveBeenCalledWith({ port: 8787 }, expect.any(Function));
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it('propagates gRPC errors and still closes the client', async () => {
+    const grpcError = new Error('daemon unreachable');
+    mockStartWebServer.mockImplementation((_req, cb) => cb(grpcError));
+
+    await expect(sendStartWebServer(8787)).rejects.toThrow('daemon unreachable');
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe('sendStopWebServer', () => {
+  beforeEach(() => {
+    mockStartWebServer.mockReset();
+    mockStopWebServer.mockReset();
+    mockClose.mockReset();
+  });
+
+  it('calls StopWebServer and closes the client', async () => {
+    mockStopWebServer.mockImplementation((_req, cb) => cb(null, {}));
+
+    await sendStopWebServer();
+    expect(mockStopWebServer).toHaveBeenCalledWith({}, expect.any(Function));
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it('propagates gRPC errors and still closes the client', async () => {
+    mockStopWebServer.mockImplementation((_req, cb) => cb(new Error('stop failed')));
+
+    await expect(sendStopWebServer()).rejects.toThrow('stop failed');
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/daemon/src/daemon/web/grpc-web-control.test.ts
+++ b/packages/daemon/src/daemon/web/grpc-web-control.test.ts
@@ -2,7 +2,7 @@
  * grpc-web-control must use secure credentials for TCP TLS (C2).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -11,7 +11,37 @@ import {
   createGrpcWebControlClient,
   grpcWebControlUsesTls,
 } from './grpc-web-control.js';
-import { createClientCredentials, generateSelfSignedPem } from '../grpc-tls.js';
+import {
+  createClientCredentials,
+  generateSelfSignedPem,
+  grpcTlsChannelOptions,
+  GRPC_TLS_DEFAULT_CN,
+} from '../grpc-tls.js';
+import { getDefaultSocketPath } from '../transport.js';
+
+const { mockAbbenayConstructor } = vi.hoisted(() => ({
+  mockAbbenayConstructor: vi.fn(),
+}));
+
+vi.mock('@grpc/grpc-js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@grpc/grpc-js')>();
+  class MockAbbenay {
+    constructor(...args: unknown[]) {
+      mockAbbenayConstructor(...args);
+    }
+    close() {}
+  }
+  return {
+    ...actual,
+    loadPackageDefinition: vi.fn(() => ({
+      abbenay: { v1: { Abbenay: MockAbbenay } },
+    })),
+  };
+});
+
+vi.mock('@grpc/proto-loader', () => ({
+  loadSync: vi.fn(() => ({})),
+}));
 
 describe('grpcWebControlUsesTls', () => {
   it('is false for default unix socket (local IPC)', () => {
@@ -39,18 +69,29 @@ describe('grpcWebControlUsesTls', () => {
 
 describe('createGrpcWebControlClient credentials', () => {
   it('constructs a client for unix (plaintext IPC)', () => {
+    mockAbbenayConstructor.mockClear();
     const client = createGrpcWebControlClient({
       address: 'unix:///tmp/abbenay-does-not-need-to-exist.sock',
     });
     expect(client).toBeDefined();
     expect(typeof client.close).toBe('function');
+    expect(mockAbbenayConstructor.mock.calls[0]?.[0]).toBe('unix:///tmp/abbenay-does-not-need-to-exist.sock');
     client.close();
   });
 
   it('constructs a client with default unix socket when address is omitted', () => {
+    mockAbbenayConstructor.mockClear();
     const client = createGrpcWebControlClient();
     expect(client).toBeDefined();
     expect(typeof client.close).toBe('function');
+    expect(mockAbbenayConstructor).toHaveBeenCalledOnce();
+    const [address, , channelOptions] = mockAbbenayConstructor.mock.calls[0] as [
+      string,
+      grpc.ChannelCredentials,
+      Record<string, string> | undefined,
+    ];
+    expect(address).toBe(`unix://${getDefaultSocketPath()}`);
+    expect(channelOptions).toBeUndefined();
     client.close();
   });
 
@@ -62,12 +103,19 @@ describe('createGrpcWebControlClient credentials', () => {
 
     try {
       expect(grpcWebControlUsesTls({ address: '127.0.0.1:1', caPath })).toBe(true);
+      mockAbbenayConstructor.mockClear();
       const client = createGrpcWebControlClient({
         address: '127.0.0.1:1',
         tls: true,
         caPath,
       });
       expect(client).toBeDefined();
+      const [, , channelOptions] = mockAbbenayConstructor.mock.calls[0] as [
+        string,
+        grpc.ChannelCredentials,
+        Record<string, string> | undefined,
+      ];
+      expect(channelOptions).toEqual(grpcTlsChannelOptions(GRPC_TLS_DEFAULT_CN));
       client.close();
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
@@ -81,6 +129,7 @@ describe('createGrpcWebControlClient credentials', () => {
     fs.writeFileSync(caPath, certPem);
 
     try {
+      mockAbbenayConstructor.mockClear();
       const client = createGrpcWebControlClient({
         address: '127.0.0.1:1',
         tls: true,
@@ -88,6 +137,12 @@ describe('createGrpcWebControlClient credentials', () => {
         sslTargetNameOverride: 'custom-grpc-host',
       });
       expect(client).toBeDefined();
+      const [, , channelOptions] = mockAbbenayConstructor.mock.calls[0] as [
+        string,
+        grpc.ChannelCredentials,
+        Record<string, string> | undefined,
+      ];
+      expect(channelOptions).toEqual(grpcTlsChannelOptions('custom-grpc-host'));
       client.close();
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/packages/daemon/src/daemon/web/grpc-web-control.test.ts
+++ b/packages/daemon/src/daemon/web/grpc-web-control.test.ts
@@ -47,6 +47,13 @@ describe('createGrpcWebControlClient credentials', () => {
     client.close();
   });
 
+  it('constructs a client with default unix socket when address is omitted', () => {
+    const client = createGrpcWebControlClient();
+    expect(client).toBeDefined();
+    expect(typeof client.close).toBe('function');
+    client.close();
+  });
+
   it('constructs a TLS client for TCP with CA path (not createInsecure-only)', () => {
     const { certPem } = generateSelfSignedPem();
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-web-ctl-'));
@@ -59,6 +66,26 @@ describe('createGrpcWebControlClient credentials', () => {
         address: '127.0.0.1:1',
         tls: true,
         caPath,
+      });
+      expect(client).toBeDefined();
+      client.close();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('constructs a TLS client with custom ssl target name override', () => {
+    const { certPem } = generateSelfSignedPem();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-web-ctl-'));
+    const caPath = path.join(tmp, 'ca.crt');
+    fs.writeFileSync(caPath, certPem);
+
+    try {
+      const client = createGrpcWebControlClient({
+        address: '127.0.0.1:1',
+        tls: true,
+        caPath,
+        sslTargetNameOverride: 'custom-grpc-host',
       });
       expect(client).toBeDefined();
       client.close();

--- a/packages/daemon/src/daemon/web/http-security.test.ts
+++ b/packages/daemon/src/daemon/web/http-security.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'node:path';
+import { getConfigDir } from '../../core/paths.js';
 import {
   isLocalhostBind,
   isLoopbackRemoteAddress,
@@ -446,7 +448,7 @@ describe('resolveHttpSecurity', () => {
 
 describe('getHttpApiTokenPath', () => {
   it('points under the config directory', () => {
-    expect(getHttpApiTokenPath()).toMatch(/http-api-token$/);
+    expect(getHttpApiTokenPath()).toBe(path.join(getConfigDir(), 'http-api-token'));
   });
 });
 
@@ -491,6 +493,22 @@ function runMiddleware(
   middleware(req as Request, res as unknown as Response, () => {
     res.nextCalled = true;
   });
+  return res;
+}
+
+function runMiddlewareChain(
+  middlewares: Array<(req: Request, res: Response, next: () => void) => void>,
+  req: Partial<Request>,
+): MockResponse {
+  const res = createMockResponse();
+  const run = (index: number) => {
+    if (index >= middlewares.length) {
+      res.nextCalled = true;
+      return;
+    }
+    middlewares[index](req as Request, res as unknown as Response, () => run(index + 1));
+  };
+  run(0);
   return res;
 }
 
@@ -577,6 +595,7 @@ describe('createAuthMiddleware', () => {
     } as Partial<Request>);
     expect(res.nextCalled).toBe(false);
     expect(res.statusCode).toBe(401);
+    expect(res.headers['www-authenticate']).toBe('Bearer');
     expect(res.body).toEqual({ error: 'Unauthorized' });
   });
 
@@ -610,6 +629,16 @@ describe('createAuthMiddleware', () => {
       },
     } as Partial<Request>);
     expect(withCsrf.nextCalled).toBe(true);
+
+    const mismatched = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'POST',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}; ${CSRF_COOKIE}=${encodeURIComponent(csrf)}`,
+        [CSRF_HEADER]: 'other-value',
+      },
+    } as Partial<Request>);
+    expect(mismatched.nextCalled).toBe(false);
+    expect(mismatched.statusCode).toBe(403);
   });
 
   it('accepts cookie auth on POST when Referer matches same-origin Host', () => {
@@ -624,16 +653,18 @@ describe('createAuthMiddleware', () => {
     expect(res.nextCalled).toBe(true);
   });
 
-  it('accepts cookie auth on POST when Origin matches Host via x-forwarded-proto', () => {
-    const res = runMiddleware(createAuthMiddleware(token, ['https://app.example.com']), {
-      method: 'POST',
-      headers: {
-        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
-        host: 'abbenay.example.com',
-        origin: 'https://abbenay.example.com',
-        'x-forwarded-proto': 'https',
-      },
-    } as Partial<Request>);
+  it('accepts cookie auth on POST when Origin is in CORS allowlist (CORS then auth chain)', () => {
+    const productionOrigins = ['http://127.0.0.1:8787', 'https://abbenay.example.com'];
+    const res = runMiddlewareChain(
+      [createCorsMiddleware(productionOrigins), createAuthMiddleware(token, productionOrigins)],
+      {
+        method: 'POST',
+        headers: {
+          cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
+          origin: 'https://abbenay.example.com',
+        },
+      } as Partial<Request>,
+    );
     expect(res.nextCalled).toBe(true);
   });
 

--- a/packages/daemon/src/daemon/web/http-security.test.ts
+++ b/packages/daemon/src/daemon/web/http-security.test.ts
@@ -14,12 +14,19 @@ import {
   resolveHttpApiToken,
   resolveHttpHost,
   resolveCorsOrigins,
+  resolveHttpSecurity,
+  getHttpApiTokenPath,
   extractBearerToken,
   getCookie,
   timingSafeEqualString,
   cookieSecureFromRequest,
   setAuthCookies,
   clearAuthCookies,
+  createCorsMiddleware,
+  createAuthMiddleware,
+  API_TOKEN_COOKIE,
+  CSRF_COOKIE,
+  CSRF_HEADER,
 } from './http-security.js';
 import {
   ownerIdFromHttpToken,
@@ -418,5 +425,228 @@ describe('session owner helpers', () => {
 
   it('assertSessionOwner throws not-found for wrong owner', () => {
     expect(() => assertSessionOwner({ id: 'abc', owner: 'a' }, 'b')).toThrow('Session not found: abc');
+  });
+});
+
+describe('resolveHttpSecurity', () => {
+  it('combines token, host, cors, and auth settings', () => {
+    const security = resolveHttpSecurity(8787, '127.0.0.1', {
+      apiToken: 'combined-token',
+      skipConfig: true,
+      corsOrigins: ['https://app.example.com'],
+    });
+    expect(security.apiToken).toBe('combined-token');
+    expect(security.host).toBe('127.0.0.1');
+    expect(security.authEnabled).toBe(true);
+    expect(security.tokenSource).toBe('options');
+    expect(security.corsOrigins).toContain('http://127.0.0.1:8787');
+    expect(security.corsOrigins).toContain('https://app.example.com');
+  });
+});
+
+describe('getHttpApiTokenPath', () => {
+  it('points under the config directory', () => {
+    expect(getHttpApiTokenPath()).toMatch(/http-api-token$/);
+  });
+});
+
+type MockResponse = {
+  statusCode: number;
+  headers: Record<string, string | string[] | undefined>;
+  body?: unknown;
+  nextCalled: boolean;
+  setHeader(name: string, value: string): void;
+  status(code: number): MockResponse;
+  json(body: unknown): void;
+  sendStatus(code: number): void;
+};
+
+function createMockResponse(): MockResponse {
+  const res: MockResponse = {
+    statusCode: 200,
+    headers: {},
+    nextCalled: false,
+    setHeader(name, value) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+    },
+    sendStatus(code) {
+      this.statusCode = code;
+    },
+  };
+  return res;
+}
+
+function runMiddleware(
+  middleware: (req: Request, res: Response, next: () => void) => void,
+  req: Partial<Request>,
+): MockResponse {
+  const res = createMockResponse();
+  middleware(req as Request, res as unknown as Response, () => {
+    res.nextCalled = true;
+  });
+  return res;
+}
+
+describe('createCorsMiddleware', () => {
+  const allowlist = ['http://127.0.0.1:8787', 'https://app.example.com'];
+
+  it('allows listed origins and sets CORS headers', () => {
+    const res = runMiddleware(createCorsMiddleware(allowlist), {
+      method: 'GET',
+      headers: { origin: 'https://app.example.com', host: '127.0.0.1:8787' },
+      path: '/api/health',
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com');
+    expect(res.headers['access-control-allow-credentials']).toBe('true');
+  });
+
+  it('rejects foreign origins on actual requests', () => {
+    const res = runMiddleware(createCorsMiddleware(allowlist), {
+      method: 'GET',
+      headers: { origin: 'https://evil.example.com', host: '127.0.0.1:8787' },
+      path: '/api/health',
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'Origin not allowed' });
+  });
+
+  it('rejects foreign origins on OPTIONS preflight', () => {
+    const res = runMiddleware(createCorsMiddleware(allowlist), {
+      method: 'OPTIONS',
+      headers: { origin: 'https://evil.example.com' },
+      path: '/api/health',
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('responds 204 to OPTIONS for allowed origins', () => {
+    const res = runMiddleware(createCorsMiddleware(allowlist), {
+      method: 'OPTIONS',
+      headers: { origin: 'http://127.0.0.1:8787' },
+      path: '/api/health',
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('allows requests without Origin header (non-browser clients)', () => {
+    const res = runMiddleware(createCorsMiddleware(allowlist), {
+      method: 'GET',
+      headers: { host: '127.0.0.1:8787' },
+      path: '/api/health',
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+  });
+});
+
+describe('createAuthMiddleware', () => {
+  const token = 'test-api-token';
+  const corsOrigins = ['http://127.0.0.1:8787'];
+
+  it('passes through when auth is disabled', () => {
+    const res = runMiddleware(createAuthMiddleware(token, corsOrigins, false), {
+      method: 'GET',
+      headers: {},
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('accepts valid Bearer token', () => {
+    const res = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+  });
+
+  it('rejects missing credentials with 401', () => {
+    const res = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'GET',
+      headers: {},
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('accepts cookie auth on GET without CSRF', () => {
+    const res = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'GET',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
+      },
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+  });
+
+  it('requires CSRF or allowlisted origin for cookie auth on POST', () => {
+    const csrf = 'csrf-token-value';
+    const withoutCsrf = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'POST',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
+        host: '127.0.0.1:8787',
+      },
+    } as Partial<Request>);
+    expect(withoutCsrf.nextCalled).toBe(false);
+    expect(withoutCsrf.statusCode).toBe(403);
+
+    const withCsrf = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'POST',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}; ${CSRF_COOKIE}=${encodeURIComponent(csrf)}`,
+        [CSRF_HEADER]: csrf,
+      },
+    } as Partial<Request>);
+    expect(withCsrf.nextCalled).toBe(true);
+  });
+
+  it('accepts cookie auth on POST when Referer matches same-origin Host', () => {
+    const res = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'POST',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
+        host: '127.0.0.1:8787',
+        referer: 'http://127.0.0.1:8787/dashboard',
+      },
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+  });
+
+  it('accepts cookie auth on POST when Origin matches Host via x-forwarded-proto', () => {
+    const res = runMiddleware(createAuthMiddleware(token, ['https://app.example.com']), {
+      method: 'POST',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
+        host: 'abbenay.example.com',
+        origin: 'https://abbenay.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(true);
+  });
+
+  it('still requires CSRF when Referer is not a valid URL', () => {
+    const res = runMiddleware(createAuthMiddleware(token, corsOrigins), {
+      method: 'POST',
+      headers: {
+        cookie: `${API_TOKEN_COOKIE}=${encodeURIComponent(token)}`,
+        referer: 'not-a-valid-url',
+      },
+    } as Partial<Request>);
+    expect(res.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'CSRF validation failed' });
   });
 });

--- a/packages/daemon/src/daemon/web/openai-compat.test.ts
+++ b/packages/daemon/src/daemon/web/openai-compat.test.ts
@@ -6,7 +6,9 @@
  * and complete response building.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
+import * as http from 'node:http';
 import {
   mapModelToOpenAI,
   mapFinishReason,
@@ -19,11 +21,16 @@ import {
   validateToolChoiceAgainstTools,
   normalizeOpenAIToolCalls,
   normalizeOpenAIChatMessage,
+  coerceToolParametersSchema,
+  registerOpenAIRoutes,
   type StreamChunkOptions,
 } from './openai-compat.js';
+import * as configModule from '../../core/config.js';
 import type { ModelInfo } from '../../core/state.js';
 import type { ChatChunk } from '../../core/engines.js';
+import type { ChatToolOptions } from '../../core/state.js';
 import type { ConfigFile } from '../../core/config.js';
+import type { DaemonState } from '../state.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- test assertions need flexible access to untyped response shapes */
 
@@ -553,5 +560,282 @@ describe('validateToolChoiceAgainstTools', () => {
       ['web_search'],
     )).toBeUndefined();
     expect(validateToolChoiceAgainstTools('required', ['web_search'])).toBeUndefined();
+  });
+});
+
+describe('coerceToolParametersSchema', () => {
+  it('normalizes object schemas with default type and properties', () => {
+    expect(coerceToolParametersSchema({
+      properties: { q: { type: 'string' } },
+    })).toEqual({
+      type: 'object',
+      properties: { q: { type: 'string' } },
+    });
+  });
+
+  it('returns empty object schema for invalid parameters', () => {
+    expect(coerceToolParametersSchema(null)).toEqual({ type: 'object', properties: {} });
+    expect(coerceToolParametersSchema('bad')).toEqual({ type: 'object', properties: {} });
+  });
+});
+
+async function startOpenAIApp(state: DaemonState): Promise<{ server: http.Server; baseUrl: string }> {
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  registerOpenAIRoutes(app, state);
+  const server = await new Promise<http.Server>((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function stopOpenAIApp(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+function openaiRequest(
+  baseUrl: string,
+  method: string,
+  urlPath: string,
+  body?: unknown,
+): Promise<{ statusCode: number; body: unknown; raw: string }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, baseUrl);
+    const postData = body === undefined ? undefined : JSON.stringify(body);
+    const req = http.request(
+      url,
+      {
+        method,
+        headers: postData
+          ? {
+              'content-type': 'application/json',
+              'content-length': Buffer.byteLength(postData),
+            }
+          : undefined,
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          let parsed: unknown = raw;
+          if ((res.headers['content-type'] || '').includes('application/json')) {
+            try { parsed = JSON.parse(raw); } catch { /* keep raw */ }
+          }
+          resolve({ statusCode: res.statusCode || 0, body: parsed, raw });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (postData) req.write(postData);
+    req.end();
+  });
+}
+
+function createOpenAIState(
+  chatChunks: ChatChunk[],
+  listModelsImpl?: () => Promise<ModelInfo[]>,
+): DaemonState {
+  return {
+    async listModels() {
+      if (listModelsImpl) return listModelsImpl();
+      return [{
+        id: 'openai/gpt-4o',
+        name: 'gpt-4o',
+        engineModelId: 'gpt-4o',
+        provider: 'openai',
+        engine: 'openai',
+        contextWindow: 128000,
+      } as ModelInfo];
+    },
+    async *chat() {
+      for (const chunk of chatChunks) {
+        yield chunk;
+      }
+    },
+  } as unknown as DaemonState;
+}
+
+describe('registerOpenAIRoutes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GET /v1/models returns OpenAI-formatted models', async () => {
+    const { server, baseUrl } = await startOpenAIApp(createOpenAIState([]));
+    try {
+      const res = await openaiRequest(baseUrl, 'GET', '/v1/models');
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        object: 'list',
+        data: [{ id: 'openai/gpt-4o', object: 'model', owned_by: 'openai' }],
+      });
+    } finally {
+      await stopOpenAIApp(server);
+    }
+  });
+
+  it('GET /v1/models returns 500 when listModels throws', async () => {
+    const state = createOpenAIState([], async () => {
+      throw new Error('list failed');
+    });
+    const { server, baseUrl } = await startOpenAIApp(state);
+    try {
+      const res = await openaiRequest(baseUrl, 'GET', '/v1/models');
+      expect(res.statusCode).toBe(500);
+      expect((res.body as { error: { message: string } }).error.message).toBe('list failed');
+    } finally {
+      await stopOpenAIApp(server);
+    }
+  });
+
+  it('POST /v1/chat/completions returns a non-streaming completion', async () => {
+    const state = createOpenAIState([
+      { type: 'text', text: 'Hello' },
+      { type: 'done', finishReason: 'stop' },
+    ]);
+    const { server, baseUrl } = await startOpenAIApp(state);
+    try {
+      const res = await openaiRequest(baseUrl, 'POST', '/v1/chat/completions', {
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+        temperature: 0.2,
+        max_tokens: 64,
+      });
+      expect(res.statusCode).toBe(200);
+      expect((res.body as { choices: Array<{ message: { content: string } }> }).choices[0].message.content)
+        .toBe('Hello');
+    } finally {
+      await stopOpenAIApp(server);
+    }
+  });
+
+  it('POST /v1/chat/completions streams SSE chunks', async () => {
+    const state = createOpenAIState([
+      { type: 'text', text: 'Hi' },
+      {
+        type: 'tool',
+        name: 'search',
+        state: 'running',
+        call: { params: { q: 'x' }, result: undefined },
+        done: false,
+      },
+      { type: 'done', finishReason: 'tool-calls' },
+    ]);
+    const { server, baseUrl } = await startOpenAIApp(state);
+    try {
+      const url = new URL('/v1/chat/completions', baseUrl);
+      const raw = await new Promise<string>((resolve, reject) => {
+        const postData = JSON.stringify({
+          model: 'openai/gpt-4o',
+          messages: [{ role: 'user', content: 'search' }],
+          stream: true,
+        });
+        const req = http.request(url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(postData),
+          },
+        }, (res) => {
+          let buf = '';
+          res.on('data', (chunk) => { buf += chunk; });
+          res.on('end', () => resolve(buf));
+        });
+        req.on('error', reject);
+        req.write(postData);
+        req.end();
+      });
+      expect(raw).toContain('chat.completion.chunk');
+      expect(raw).toContain('tool_calls');
+      expect(raw).toContain('[DONE]');
+    } finally {
+      await stopOpenAIApp(server);
+    }
+  });
+
+  it('returns 400 for invalid request bodies and tool_choice', async () => {
+    const { server, baseUrl } = await startOpenAIApp(createOpenAIState([]));
+    try {
+      const invalidBody = await openaiRequest(baseUrl, 'POST', '/v1/chat/completions', {
+        model: 'openai/gpt-4o',
+        messages: [],
+      });
+      expect(invalidBody.statusCode).toBe(400);
+
+      const invalidChoice = await openaiRequest(baseUrl, 'POST', '/v1/chat/completions', {
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+        tool_choice: 'forced',
+      });
+      expect(invalidChoice.statusCode).toBe(400);
+    } finally {
+      await stopOpenAIApp(server);
+    }
+  });
+
+  it('honors passthrough tools when config enables them', async () => {
+    vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      openai_compat: { tools: 'passthrough' },
+      providers: {},
+    } as ConfigFile);
+
+    let capturedToolOptions: ChatToolOptions | undefined;
+    const state = {
+      async listModels() {
+        return [{
+          id: 'openai/gpt-4o',
+          name: 'gpt-4o',
+          engineModelId: 'gpt-4o',
+          provider: 'openai',
+          engine: 'openai',
+          contextWindow: 128000,
+        } as ModelInfo];
+      },
+      async *chat(
+        _model: string,
+        _messages: Array<{ role: string; content: string }>,
+        _params?: Record<string, unknown>,
+        toolOptions?: ChatToolOptions,
+      ) {
+        capturedToolOptions = toolOptions;
+        yield { type: 'done', finishReason: 'stop' } as ChatChunk;
+      },
+    } as unknown as DaemonState;
+
+    const { server, baseUrl } = await startOpenAIApp(state);
+    try {
+      const res = await openaiRequest(baseUrl, 'POST', '/v1/chat/completions', {
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+        tools: [{
+          type: 'function',
+          function: { name: 'web_search', parameters: { type: 'object', properties: {} } },
+        }],
+        tool_choice: 'required',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(capturedToolOptions?.toolMode).toBe('passthrough');
+      expect(capturedToolOptions?.tools?.map((t) => t.name)).toEqual(['web_search']);
+      expect(capturedToolOptions?.toolChoice).toBe('required');
+    } finally {
+      await stopOpenAIApp(server);
+    }
+  });
+
+  it('returns 500 when chat yields an error chunk', async () => {
+    const state = createOpenAIState([{ type: 'error', error: 'model failed' }]);
+    const { server, baseUrl } = await startOpenAIApp(state);
+    try {
+      const res = await openaiRequest(baseUrl, 'POST', '/v1/chat/completions', {
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+      expect(res.statusCode).toBe(500);
+      expect((res.body as { error: { message: string } }).error.message).toBe('model failed');
+    } finally {
+      await stopOpenAIApp(server);
+    }
   });
 });

--- a/packages/daemon/src/daemon/web/server.test.ts
+++ b/packages/daemon/src/daemon/web/server.test.ts
@@ -24,15 +24,28 @@ import { API_TOKEN_COOKIE, CSRF_COOKIE } from './http-security.js';
 
 const TEST_TOKEN = 'unit-test-web-api-token';
 
-const tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-server-unit-config-'));
+const { tmpConfigDir, configOverrides } = vi.hoisted(() => {
+  const nodeFs = require('node:fs') as typeof import('node:fs');
+  const nodeOs = require('node:os') as typeof import('node:os');
+  const nodePath = require('node:path') as typeof import('node:path');
+  return {
+    tmpConfigDir: nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'abbenay-server-unit-config-')),
+    configOverrides: { userConfigPath: null as string | null },
+  };
+});
+
 vi.mock('../../core/paths.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../core/paths.js')>();
   return {
     ...actual,
-    getUserConfigPath: () => path.join(tmpConfigDir, 'config.yaml'),
+    getUserConfigPath: () => configOverrides.userConfigPath ?? path.join(tmpConfigDir, 'config.yaml'),
     getWorkspaceConfigPath: (wsPath: string) => path.join(wsPath, '.config', 'abbenay', 'config.yaml'),
     getConfigDir: () => tmpConfigDir,
   };
+});
+
+afterAll(() => {
+  fs.rmSync(tmpConfigDir, { recursive: true, force: true });
 });
 
 function getEphemeralPort(host = '127.0.0.1'): Promise<number> {
@@ -829,8 +842,10 @@ describe('createWebApp routes', () => {
   });
 
   it('GET /api/mcp-servers includes configured servers from config file', async () => {
-    const configPath = path.join(tmpConfigDir, 'config.yaml');
+    const isolatedConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-mcp-servers-config-'));
+    const configPath = path.join(isolatedConfigDir, 'config.yaml');
     fs.writeFileSync(configPath, 'mcp_servers:\n  myserver:\n    transport: stdio\n    enabled: true\n');
+    configOverrides.userConfigPath = configPath;
     const mcpState = createMockState({
       sessionsDir,
       mcpPoolStatuses: [{
@@ -850,7 +865,8 @@ describe('createWebApp routes', () => {
       expect(servers.some((s) => s.id === 'orphan')).toBe(true);
     } finally {
       await stopTestApp(mcpServer);
-      if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+      configOverrides.userConfigPath = null;
+      fs.rmSync(isolatedConfigDir, { recursive: true, force: true });
     }
   });
 
@@ -984,8 +1000,11 @@ describe('createWebApp error paths', () => {
   it('GET /api/providers returns 500 when listProviders throws', async () => {
     const state = createMockState({ sessionsDir, throwOnListProviders: true });
     const { httpServer, baseUrl } = await startTestApp(state);
-    const res = await httpRequest(baseUrl, 'GET', '/api/providers');
-    expect(res.statusCode).toBe(500);
-    await stopTestApp(httpServer);
+    try {
+      const res = await httpRequest(baseUrl, 'GET', '/api/providers');
+      expect(res.statusCode).toBe(500);
+    } finally {
+      await stopTestApp(httpServer);
+    }
   });
 });

--- a/packages/daemon/src/daemon/web/server.test.ts
+++ b/packages/daemon/src/daemon/web/server.test.ts
@@ -24,28 +24,38 @@ import { API_TOKEN_COOKIE, CSRF_COOKIE } from './http-security.js';
 
 const TEST_TOKEN = 'unit-test-web-api-token';
 
-const { tmpConfigDir, configOverrides } = vi.hoisted(() => {
-  const nodeFs = require('node:fs') as typeof import('node:fs');
-  const nodeOs = require('node:os') as typeof import('node:os');
-  const nodePath = require('node:path') as typeof import('node:path');
-  return {
-    tmpConfigDir: nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'abbenay-server-unit-config-')),
-    configOverrides: { userConfigPath: null as string | null },
-  };
-});
+const hoisted = vi.hoisted(() => ({
+  configOverrides: { userConfigPath: null as string | null },
+  tmpConfigDir: undefined as string | undefined,
+}));
 
 vi.mock('../../core/paths.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../core/paths.js')>();
+  const nodePath = await import('node:path');
+  const nodeFs = await import('node:fs');
+  const nodeOs = await import('node:os');
+
+  const ensureConfigDir = () => {
+    if (!hoisted.tmpConfigDir) {
+      hoisted.tmpConfigDir = nodeFs.mkdtempSync(
+        nodePath.join(nodeOs.tmpdir(), 'abbenay-server-unit-config-'),
+      );
+    }
+    return hoisted.tmpConfigDir;
+  };
+
   return {
     ...actual,
-    getUserConfigPath: () => configOverrides.userConfigPath ?? path.join(tmpConfigDir, 'config.yaml'),
-    getWorkspaceConfigPath: (wsPath: string) => path.join(wsPath, '.config', 'abbenay', 'config.yaml'),
-    getConfigDir: () => tmpConfigDir,
+    getUserConfigPath: () => hoisted.configOverrides.userConfigPath ?? nodePath.join(ensureConfigDir(), 'config.yaml'),
+    getWorkspaceConfigPath: (wsPath: string) => nodePath.join(wsPath, '.config', 'abbenay', 'config.yaml'),
+    getConfigDir: () => ensureConfigDir(),
   };
 });
 
 afterAll(() => {
-  fs.rmSync(tmpConfigDir, { recursive: true, force: true });
+  if (hoisted.tmpConfigDir) {
+    fs.rmSync(hoisted.tmpConfigDir, { recursive: true, force: true });
+  }
 });
 
 function getEphemeralPort(host = '127.0.0.1'): Promise<number> {
@@ -845,7 +855,7 @@ describe('createWebApp routes', () => {
     const isolatedConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-mcp-servers-config-'));
     const configPath = path.join(isolatedConfigDir, 'config.yaml');
     fs.writeFileSync(configPath, 'mcp_servers:\n  myserver:\n    transport: stdio\n    enabled: true\n');
-    configOverrides.userConfigPath = configPath;
+    hoisted.configOverrides.userConfigPath = configPath;
     const mcpState = createMockState({
       sessionsDir,
       mcpPoolStatuses: [{
@@ -865,7 +875,7 @@ describe('createWebApp routes', () => {
       expect(servers.some((s) => s.id === 'orphan')).toBe(true);
     } finally {
       await stopTestApp(mcpServer);
-      configOverrides.userConfigPath = null;
+      hoisted.configOverrides.userConfigPath = null;
       fs.rmSync(isolatedConfigDir, { recursive: true, force: true });
     }
   });

--- a/packages/daemon/src/daemon/web/server.test.ts
+++ b/packages/daemon/src/daemon/web/server.test.ts
@@ -1,0 +1,991 @@
+/**
+ * Unit tests for embedded web server lifecycle and createWebApp routes.
+ */
+
+import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import * as http from 'node:http';
+import * as net from 'node:net';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  createWebApp,
+  startEmbeddedWebServer,
+  stopEmbeddedWebServer,
+  isWebServerRunning,
+  getWebServerPort,
+} from './server.js';
+import type { DaemonState } from '../state.js';
+import type { ConnectedClient } from '../state.js';
+import type { ProviderInfo, ModelInfo, ChatToolOptions } from '../../core/state.js';
+import type { SecretStore } from '../../core/secrets.js';
+import { SessionStore } from '../../core/session-store.js';
+import { API_TOKEN_COOKIE, CSRF_COOKIE } from './http-security.js';
+
+const TEST_TOKEN = 'unit-test-web-api-token';
+
+const tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-server-unit-config-'));
+vi.mock('../../core/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/paths.js')>();
+  return {
+    ...actual,
+    getUserConfigPath: () => path.join(tmpConfigDir, 'config.yaml'),
+    getWorkspaceConfigPath: (wsPath: string) => path.join(wsPath, '.config', 'abbenay', 'config.yaml'),
+    getConfigDir: () => tmpConfigDir,
+  };
+});
+
+function getEphemeralPort(host = '127.0.0.1'): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, host, () => {
+      const addr = server.address();
+      if (typeof addr !== 'object' || addr === null || !addr.port) {
+        server.close(() => reject(new Error(`Failed to allocate ephemeral port on ${host}`)));
+        return;
+      }
+      const port = addr.port;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+function createSecretStore(overrides?: Partial<SecretStore>): SecretStore {
+  return {
+    async get() { return null; },
+    async set() {},
+    async delete() { return true; },
+    async has() { return false; },
+    ...overrides,
+  };
+}
+
+interface MockStateOptions {
+  sessionsDir: string;
+  secretStore?: SecretStore;
+  providers?: ProviderInfo[];
+  models?: ModelInfo[];
+  discoverModels?: ModelInfo[];
+  resolveCredentials?: { apiKey?: string; baseUrl?: string };
+  chatChunks?: Array<
+    | { type: 'text'; text: string }
+    | { type: 'tool'; name: string; state: string; done: boolean; call?: { params: unknown; result: unknown } }
+    | { type: 'error'; error: string }
+    | { type: 'done'; finishReason: string }
+  >;
+  onToolApprovalNeeded?: (requestId: string, toolName: string, args: unknown) => void;
+  clients?: ConnectedClient[];
+  vscodeWorkspaces?: string[];
+  vscodeConnectionIds?: string[];
+  requestWorkspaceFails?: boolean;
+  mcpRunning?: boolean;
+  mcpSessions?: Array<{ sessionId: string; clientName: string }>;
+  rememberedClients?: string[];
+  toolRegistryTools?: Array<{
+    namespacedName: string;
+    originalName: string;
+    source: string;
+    sourceType: string;
+    description: string;
+  }>;
+  mcpPoolStatuses?: Array<{
+    id: string;
+    connected: boolean;
+    error?: string;
+    toolCount?: number;
+    config?: { transport?: string; enabled?: boolean };
+  }>;
+  throwOnListProviders?: boolean;
+}
+
+function createMockState(opts: MockStateOptions): DaemonState {
+  const {
+    sessionsDir,
+    secretStore = createSecretStore(),
+    providers = [],
+    models = [],
+    discoverModels = [],
+    resolveCredentials = {},
+    chatChunks = [{ type: 'done', finishReason: 'stop' }],
+    onToolApprovalNeeded,
+    clients = [],
+    vscodeWorkspaces = [],
+    vscodeConnectionIds = [],
+    requestWorkspaceFails = false,
+    mcpRunning = false,
+    mcpSessions = [],
+    rememberedClients = [],
+    toolRegistryTools = [],
+    mcpPoolStatuses = [],
+    throwOnListProviders = false,
+  } = opts;
+
+  let running = mcpRunning;
+
+  return {
+    version: '0.1.0-test',
+    startedAt: new Date(),
+    secretStore,
+    sessionStore: new SessionStore(sessionsDir),
+    clientCount: clients.length,
+    getClients() { return clients; },
+    getConnectedClients() { return clients; },
+    getVSCodeWorkspaces() { return vscodeWorkspaces; },
+    getVSCodeConnectionIds() { return vscodeConnectionIds; },
+    async requestWorkspace() {
+      if (requestWorkspaceFails) throw new Error('timeout');
+    },
+    notifyModelsChanged() {},
+    async refreshMcpConnections() {},
+    async listProviders() {
+      if (throwOnListProviders) throw new Error('provider list failed');
+      return providers;
+    },
+    async listModels() { return models; },
+    async discoverModels() { return discoverModels; },
+    async resolveProviderCredentials() { return resolveCredentials; },
+    async *chat(
+      _model: string,
+      _messages: Array<{ role: string; content: string }>,
+      _params?: Record<string, unknown>,
+      toolOptions?: ChatToolOptions,
+    ) {
+      if (onToolApprovalNeeded && toolOptions?.onToolApprovalNeeded) {
+        const decision = await toolOptions.onToolApprovalNeeded('req-1', 'my_tool', { x: 1 });
+        if (decision === 'abort') {
+          yield { type: 'done' as const, finishReason: 'stop' };
+          return;
+        }
+      }
+      for (const chunk of chatChunks) {
+        yield chunk;
+      }
+    },
+    getStatus() {
+      return { version: '0.1.0-test', uptime: 0, providers: 0, models: 0 };
+    },
+    mcpClientPool: {
+      getAllStatus() { return mcpPoolStatuses; },
+      getStatuses() { return mcpPoolStatuses; },
+      getRecentDenials() { return [{ serverId: 'srv', command: 'echo', at: Date.now() }]; },
+      applySecurityConfig() {},
+      setStdioSpawnApprovalHandler() {},
+      setListenEndpoints() {},
+      async reconnect() {},
+    },
+    toolRegistry: {
+      listTools() { return []; },
+      getAll() { return toolRegistryTools; },
+      get size() { return toolRegistryTools.length; },
+    },
+    mcpServer: {
+      get isRunning() { return running; },
+      getStatus() { return { running, transport: 'stdio' as const }; },
+      configure() {},
+      listSessions() { return mcpSessions; },
+      listRememberedClients() { return [...rememberedClients]; },
+      rememberClient(name: string) { rememberedClients.push(name); },
+      forgetClient(name: string) {
+        const idx = rememberedClients.indexOf(name);
+        if (idx >= 0) rememberedClients.splice(idx, 1);
+      },
+      async revokeSession(id: string) { return mcpSessions.some((s) => s.sessionId === id); },
+      async start() { running = true; },
+      async stop() { running = false; },
+    },
+  } as unknown as DaemonState;
+}
+
+type HttpResult = {
+  statusCode: number;
+  body: unknown;
+  headers: http.IncomingHttpHeaders;
+  raw: string;
+};
+
+function httpRequest(
+  baseUrl: string,
+  method: string,
+  urlPath: string,
+  opts?: {
+    token?: string | null;
+    headers?: Record<string, string>;
+    body?: unknown;
+    form?: Record<string, string>;
+    cookie?: string;
+  },
+): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, baseUrl);
+    const headers: Record<string, string> = { ...(opts?.headers ?? {}) };
+    if (opts?.cookie) headers.cookie = opts.cookie;
+    if (opts?.token !== null) {
+      headers.authorization = `Bearer ${opts?.token ?? TEST_TOKEN}`;
+    }
+
+    let postData: string | undefined;
+    if (opts?.form) {
+      postData = new URLSearchParams(opts.form).toString();
+      headers['content-type'] = 'application/x-www-form-urlencoded';
+    } else if (opts?.body !== undefined) {
+      postData = JSON.stringify(opts.body);
+      headers['content-type'] = 'application/json';
+    }
+
+    const req = http.request(
+      url,
+      { method, headers },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          let body: unknown = data;
+          try { body = JSON.parse(data); } catch { /* raw */ }
+          resolve({
+            statusCode: res.statusCode || 0,
+            body,
+            headers: res.headers,
+            raw: data,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (postData) req.write(postData);
+    req.end();
+  });
+}
+
+function postSSE(
+  baseUrl: string,
+  urlPath: string,
+  body: unknown,
+): Promise<{ statusCode: number; events: unknown[]; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, baseUrl);
+    const postData = JSON.stringify(body);
+    const req = http.request(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(postData),
+        },
+      },
+      (res) => {
+        let buf = '';
+        const events: unknown[] = [];
+        res.on('data', (chunk) => {
+          buf += chunk;
+          const parts = buf.split('\n\n');
+          buf = parts.pop() || '';
+          for (const part of parts) {
+            const line = part.split('\n').find((l) => l.startsWith('data: '));
+            if (!line) continue;
+            const payload = line.slice(6);
+            if (payload === '[DONE]') {
+              events.push({ type: 'done_signal' });
+              continue;
+            }
+            try { events.push(JSON.parse(payload)); } catch { /* ignore */ }
+          }
+        });
+        res.on('end', () => resolve({ statusCode: res.statusCode || 0, events, headers: res.headers }));
+      },
+    );
+    req.on('error', reject);
+    req.write(postData);
+    req.end();
+  });
+}
+
+async function startTestApp(state: DaemonState, options?: Parameters<typeof createWebApp>[1]) {
+  const app = createWebApp(state, {
+    apiToken: TEST_TOKEN,
+    skipConfig: true,
+    host: '127.0.0.1',
+    ...options,
+  });
+  const httpServer = await new Promise<http.Server>((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+  const addr = httpServer.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  return { app, httpServer, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function stopTestApp(httpServer: http.Server) {
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+}
+
+describe('embedded web server lifecycle', () => {
+  let sessionsDir: string;
+  let state: DaemonState;
+
+  beforeAll(() => {
+    sessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-web-unit-'));
+    state = createMockState({ sessionsDir });
+  });
+
+  afterAll(() => {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await stopEmbeddedWebServer();
+  });
+
+  it('reports not running before start', () => {
+    expect(isWebServerRunning()).toBe(false);
+    expect(getWebServerPort()).toBeNull();
+  });
+
+  it('tracks running state and port after start/stop', async () => {
+    const port = await getEphemeralPort();
+    const started = await startEmbeddedWebServer(state, port, '127.0.0.1', {
+      apiToken: TEST_TOKEN,
+      skipConfig: true,
+      authEnabled: true,
+    });
+
+    expect(isWebServerRunning()).toBe(true);
+    expect(getWebServerPort()).toBe(port);
+    expect(started.port).toBe(port);
+    expect(started.url).toBe(`http://127.0.0.1:${port}`);
+    expect(started.security.apiToken).toBe(TEST_TOKEN);
+
+    await stopEmbeddedWebServer();
+    expect(isWebServerRunning()).toBe(false);
+    expect(getWebServerPort()).toBeNull();
+  });
+
+  it('returns the existing server when start is called twice', async () => {
+    const port = await getEphemeralPort();
+    const first = await startEmbeddedWebServer(state, port, '127.0.0.1', {
+      apiToken: TEST_TOKEN,
+      skipConfig: true,
+    });
+    const second = await startEmbeddedWebServer(state, 9999, '127.0.0.1', {
+      apiToken: TEST_TOKEN,
+      skipConfig: true,
+    });
+
+    expect(second.port).toBe(first.port);
+    expect(second.app).toBe(first.app);
+    expect(second.security).toBe(first.security);
+  });
+
+  it('warns when auth is disabled on start', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const port = await getEphemeralPort();
+    await startEmbeddedWebServer(state, port, '127.0.0.1', {
+      apiToken: TEST_TOKEN,
+      skipConfig: true,
+      authEnabled: false,
+    });
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('authentication is DISABLED'))).toBe(true);
+    warnSpy.mockRestore();
+    await stopEmbeddedWebServer();
+  });
+});
+
+describe('createWebApp routes', () => {
+  let sessionsDir: string;
+  let httpServer: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    sessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-web-app-'));
+    const state = createMockState({
+      sessionsDir,
+      providers: [{
+        id: 'openai',
+        engine: 'openai',
+        configured: true,
+        healthy: true,
+        requiresKey: true,
+        defaultBaseUrl: 'https://api.openai.com',
+        baseUrl: 'https://api.openai.com',
+      } as ProviderInfo],
+      models: [{
+        id: 'openai/gpt-4o',
+        name: 'gpt-4o',
+        engineModelId: 'gpt-4o',
+        provider: 'openai',
+        engine: 'openai',
+        contextWindow: 128000,
+        capabilities: { supportsTools: true, supportsVision: true },
+      } as ModelInfo],
+      discoverModels: [{
+        id: 'openai/gpt-4o',
+        engine: 'openai',
+        contextWindow: 128000,
+        capabilities: { supportsTools: true, supportsVision: false },
+      } as ModelInfo],
+      toolRegistryTools: [{
+        namespacedName: 'local.echo',
+        originalName: 'echo',
+        source: 'local',
+        sourceType: 'builtin',
+        description: 'Echo tool',
+      }],
+      clients: [{
+        clientId: 'c1',
+        clientType: 'CLI' as never,
+        connectedAt: new Date(),
+        isSpawner: false,
+        workspacePaths: [],
+        workspacePath: '/tmp/ws-fallback',
+      }],
+      vscodeConnectionIds: ['vscode-1'],
+      requestWorkspaceFails: true,
+    });
+    const started = await startTestApp(state);
+    httpServer = started.httpServer;
+    baseUrl = started.baseUrl;
+  });
+
+  afterAll(async () => {
+    if (httpServer) await stopTestApp(httpServer);
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+    await stopEmbeddedWebServer();
+  });
+
+  it('GET /api/health returns daemon status when authenticated', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/health');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'ok',
+      daemon: 'connected',
+      healthy: true,
+      version: '0.1.0-test',
+    });
+  });
+
+  it('GET /api/health rejects unauthenticated requests', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/health', { token: null });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('GET /api/status returns daemon client info when authenticated', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/status');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      version: '0.1.0-test',
+      connectedClients: 1,
+    });
+    expect((res.body as { clients: unknown[] }).clients).toHaveLength(1);
+  });
+
+  it('GET /api/engines lists available engines', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/engines');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('engines');
+    expect(Array.isArray((res.body as { engines: unknown[] }).engines)).toBe(true);
+  });
+
+  it('GET /api/templates returns provider templates', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/templates');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray((res.body as { templates: unknown[] }).templates)).toBe(true);
+  });
+
+  it('GET /api/providers returns configured providers', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/providers');
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { providers: ProviderInfo[] }).providers[0].id).toBe('openai');
+  });
+
+  it('GET /api/models returns model list', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/models');
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { models: ModelInfo[] }).models[0].id).toBe('openai/gpt-4o');
+  });
+
+  it('GET /api/workspaces falls back to client workspace paths', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/workspaces');
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { workspaces: string[] }).workspaces).toContain('/tmp/ws-fallback');
+  });
+
+  it('GET /api/discover-models rejects apiKey query param', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/discover-models/openai?apiKey=secret');
+    expect(res.statusCode).toBe(400);
+    expect(String((res.body as { error: string }).error)).toMatch(/query parameter/i);
+  });
+
+  it('POST /api/discover-models returns models', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/discover-models/openai', {
+      body: { baseUrl: 'https://api.openai.com' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { models: unknown[] }).models).toHaveLength(1);
+  });
+
+  it('GET /api/config returns user config shape', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/config');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('config');
+    expect(res.body).toHaveProperty('path');
+  });
+
+  it('GET /api/config rejects non-allowlisted workspace locations', async () => {
+    const res = await httpRequest(baseUrl, 'GET', `/api/config?location=${encodeURIComponent('/tmp/not-allowed')}`);
+    expect(res.statusCode).toBe(403);
+    expect((res.body as { error: string }).error).toMatch(/allowlisted/i);
+  });
+
+  it('POST /api/config saves user config', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/config', {
+      body: {
+        location: 'user',
+        config: { providers: { custom: { engine: 'openai' } } },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { success: boolean }).success).toBe(true);
+  });
+
+  it('GET /v1/models returns OpenAI model list', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/v1/models');
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { data: Array<{ id: string }> }).data[0].id).toBe('openai/gpt-4o');
+  });
+
+  it('POST /v1/chat/completions returns non-streaming completion', async () => {
+    const chatState = createMockState({
+      sessionsDir,
+      chatChunks: [
+        { type: 'text', text: 'OpenAI hello' },
+        { type: 'done', finishReason: 'stop' },
+      ],
+    });
+    const { httpServer: chatServer, baseUrl: chatBase } = await startTestApp(chatState);
+    try {
+      const res = await httpRequest(chatBase, 'POST', '/v1/chat/completions', {
+        body: {
+          model: 'openai/gpt-4o',
+          messages: [{ role: 'user', content: 'Hi' }],
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(
+        (res.body as { choices: Array<{ message: { content: string } }> }).choices[0].message.content,
+      ).toBe('OpenAI hello');
+    } finally {
+      await stopTestApp(chatServer);
+    }
+  });
+
+  it('GET /api/secrets lists engine keys', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/secrets');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray((res.body as { secrets: unknown[] }).secrets)).toBe(true);
+  });
+
+  it('POST /api/secrets sets a secret via legacy route', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/secrets', {
+      body: { key: 'LEGACY_KEY', value: 'legacy-value' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { success: boolean }).success).toBe(true);
+  });
+
+  it('POST /api/secrets/:key sets a secret', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/secrets/MY_KEY', {
+      body: { value: 'secret-value' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('DELETE /api/secrets/:key deletes a secret', async () => {
+    const res = await httpRequest(baseUrl, 'DELETE', '/api/secrets/MY_KEY');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('GET /api/key-status checks keychain and env', async () => {
+    const keychain = await httpRequest(baseUrl, 'GET', '/api/key-status?source=keychain&name=OPENAI_API_KEY');
+    expect(keychain.statusCode).toBe(200);
+    const env = await httpRequest(baseUrl, 'GET', '/api/key-status?source=env&name=HOME');
+    expect(env.statusCode).toBe(200);
+    expect((env.body as { exists: boolean }).exists).toBe(true);
+    const bad = await httpRequest(baseUrl, 'GET', '/api/key-status');
+    expect(bad.statusCode).toBe(400);
+  });
+
+  it('GET /api/tools lists registered tools', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/tools');
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { tools: unknown[] }).tools[0]).toMatchObject({ name: 'local.echo' });
+    expect((res.body as { total: number }).total).toBe(1);
+  });
+
+  it('GET /api/policies lists built-in policies', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/policies');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray((res.body as { policies: unknown[] }).policies)).toBe(true);
+  });
+
+  it('POST and DELETE /api/policies manage custom policies', async () => {
+    const created = await httpRequest(baseUrl, 'POST', '/api/policies', {
+      body: { name: 'my_custom_policy', config: {} },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const builtin = await httpRequest(baseUrl, 'POST', '/api/policies', {
+      body: { name: 'precise', config: {} },
+    });
+    expect(builtin.statusCode).toBe(400);
+
+    const deleted = await httpRequest(baseUrl, 'DELETE', '/api/policies/my_custom_policy');
+    expect(deleted.statusCode).toBe(200);
+
+    const missing = await httpRequest(baseUrl, 'DELETE', '/api/policies/no_such_policy');
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it('GET /api/mcp-servers returns configured servers', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/mcp-servers');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('mcp_servers');
+  });
+
+  it('POST /api/mcp-servers/:id/reconnect succeeds', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/mcp-servers/test-server/reconnect');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('GET /api/mcp-server/status reports running state', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/mcp-server/status');
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { running: boolean }).running).toBe(false);
+  });
+
+  it('POST /api/mcp-server/start and stop manage MCP server', async () => {
+    const start = await httpRequest(baseUrl, 'POST', '/api/mcp-server/start');
+    expect(start.statusCode).toBe(200);
+    const again = await httpRequest(baseUrl, 'POST', '/api/mcp-server/start');
+    expect(again.statusCode).toBe(200);
+    expect((again.body as { message?: string }).message).toMatch(/already running/i);
+    const stop = await httpRequest(baseUrl, 'POST', '/api/mcp-server/stop');
+    expect(stop.statusCode).toBe(200);
+  });
+
+  it('MCP connection and approval endpoints handle empty and missing requests', async () => {
+    const connections = await httpRequest(baseUrl, 'GET', '/api/mcp/connections');
+    expect(connections.statusCode).toBe(200);
+    expect((connections.body as { pending: unknown[] }).pending).toEqual([]);
+
+    const missingConn = await httpRequest(baseUrl, 'POST', '/api/mcp/connections/missing-id', {
+      body: { decision: 'deny' },
+    });
+    expect(missingConn.statusCode).toBe(404);
+
+    const approvals = await httpRequest(baseUrl, 'GET', '/api/mcp/approvals');
+    expect(approvals.statusCode).toBe(200);
+
+    const missingApproval = await httpRequest(baseUrl, 'POST', '/api/mcp/approvals/missing-id', {
+      body: { decision: 'deny' },
+    });
+    expect(missingApproval.statusCode).toBe(404);
+
+    const spawns = await httpRequest(baseUrl, 'GET', '/api/mcp/stdio-spawns');
+    expect(spawns.statusCode).toBe(200);
+    expect((spawns.body as { denials: unknown[] }).denials).toHaveLength(1);
+
+    const missingSpawn = await httpRequest(baseUrl, 'POST', '/api/mcp/stdio-spawns/missing-id', {
+      body: { decision: 'deny' },
+    });
+    expect(missingSpawn.statusCode).toBe(404);
+  });
+
+  it('DELETE /api/mcp/connections endpoints handle sessions and remembered clients', async () => {
+    const noSession = await httpRequest(baseUrl, 'DELETE', '/api/mcp/connections/sessions/sess-1');
+    expect(noSession.statusCode).toBe(404);
+
+    const noClient = await httpRequest(baseUrl, 'DELETE', '/api/mcp/connections/remembered/unknown-client');
+    expect(noClient.statusCode).toBe(404);
+  });
+
+  it('session CRUD endpoints work', async () => {
+    const created = await httpRequest(baseUrl, 'POST', '/api/sessions', {
+      body: { model: 'openai/gpt-4o', title: 'Test session' },
+    });
+    expect(created.statusCode).toBe(200);
+    const id = (created.body as { id: string }).id;
+
+    const list = await httpRequest(baseUrl, 'GET', '/api/sessions');
+    expect(list.statusCode).toBe(200);
+
+    const one = await httpRequest(baseUrl, 'GET', `/api/sessions/${id}`);
+    expect(one.statusCode).toBe(200);
+
+    const badLimit = await httpRequest(baseUrl, 'GET', '/api/sessions?limit=-1');
+    expect(badLimit.statusCode).toBe(400);
+
+    const deleted = await httpRequest(baseUrl, 'DELETE', `/api/sessions/${id}`);
+    expect(deleted.statusCode).toBe(200);
+  });
+
+  it('POST /api/chat streams SSE events', async () => {
+    const { statusCode, events } = await postSSE(baseUrl, '/api/chat', {
+      model: 'openai/gpt-4o',
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+    expect(statusCode).toBe(200);
+    expect(events.some((e) => (e as { type: string }).type === 'chat_started')).toBe(true);
+    expect(events.some((e) => (e as { type: string }).type === 'done')).toBe(true);
+  });
+
+  it('POST /api/chat streams tool chunks when provided', async () => {
+    const toolState = createMockState({
+      sessionsDir,
+      chatChunks: [
+        {
+          type: 'tool',
+          name: 'echo',
+          state: 'result',
+          done: true,
+          call: { params: { msg: 'hi' }, result: 'hi' },
+        },
+        { type: 'done', finishReason: 'stop' },
+      ],
+    });
+    const { httpServer: toolServer, baseUrl: toolBase } = await startTestApp(toolState);
+    try {
+      const { events } = await postSSE(toolBase, '/api/chat', {
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'run tool' }],
+        tools: [{ name: 'echo', description: 'echo', input_schema: {} }],
+      });
+      expect(events.some((e) => (e as { type: string }).type === 'tool')).toBe(true);
+    } finally {
+      await stopTestApp(toolServer);
+    }
+  });
+
+  it('POST /api/sessions/:id/chat streams and persists messages', async () => {
+    const chatState = createMockState({
+      sessionsDir,
+      chatChunks: [
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: ' session' },
+        { type: 'done', finishReason: 'stop' },
+      ],
+    });
+    const { httpServer: chatServer, baseUrl: chatBase } = await startTestApp(chatState);
+    try {
+      const created = await httpRequest(chatBase, 'POST', '/api/sessions', {
+        body: { model: 'openai/gpt-4o' },
+      });
+      const id = (created.body as { id: string }).id;
+      const { statusCode, events } = await postSSE(chatBase, `/api/sessions/${id}/chat`, {
+        message: { role: 'user', content: 'Hi' },
+      });
+      expect(statusCode).toBe(200);
+      expect(events.some((e) => (e as { type: string }).type === 'text')).toBe(true);
+
+      const summary = await httpRequest(chatBase, 'GET', `/api/sessions/${id}/summary`);
+      expect(summary.statusCode).toBe(200);
+    } finally {
+      await stopTestApp(chatServer);
+    }
+  });
+
+  it('POST /api/chat/:chatId/approve returns 404 for unknown request', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/chat/chat-1/approve', {
+      body: { requestId: 'missing', decision: 'allow' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('POST /api/provider/:id/configure updates provider config', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/api/provider/openai/configure', {
+      body: { engine: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { success: boolean }).success).toBe(true);
+
+    const envOnly = await httpRequest(baseUrl, 'POST', '/api/provider/anthropic/configure', {
+      body: { engine: 'anthropic', envVarName: 'ANTHROPIC_API_KEY' },
+    });
+    expect(envOnly.statusCode).toBe(200);
+
+    const missingEngine = await httpRequest(baseUrl, 'POST', '/api/provider/new-provider/configure', {
+      body: { apiKey: 'sk-test' },
+    });
+    expect(missingEngine.statusCode).toBe(400);
+  });
+
+  it('DELETE /api/provider/:id removes provider', async () => {
+    await httpRequest(baseUrl, 'POST', '/api/provider/openai/configure', {
+      body: { engine: 'openai', apiKey: 'sk-test' },
+    });
+    const res = await httpRequest(baseUrl, 'DELETE', '/api/provider/openai');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('GET /api/mcp-servers includes configured servers from config file', async () => {
+    const configPath = path.join(tmpConfigDir, 'config.yaml');
+    fs.writeFileSync(configPath, 'mcp_servers:\n  myserver:\n    transport: stdio\n    enabled: true\n');
+    const mcpState = createMockState({
+      sessionsDir,
+      mcpPoolStatuses: [{
+        id: 'orphan',
+        connected: false,
+        error: 'down',
+        toolCount: 2,
+        config: { transport: 'http', enabled: true },
+      }],
+    });
+    const { httpServer: mcpServer, baseUrl: mcpBase } = await startTestApp(mcpState, { skipConfig: false });
+    try {
+      const res = await httpRequest(mcpBase, 'GET', '/api/mcp-servers');
+      expect(res.statusCode).toBe(200);
+      const servers = (res.body as { mcp_servers: Array<{ id: string; status: string }> }).mcp_servers;
+      expect(servers.some((s) => s.id === 'myserver')).toBe(true);
+      expect(servers.some((s) => s.id === 'orphan')).toBe(true);
+    } finally {
+      await stopTestApp(mcpServer);
+      if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+    }
+  });
+
+  it('GET unknown /api/* path returns JSON 404', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/api/no-such-route');
+    expect(res.statusCode).toBe(404);
+    expect((res.body as { error: string }).error).toBe('Not found');
+  });
+
+  it('GET /login serves the login form when unauthenticated', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/login', { token: null });
+    expect(res.statusCode).toBe(200);
+    expect(String(res.body)).toContain('Sign in');
+  });
+
+  it('GET / serves dashboard HTML on localhost without prior cookie', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/', { token: null });
+    expect(res.statusCode).toBe(200);
+    expect(String(res.body)).toContain('window.__ABBENAY_CSRF__');
+  });
+
+  it('GET /index.html serves dashboard HTML', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/index.html', { token: null });
+    expect(res.statusCode).toBe(200);
+    expect(String(res.body)).toContain('window.__ABBENAY_CSRF__');
+  });
+});
+
+describe('dashboard login HTML flows', () => {
+  let sessionsDir: string;
+  let httpServer: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    sessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-web-login-'));
+    const state = createMockState({ sessionsDir });
+    const started = await startTestApp(state);
+    httpServer = started.httpServer;
+    baseUrl = started.baseUrl;
+  });
+
+  afterAll(async () => {
+    if (httpServer) await stopTestApp(httpServer);
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  });
+
+  it('POST /login with form body redirects on success', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/login', {
+      token: null,
+      form: { token: TEST_TOKEN },
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+
+  it('POST /login with invalid form token returns HTML error', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/login', {
+      token: null,
+      form: { token: 'wrong' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(String(res.body)).toContain('Invalid token');
+  });
+
+  it('GET /login redirects when auth cookie is already set', async () => {
+    const login = await httpRequest(baseUrl, 'POST', '/login', {
+      token: null,
+      form: { token: TEST_TOKEN },
+    });
+    const setCookie = login.headers['set-cookie'];
+    const cookies = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : [];
+    const cookieHeader = cookies.map((c) => c.split(';')[0]).join('; ');
+
+    const res = await httpRequest(baseUrl, 'GET', '/login', {
+      token: null,
+      cookie: cookieHeader,
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+
+  it('legacy ?token= login sets cookies and redirects', async () => {
+    const res = await httpRequest(baseUrl, 'GET', `/?token=${encodeURIComponent(TEST_TOKEN)}`, {
+      token: null,
+    });
+    expect(res.statusCode).toBe(302);
+    const setCookie = res.headers['set-cookie'];
+    const cookies = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : [];
+    expect(cookies.some((c) => c.startsWith(`${API_TOKEN_COOKIE}=`))).toBe(true);
+    expect(cookies.some((c) => c.startsWith(`${CSRF_COOKIE}=`))).toBe(true);
+  });
+
+  it('legacy ?token= login rejects invalid token with 401', async () => {
+    const res = await httpRequest(baseUrl, 'GET', '/?token=wrong-token', { token: null });
+    expect(res.statusCode).toBe(401);
+    expect(String(res.body)).toContain('Invalid token');
+  });
+
+  it('POST /login with JSON body returns 400 for invalid payload', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/login', {
+      token: null,
+      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      body: { password: 'nope' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/Invalid request body/i);
+  });
+
+  it('POST /login with JSON body returns 401 for wrong token', async () => {
+    const res = await httpRequest(baseUrl, 'POST', '/login', {
+      token: null,
+      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      body: { token: 'wrong-token' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect((res.body as { error: string }).error).toBe('Invalid token');
+  });
+});
+
+describe('createWebApp error paths', () => {
+  let sessionsDir: string;
+
+  beforeAll(() => {
+    sessionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abbenay-web-errors-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  });
+
+  it('GET /api/providers returns 500 when listProviders throws', async () => {
+    const state = createMockState({ sessionsDir, throwOnListProviders: true });
+    const { httpServer, baseUrl } = await startTestApp(state);
+    const res = await httpRequest(baseUrl, 'GET', '/api/providers');
+    expect(res.statusCode).toBe(500);
+    await stopTestApp(httpServer);
+  });
+});

--- a/packages/daemon/src/daemon/web/validate-body.test.ts
+++ b/packages/daemon/src/daemon/web/validate-body.test.ts
@@ -5,11 +5,16 @@
 import { describe, it, expect } from 'vitest';
 import * as path from 'node:path';
 import { z } from 'zod';
+import type { Response } from 'express';
+import type { DaemonState } from '../state.js';
 import {
   containsPathTraversal,
   checkWorkspaceLocation,
+  collectAllowlistedWorkspaces,
   formatZodError,
   parseRequestBody,
+  resolveConfigLocation,
+  sendBadRequest,
 } from './validate-body.js';
 import {
   PostChatBodySchema,
@@ -66,6 +71,94 @@ describe('checkWorkspaceLocation', () => {
       expect(result.status).toBe(400);
       expect(result.error).toMatch(/null/i);
     }
+  });
+
+  it('rejects empty location with 400', () => {
+    const result = checkWorkspaceLocation('', allowed);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/non-empty string/i);
+    }
+  });
+});
+
+describe('collectAllowlistedWorkspaces', () => {
+  it('collects vscode workspaces and connected client paths', () => {
+    const state = {
+      getVSCodeWorkspaces: () => [path.resolve('/tmp/vs-workspace')],
+      getClients: () => [{
+        workspacePath: path.resolve('/tmp/client-primary'),
+        workspacePaths: [path.resolve('/tmp/client-extra')],
+      }],
+    } as unknown as DaemonState;
+
+    const workspaces = collectAllowlistedWorkspaces(state);
+    expect(workspaces).toContain(path.resolve('/tmp/vs-workspace'));
+    expect(workspaces).toContain(path.resolve('/tmp/client-primary'));
+    expect(workspaces).toContain(path.resolve('/tmp/client-extra'));
+  });
+
+  it('skips empty, whitespace, and null-byte paths', () => {
+    const state = {
+      getVSCodeWorkspaces: () => ['', '  ', '/tmp/bad\0path'],
+      getClients: () => [],
+    } as unknown as DaemonState;
+
+    expect(collectAllowlistedWorkspaces(state)).toEqual([]);
+  });
+});
+
+describe('resolveConfigLocation', () => {
+  const workspacePath = path.resolve('/tmp/allowed-config-ws');
+
+  function createState(): DaemonState {
+    return {
+      getVSCodeWorkspaces: () => [workspacePath],
+      getClients: () => [],
+    } as unknown as DaemonState;
+  }
+
+  it('accepts user location', () => {
+    const result = resolveConfigLocation('user', createState());
+    expect(result).toEqual({ ok: true, kind: 'user' });
+  });
+
+  it('accepts allowlisted workspace paths', () => {
+    const result = resolveConfigLocation(workspacePath, createState());
+    expect(result.ok).toBe(true);
+    if (result.ok && result.kind === 'workspace') {
+      expect(result.resolved).toBe(workspacePath);
+    }
+  });
+
+  it('rejects workspace paths outside the allowlist', () => {
+    const result = resolveConfigLocation('/tmp/other-workspace', createState());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.error).toMatch(/allowlisted/i);
+    }
+  });
+});
+
+describe('sendBadRequest', () => {
+  it('responds with 400 JSON and returns true', () => {
+    const res = {
+      statusCode: 200,
+      body: undefined as unknown,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body: unknown) {
+        this.body = body;
+      },
+    };
+
+    expect(sendBadRequest(res as Response, 'Invalid request body: model: Required')).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid request body: model: Required' });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add and expand unit tests for `packages/daemon/src/daemon/web/` covering grpc-web-control RPC helpers, http-security (CORS/auth/CSRF), validate-body, API schemas, OpenAI-compat routes, and createWebApp HTTP routes.
- Mock gRPC transport in `grpc-web-control.rpc.test.ts` for `sendStartWebServer` / `sendStopWebServer` without a live daemon.
- Raise web package line coverage from ~66% to ~78% (grpc-web-control, openai-compat, validate-body now ~90%+).
- Address CodeRabbit review feedback: stronger constructor/CSRF/CORS assertions, isolated MCP config fixtures, server cleanup in `finally` blocks.

## Commits

- `test(web): Add unit tests for daemon web HTTP layer` — initial web-layer unit test coverage
- `Merge branch 'main' into test/daemon-web-unit-coverage` — sync with main
- `test(web): address CodeRabbit review feedback on web unit tests` — review-driven test hardening (bbe0a4f)
- `fix(test): avoid require() in server.test vi.hoisted for eslint` — CI lint fix for lazy config dir init (32e72b2)

## Test plan

- [x] `npm run lint -w packages/daemon`
- [x] `npm run test -w packages/daemon -- --run src/daemon/web/` (226+ tests)
- [ ] Full `npm test` (all workspaces)
- [ ] CI green on PR