### PR TITLE
test(daemon): use vitest context.skip() instead of early return

### DIFF
--- a/packages/daemon/src/cli.test.ts
+++ b/packages/daemon/src/cli.test.ts
@@ -157,8 +157,8 @@ describe('CLI subprocess', () => {
     expect(output).toMatch(new RegExp(`PID:\\s+${process.pid}`));
   });
 
-  it('status uses Address label on win32', async () => {
-    if (process.platform !== 'win32') return;
+  it('status uses Address label on win32', async (context) => {
+    if (process.platform !== 'win32') { context.skip(); return; }
 
     process.env.XDG_RUNTIME_DIR = tmpRoot;
     ensureRuntimeDir();

--- a/packages/daemon/src/daemon/transport.address.test.ts
+++ b/packages/daemon/src/daemon/transport.address.test.ts
@@ -94,9 +94,9 @@ describe('address file helpers', () => {
     });
   });
 
-  it('getTransport returns unix on non-win32', () => {
+  it('getTransport returns unix on non-win32', (context) => {
     if (process.platform === 'win32') {
-      return;
+      context.skip(); return;
     }
     Object.defineProperty(process, 'platform', { value: 'linux' });
     const info = getTransport();
@@ -139,8 +139,8 @@ describe('transport lifecycle helpers', () => {
     expect(fs.existsSync(runtimeDir)).toBe(true);
   });
 
-  it('ensureSocketDir creates parent dir on unix', () => {
-    if (process.platform === 'win32') return;
+  it('ensureSocketDir creates parent dir on unix', (context) => {
+    if (process.platform === 'win32') { context.skip(); return; }
     Object.defineProperty(process, 'platform', { value: 'linux' });
     const socketDir = path.dirname(getSocketPath());
     if (fs.existsSync(socketDir)) {
@@ -184,8 +184,8 @@ describe('transport lifecycle helpers', () => {
     }
   });
 
-  it('cleanupSocket removes unix socket file', () => {
-    if (process.platform === 'win32') return;
+  it('cleanupSocket removes unix socket file', (context) => {
+    if (process.platform === 'win32') { context.skip(); return; }
     Object.defineProperty(process, 'platform', { value: 'linux' });
     ensureSocketDir();
     const socketPath = getSocketPath();
@@ -288,8 +288,8 @@ describe('isDaemonRunning', () => {
     Object.defineProperty(process, 'platform', { value: original });
   });
 
-  it('on unix probes socket connectivity', async () => {
-    if (process.platform === 'win32') return;
+  it('on unix probes socket connectivity', async (context) => {
+    if (process.platform === 'win32') { context.skip(); return; }
     Object.defineProperty(process, 'platform', { value: 'linux' });
     ensureSocketDir();
     const socketPath = getDefaultSocketPath();


### PR DESCRIPTION
## Summary
- Replaces early `return` with `context.skip()` in 5 platform-gated test cases flagged by SonarCloud (rule S8968, HIGH)
- Tests now report as "skipped" in vitest output instead of silently passing with no assertions

## Files changed
- `packages/daemon/src/cli.test.ts` (1 test)
- `packages/daemon/src/daemon/transport.address.test.ts` (4 tests)

## Test plan
- [x] `vitest run packages/daemon/src/cli.test.ts` passes
- [x] `vitest run packages/daemon/src/daemon/transport.address.test.ts` passes (6 passed, 18 skipped)