### PR TITLE
fix(vscode): verify message origin in webview handlers

### DIFF
--- a/packages/vscode/src/webview-ui/chat/main.ts
+++ b/packages/vscode/src/webview-ui/chat/main.ts
@@ -335,6 +335,7 @@ function handleScroll(): void {
 // ── Message Handler ──────────────────────────────────────────────────────────
 
 function onMessage(event: MessageEvent): void {
+  if (event.origin !== window.origin) return;
   const msg = event.data;
 
   switch (msg.type) {

--- a/packages/vscode/src/webview-ui/provider/main.ts
+++ b/packages/vscode/src/webview-ui/provider/main.ts
@@ -890,6 +890,7 @@ function handleSave(): void {
 // ─── Message Handler ─────────────────────────────────────────────────
 
 window.addEventListener('message', (event) => {
+  if (event.origin !== window.origin) return;
   const msg = event.data;
 
   switch (msg.type) {


### PR DESCRIPTION
## Summary
- Adds origin verification to webview message handlers to resolve SonarCloud S2819 security issues
- Guards \`window.addEventListener('message', ...)\` callbacks with \`event.origin !== window.origin\` check in chat and provider webview UIs

## Test plan
- [x] Verified the origin check pattern matches VS Code webview conventions
- [ ] Manual test: chat and provider webviews still receive and process extension messages