### PR TITLE
feat(vscode): add lmToolMode setting for Copilot tool passthrough

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -129,6 +129,16 @@ HTTP auth is on by default — use the dashboard login / API token when prompted
 The daemon binds to loopback by default; see
 [Security & air-gap](../../docs/SECURITY.md).
 
+### Copilot and other Language Model hosts
+
+When Copilot (or another extension) uses an Abbenay model with tools, set
+**Abbenay: Language Model Tool Mode** (`abbenay.lmToolMode`) to **passthrough**
+(default). Abbenay returns tool calls to the host for native execution instead
+of running them via the backchannel (which prompts on every tool).
+
+Use **auto** only if you need the legacy behavior where Abbenay executes tools
+itself.
+
 ### Config Files
 
 Configuration is stored in YAML files:

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -131,6 +131,15 @@
           "type": "string",
           "default": "",
           "description": "Environment variable name whose value is sent as x-abbenay-token consumer auth metadata. Prefer Abbenay: Set Daemon Token (SecretStorage) when possible."
+        },
+        "abbenay.lmToolMode": {
+          "type": "string",
+          "enum": [
+            "passthrough",
+            "auto"
+          ],
+          "default": "passthrough",
+          "description": "How Abbenay handles tools when another extension (e.g. GitHub Copilot) sends tools with a chat request. passthrough: return tool calls to the host for native VS Code execution (recommended for Copilot). auto: Abbenay runs the tool loop and invokes tools via the backchannel (legacy)."
         }
       }
     },

--- a/packages/vscode/src/providers/AbbenayLanguageModelProvider.ts
+++ b/packages/vscode/src/providers/AbbenayLanguageModelProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { DaemonClient } from '../daemon/client';
 import * as proto from '../proto/abbenay/v1/service';
 import { getLogger } from '../utils/logger';
+import { readLmToolModeSetting, resolveDaemonToolMode } from './lm-tool-mode';
 
 const logger = getLogger();
 
@@ -139,15 +140,13 @@ class AbbenayHandler implements vscode.LanguageModelChatProvider {
             logger.debug(`[LMProvider] Forwarding ${protoTools.length} tools to daemon`);
         }
 
-        // Determine tool mode:
-        // - When VS Code provides tools, use 'auto' (daemon owns the loop via Vercel AI SDK)
-        // - If toolMode is explicitly set in options, map it; otherwise infer from tools presence
-        let toolMode = protoTools.length > 0 ? 'auto' : 'none';
-        if (options.toolMode !== undefined) {
-            // VS Code LanguageModelChatToolMode enum: Required=1
-            // Map any non-undefined toolMode to 'auto' since VS Code only sends tools it wants used
-            toolMode = 'auto';
-        }
+        // Host-provided tools (Copilot, etc.): passthrough returns tool_call chunks for
+        // native host execution; auto runs the loop via the backchannel (legacy).
+        const lmToolMode = readLmToolModeSetting();
+        const toolMode = resolveDaemonToolMode(protoTools.length > 0, lmToolMode);
+        logger.debug(
+            `[LMProvider] toolMode=${toolMode} (abbenay.lmToolMode=${lmToolMode}, hostTools=${protoTools.length})`,
+        );
 
         const request: proto.DeepPartial<proto.ChatRequest> = {
             model: compositeId,
@@ -180,7 +179,7 @@ class AbbenayHandler implements vscode.LanguageModelChatProvider {
                         break;
                     }
                     case 'toolCall': {
-                        // Tool call from the LLM (passthrough mode or before execution)
+                        // Tool call from the LLM (passthrough — host executes natively)
                         const tc = c.toolCall;
                         logger.debug(`[LMProvider] Tool call: ${tc.name} (id: ${tc.id})`);
                         progress.report(new vscode.LanguageModelToolCallPart(

--- a/packages/vscode/src/providers/lm-tool-mode.ts
+++ b/packages/vscode/src/providers/lm-tool-mode.ts
@@ -1,0 +1,37 @@
+/**
+ * Language Model API tool routing for hosts (Copilot, etc.) that register tools
+ * with Abbenay models.
+ *
+ * - passthrough (default): daemon returns tool_call chunks; the host executes
+ *   tools with native VS Code UX (recommended for Copilot).
+ * - auto: daemon runs the tool loop and invokes tools via the backchannel.
+ */
+
+import * as vscode from 'vscode';
+
+export type LmToolModeSetting = 'passthrough' | 'auto';
+
+export type DaemonChatToolMode = 'passthrough' | 'auto' | 'none';
+
+export const LM_TOOL_MODE_DEFAULT: LmToolModeSetting = 'passthrough';
+
+/** Map extension setting + whether the host sent tools → daemon ChatRequest.toolMode. */
+export function resolveDaemonToolMode(
+  hasClientTools: boolean,
+  setting: LmToolModeSetting,
+): DaemonChatToolMode {
+  if (!hasClientTools) {
+    return 'none';
+  }
+  return setting;
+}
+
+type LmToolModeConfig = Pick<vscode.WorkspaceConfiguration, 'get'>;
+
+/** Read abbenay.lmToolMode; unknown values fall back to passthrough. */
+export function readLmToolModeSetting(
+  config: LmToolModeConfig = vscode.workspace.getConfiguration('abbenay'),
+): LmToolModeSetting {
+  const raw = config.get<string>('lmToolMode', LM_TOOL_MODE_DEFAULT);
+  return raw === 'auto' ? 'auto' : 'passthrough';
+}

--- a/packages/vscode/src/test/providers/lm-tool-mode.test.ts
+++ b/packages/vscode/src/test/providers/lm-tool-mode.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import {
+  LM_TOOL_MODE_DEFAULT,
+  readLmToolModeSetting,
+  resolveDaemonToolMode,
+} from '../../providers/lm-tool-mode';
+
+function fakeConfig(values: Record<string, unknown>): {
+  get<T>(key: string, defaultValue?: T): T | undefined;
+} {
+  return {
+    get<T>(key: string, defaultValue?: T): T | undefined {
+      if (key in values) {
+        return values[key] as T;
+      }
+      return defaultValue;
+    },
+  };
+}
+
+suite('lm-tool-mode', () => {
+  test('resolveDaemonToolMode returns none when host sends no tools', () => {
+    assert.strictEqual(resolveDaemonToolMode(false, 'passthrough'), 'none');
+    assert.strictEqual(resolveDaemonToolMode(false, 'auto'), 'none');
+  });
+
+  test('resolveDaemonToolMode maps setting when host sends tools', () => {
+    assert.strictEqual(resolveDaemonToolMode(true, 'passthrough'), 'passthrough');
+    assert.strictEqual(resolveDaemonToolMode(true, 'auto'), 'auto');
+  });
+
+  test('readLmToolModeSetting defaults to passthrough', () => {
+    assert.strictEqual(readLmToolModeSetting(fakeConfig({})), LM_TOOL_MODE_DEFAULT);
+    assert.strictEqual(readLmToolModeSetting(fakeConfig({ lmToolMode: undefined })), 'passthrough');
+  });
+
+  test('readLmToolModeSetting honors auto', () => {
+    assert.strictEqual(readLmToolModeSetting(fakeConfig({ lmToolMode: 'auto' })), 'auto');
+  });
+
+  test('readLmToolModeSetting treats unknown values as passthrough', () => {
+    assert.strictEqual(readLmToolModeSetting(fakeConfig({ lmToolMode: 'bogus' })), 'passthrough');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `abbenay.lmToolMode` setting (`passthrough` | `auto`, default `passthrough`) so Copilot and other Language Model hosts receive tool calls for native execution instead of Abbenay running the tool loop via the backchannel.
- Replace hardcoded `toolMode: 'auto'` in `AbbenayLanguageModelProvider` with setting-driven resolution when the host sends tools.
- Document the setting in the VS Code extension README.

## Commits

- `feat(vscode): add lmToolMode setting for Copilot tool passthrough` — fixes per-tool approval prompts in Copilot by defaulting to passthrough; `auto` preserves legacy backchannel behavior.

## Test plan

- [x] `npm run lint` passes locally (0 errors)
- [x] `npm test` passes locally (46 vscode tests including 5 new `lm-tool-mode` unit tests)
- [x] `npm run ci:build` passes locally
- [x] New features have tests (`packages/vscode/src/test/providers/lm-tool-mode.test.ts`)
- [x] Docs updated for user-facing changes (`packages/vscode/README.md`)
- [x] Manual: use Abbenay model in Copilot with tools; confirm no per-tool approval prompt with default `passthrough`


Made with [Cursor](https://cursor.com)