### PR TITLE
fix(daemon): remove async operation from KeychainSecretStore constructor

### DIFF
--- a/packages/daemon/src/daemon/secrets/keychain.ts
+++ b/packages/daemon/src/daemon/secrets/keychain.ts
@@ -35,14 +35,9 @@ function isSea(): boolean {
 export class KeychainSecretStore implements SecretStore {
   private keytar: typeof import('keytar') | null = null;
   private loadError: string | null = null;
-  /** Shared in-flight import so constructor + first get/set cannot race. */
+  /** Shared in-flight import so first get/set cannot race. */
   private loadPromise: Promise<typeof import('keytar') | null> | null = null;
-  
-  constructor() {
-    // Load keytar lazily since it's a native module
-    this.loadKeytar();
-  }
-  
+
   private async loadKeytar(): Promise<typeof import('keytar') | null> {
     if (this.keytar) return this.keytar;
     if (this.loadError) return null;


### PR DESCRIPTION
## Summary
- Removes fire-and-forget `this.loadKeytar()` call from the `KeychainSecretStore` constructor
- Fixes SonarCloud S7059 (HIGH): async operations should not run in constructors
- The `loadKeytar()` method is already called lazily from every public method (`get`, `set`, `delete`, `has`), so the constructor warm-up was redundant

## Test plan
- [x] `vitest run packages/daemon/src/daemon/secrets/keychain.test.ts` (26/26 pass)