### PR TITLE
ci(sonar): resolve fork PR numbers for finalize

### DIFF
--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -77,6 +77,15 @@ jobs:
               --jq '.[0].number // empty')
           fi
 
+          # Fork PR head SHAs are often missing from the commits/{sha}/pulls API
+          # and workflow_run.pull_requests. Match an open PR by head OID instead.
+          if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            PR_NUMBER=$(gh pr list --repo "${REPO}" --state open --limit 100 \
+              --json number,headRefOid \
+              --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\") | .number" \
+              | head -n1)
+          fi
+
           if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
             echo "::error::Unable to resolve a trusted PR number for head SHA ${HEAD_SHA}"
             exit 1

--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -64,6 +64,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           REPO: ${{ github.repository }}
           # Trusted GitHub payload — not PR-controlled artifact content
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
@@ -78,12 +80,24 @@ jobs:
           fi
 
           # Fork PR head SHAs are often missing from the commits/{sha}/pulls API
-          # and workflow_run.pull_requests. Match an open PR by head OID instead.
+          # and workflow_run.pull_requests. Resolve via trusted head owner:branch,
+          # then require an exact head OID match (fail if 0 or >1).
           if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-            PR_NUMBER=$(gh pr list --repo "${REPO}" --state open --limit 100 \
-              --json number,headRefOid \
-              --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\") | .number" \
-              | head -n1)
+            if [[ -z "${HEAD_BRANCH}" || -z "${HEAD_REPOSITORY}" ]]; then
+              echo "::error::Missing workflow_run head_branch/head_repository for SHA ${HEAD_SHA}"
+              exit 1
+            fi
+            HEAD_OWNER="${HEAD_REPOSITORY%%/*}"
+            MATCHES=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${REPO}/pulls?state=open&head=${HEAD_OWNER}:${HEAD_BRANCH}" \
+              --jq "[.[] | select(.head.sha == \"${HEAD_SHA}\") | .number]")
+            MATCH_COUNT=$(jq 'length' <<< "${MATCHES}")
+            if [[ "${MATCH_COUNT}" -ne 1 ]]; then
+              echo "::error::Expected exactly one open PR for ${HEAD_OWNER}:${HEAD_BRANCH}@${HEAD_SHA}, found ${MATCH_COUNT}: ${MATCHES}"
+              exit 1
+            fi
+            PR_NUMBER=$(jq -r '.[0]' <<< "${MATCHES}")
           fi
 
           if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- Sonar finalize has been failing on fork PRs with `Unable to resolve a trusted PR number` because `workflow_run.pull_requests` and `commits/{sha}/pulls` return empty for fork head SHAs.
- Add a fallback that matches an open PR by `headRefOid`.

## Test plan
- [ ] Merge this to main (finalize always runs the default-branch workflow)
- [ ] Re-run CI on https://github.com/redhat-developer/abbenay/pull/113 (or push an empty commit)
- [ ] Confirm finalize resolves PR #113 and Sonar updates


Made with [Cursor](https://cursor.com)