### PR TITLE
fix(daemon): default tool_mode to none so plain chat skips registry load

### DIFF
--- a/packages/daemon/src/core/state.test.ts
+++ b/packages/daemon/src/core/state.test.ts
@@ -584,6 +584,26 @@ describe('CoreState.chat', () => {
     expect(tools).toBeUndefined();
   });
 
+  it('infers auto mode when caller supplies tools without explicit toolMode', async () => {
+    const core = createCore({
+      config: {
+        providers: { 'my-mock': { engine: 'mock', models: { echo: {} } } },
+      },
+    });
+
+    const suppliedTools = [
+      { name: 'search', description: 'web search', inputSchema: '{}' },
+    ];
+    await collectChat(core, 'my-mock/echo', [{ role: 'user', content: 'find it' }], undefined, {
+      tools: suppliedTools,
+    });
+
+    expect(mockStreamChat).toHaveBeenCalled();
+    const tools = mockStreamChat.mock.calls[0][6];
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe('search');
+  });
+
   it('applies inline policy without inheriting named policy fields', async () => {
     const core = createCore({
       config: {

--- a/packages/daemon/src/core/state.test.ts
+++ b/packages/daemon/src/core/state.test.ts
@@ -548,6 +548,7 @@ describe('CoreState.chat', () => {
 
     const onApproval = vi.fn().mockResolvedValue('allow');
     await collectChat(core, 'my-mock/echo', [{ role: 'user', content: 'run tool' }], undefined, {
+      toolMode: 'auto',
       toolFilter: ['tool'],
       onToolApprovalNeeded: onApproval,
     });
@@ -557,6 +558,30 @@ describe('CoreState.chat', () => {
     expect(tools).toHaveLength(1);
     expect(tools[0].name).toBe('tool');
     expect(mockStreamChat.mock.calls[0][9]).toBe(10);
+  });
+
+  it('defaults to none mode and skips registry when toolMode is omitted', async () => {
+    const core = createCore({
+      config: {
+        providers: { 'my-mock': { engine: 'mock', models: { echo: {} } } },
+      },
+    });
+    const registry = new ToolRegistry();
+    registry.register('test', 'local', [
+      {
+        name: 'tool',
+        description: 'test tool',
+        inputSchema: '{}',
+        executor: async () => ({ ok: true }),
+      },
+    ]);
+    core.toolRegistry = registry;
+
+    await collectChat(core, 'my-mock/echo', [{ role: 'user', content: 'plain chat' }]);
+
+    expect(mockStreamChat).toHaveBeenCalled();
+    const tools = mockStreamChat.mock.calls[0][6];
+    expect(tools).toBeUndefined();
   });
 
   it('applies inline policy without inheriting named policy fields', async () => {

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -614,7 +614,10 @@ export class CoreState {
     }
 
     // Policy can override tool mode (caller's explicit value takes priority)
-    const effectiveToolMode = toolOptions?.toolMode || flatPolicy?.toolMode || 'none';
+    const effectiveToolMode =
+      toolOptions?.toolMode ||
+      flatPolicy?.toolMode ||
+      (toolOptions?.tools?.length ? 'auto' : 'none');
 
     // ── Apply system prompt (policy snippet + model prompt) ──
     let processedMessages = [...messages];

--- a/packages/daemon/src/core/state.ts
+++ b/packages/daemon/src/core/state.ts
@@ -614,7 +614,7 @@ export class CoreState {
     }
 
     // Policy can override tool mode (caller's explicit value takes priority)
-    const effectiveToolMode = toolOptions?.toolMode || flatPolicy?.toolMode || 'auto';
+    const effectiveToolMode = toolOptions?.toolMode || flatPolicy?.toolMode || 'none';
 
     // ── Apply system prompt (policy snippet + model prompt) ──
     let processedMessages = [...messages];

--- a/packages/daemon/src/daemon/server/abbenay-service.test.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.test.ts
@@ -2187,6 +2187,30 @@ describe('createAbbenayService handlers', () => {
     expect(failed.written.some((c) => (c as { error?: { message: string } }).error?.message === 'chat exploded')).toBe(true);
   });
 
+  it('Chat infers auto tool_mode when tools are supplied without an explicit mode', async () => {
+    async function* doneChunk() {
+      yield { type: 'done' as const, finishReason: 'stop' };
+    }
+    const chat = vi.fn().mockReturnValue(doneChunk());
+    const state = createMockState({ chat });
+    const service = createAbbenayService(state);
+
+    const { call } = makeWritableStreamCall({
+      model: 'mock/echo',
+      messages: [{ role: 2, content: 'find it' }],
+      tools: [{ name: 'search', description: 'web search', input_schema: '{}' }],
+      // No tool_mode/toolMode set — should be inferred as 'auto' since tools are present.
+    });
+    service.Chat(call as never);
+    await vi.waitFor(() => expect(call.end).toHaveBeenCalled());
+
+    expect(chat).toHaveBeenCalled();
+    const toolOptions = chat.mock.calls[0][3] as { toolMode?: string; tools?: Array<{ name: string }> };
+    expect(toolOptions.toolMode).toBe('auto');
+    expect(toolOptions.tools).toHaveLength(1);
+    expect(toolOptions.tools?.[0].name).toBe('search');
+  });
+
   it('SessionChat covers inline policy, tool lifecycle, and errors', async () => {
     async function* toolChunks() {
       yield { type: 'tool' as const, name: 'search', done: false, call: { params: { q: 'x' } } };

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -703,7 +703,8 @@ export function createAbbenayService(
       })).filter((t: ToolDefinition) => t.name); // Filter out empty-name tools
       
       // ── Extract tool mode from options ──
-      const toolMode = opts.tool_mode || opts.toolMode || (tools.length > 0 ? 'auto' : 'none');
+      const requestedToolMode = opts.tool_mode || opts.toolMode;
+      const toolMode = requestedToolMode || (tools.length > 0 ? 'auto' : undefined);
       const maxToolIterations = opts.max_tool_iterations || opts.maxToolIterations || 10;
       const chatToolFilter = opts.tool_filter || opts.toolFilter || [];
       

--- a/packages/daemon/src/daemon/server/abbenay-service.ts
+++ b/packages/daemon/src/daemon/server/abbenay-service.ts
@@ -703,7 +703,7 @@ export function createAbbenayService(
       })).filter((t: ToolDefinition) => t.name); // Filter out empty-name tools
       
       // ── Extract tool mode from options ──
-      const toolMode = opts.tool_mode || opts.toolMode || 'auto';
+      const toolMode = opts.tool_mode || opts.toolMode || (tools.length > 0 ? 'auto' : 'none');
       const maxToolIterations = opts.max_tool_iterations || opts.maxToolIterations || 10;
       const chatToolFilter = opts.tool_filter || opts.toolFilter || [];
       

--- a/packages/vscode/src/webviews/chat/chatHandler.ts
+++ b/packages/vscode/src/webviews/chat/chatHandler.ts
@@ -272,7 +272,9 @@ async function handleSendMessage(
         toolCallId: '',
         name: '',
       },
-      options: {},
+      options: {
+        toolMode: 'auto',
+      },
     });
 
     for await (const chunk of stream) {

--- a/packages/vscode/src/webviews/chat/chatHandler.ts
+++ b/packages/vscode/src/webviews/chat/chatHandler.ts
@@ -272,10 +272,7 @@ async function handleSendMessage(
         toolCallId: '',
         name: '',
       },
-      options: {
-        toolMode: 'auto',
-        enableTools: true,
-      },
+      options: {},
     });
 
     for await (const chunk of stream) {


### PR DESCRIPTION
## Summary

- Fix the Chat RPC defaulting `tool_mode` to `'auto'` when unset, which injected the entire aggregated tool registry (~82 VS Code `lm.tool` schemas + MCP tools) into **every** request — even plain chat with no tool use intent. On CPU-only hosts this caused ~4 min prompt processing before the first output token and inflated cloud provider input-token cost.
- Align all default paths to `'none'` (matching `SessionChat` and `openai-compat` which already defaulted correctly), so tool loading is strictly opt-in.
- Preserve policy precedence: pass `undefined` (not `'none'`) when no tools and no explicit mode, so `flatPolicy.toolMode` is not suppressed.
- Infer `'auto'` when caller supplies tools but omits `toolMode`, so client-provided tools are not silently cleared.
- Restore webview `toolMode: 'auto'` since the chat panel is designed for tool use; drop only the dead `enableTools` field.
- Add regression tests verifying the new default behavior, supplied-tools inference, and the Chat RPC's inferred-auto branch (closing a codecov/patch coverage gap).

## Changes

| File | What changed |
|------|-------------|
| `packages/daemon/src/daemon/server/abbenay-service.ts` | Stateless Chat RPC: preserve undefined when no tools and no explicit mode (lets flatPolicy.toolMode apply); infer auto only when tools are present in the request |
| `packages/daemon/src/core/state.ts` | effectiveToolMode fallback infers auto when toolOptions.tools has entries, falls back to none only when no tools and no policy mode |
| `packages/vscode/src/webviews/chat/chatHandler.ts` | Keep toolMode auto (webview is designed for tool use); drop only dead enableTools field |
| `packages/daemon/src/core/state.test.ts` | Make existing auto-mode test explicit; add regression test for omitted toolMode skipping registry; add test for supplied tools inferring auto |
| `packages/daemon/src/daemon/server/abbenay-service.test.ts` | Add regression test covering the Chat RPC's inferred-`'auto'` branch when tools are supplied without an explicit mode |

## Commits

- `fix(daemon): default tool_mode to none so plain chat skips registry load` — core fix for #116
- `fix(daemon): preserve policy precedence and webview tool support` — address CodeRabbit review feedback
- `test(daemon): cover inferred auto tool_mode in Chat RPC` — close codecov/patch coverage gap on the inferred-auto branch

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test` passes for changed files (204/204)
- [x] TypeScript compilation (tsc) passes for daemon and vscode packages
- [x] Regression test: omitted toolMode skips registry load
- [x] Regression test: supplied tools with omitted toolMode infers auto and passes tools through (both `CoreState.chat` and the `Chat` RPC handler)
- [x] Existing auto-mode test updated to explicitly opt in, confirming auto still works when requested

Closes #116
