### PR TITLE
fix(daemon): use localeCompare for stable alphabetical sorting

### DIFF
--- a/packages/daemon/src/daemon/mcp-server.ts
+++ b/packages/daemon/src/daemon/mcp-server.ts
@@ -159,7 +159,7 @@ export class AbbenayMcpServer {
   }
 
   listRememberedClients(): string[] {
-    return [...this.rememberedClients].sort();
+    return [...this.rememberedClients].sort((a, b) => a.localeCompare(b));
   }
 
   listSessions(): McpSessionInfo[] {

--- a/packages/daemon/src/daemon/state.ts
+++ b/packages/daemon/src/daemon/state.ts
@@ -464,7 +464,7 @@ export class DaemonState extends CoreState {
       }
     }
 
-    return workspaces.sort();
+    return workspaces.sort((a, b) => a.localeCompare(b));
   }
 
   getVSCodeConnectionIds(): string[] {


### PR DESCRIPTION
## Summary
- Adds `localeCompare` compare function to two `.sort()` calls flagged as HIGH reliability bugs by SonarCloud (rule S2871)
- `mcp-server.ts:162`: `listRememberedClients()` sort
- `state.ts:467`: `getVSCodeWorkspaces()` sort

## Test plan
- [x] `vitest run packages/daemon/src/daemon/mcp-server.test.ts` (16/16 pass)
- [x] `vitest run packages/daemon/src/state.test.ts` (70/70 pass)