### PR TITLE
test(daemon): add assertions to SonarCloud blocker test cases

### DIFF
--- a/packages/daemon/src/state.test.ts
+++ b/packages/daemon/src/state.test.ts
@@ -898,6 +898,9 @@ describe('DaemonState.runHealthChecks', () => {
     mockMergeConfigs.mockReturnValue(config);
 
     await state.runHealthChecks();
+
+    const providers = await state.listProviders();
+    expect(providers).toHaveLength(0);
   });
 });
 
@@ -1285,7 +1288,7 @@ describe('DaemonState VS Code backchannel', () => {
 
   it('handleVSCodeResponse ignores malformed responses', () => {
     const connId = state.registerVSCodeConnection(createStreamCapture().stream);
-    state.handleVSCodeResponse(connId, { bad: true });
-    state.handleVSCodeResponse(connId, { request_id: 123 });
+    expect(() => state.handleVSCodeResponse(connId, { bad: true })).not.toThrow();
+    expect(() => state.handleVSCodeResponse(connId, { request_id: 123 })).not.toThrow();
   });
 });

--- a/packages/daemon/tests/integration/consumer-auth.test.ts
+++ b/packages/daemon/tests/integration/consumer-auth.test.ts
@@ -440,8 +440,10 @@ describe('Consumer auth RPC gating', () => {
   });
 
   it('full token can call secrets and config', async () => {
-    await callUnary(client, 'SetSecret', { key: 'FULL', value: 'ok' }, GOOD_TOKEN);
-    await callUnary(client, 'GetConfig', {}, GOOD_TOKEN);
+    const setRes = await callUnary(client, 'SetSecret', { key: 'FULL', value: 'ok' }, GOOD_TOKEN);
+    expect(setRes).toBeDefined();
+    const configRes = await callUnary(client, 'GetConfig', {}, GOOD_TOKEN);
+    expect(configRes).toBeDefined();
   });
 
   it('denies SummarizeSession without chat capability', async () => {


### PR DESCRIPTION
## Summary
- Adds assertions to 3 test cases flagged as blocker code smells by SonarCloud for having no assertions
- `state.test.ts` L890: asserts unknown engine produces no providers
- `state.test.ts` L1286: asserts malformed responses do not throw
- `consumer-auth.test.ts` L442: asserts full token RPC calls return defined responses

## Test plan
- [x] `vitest run packages/daemon/src/state.test.ts` (70/70 pass)
- [x] `vitest run packages/daemon/tests/integration/consumer-auth.test.ts` (22/22 pass)